### PR TITLE
Re-sync with internal repository

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+def get_libkineto_srcs():
+    return [
+        "src/ActivityProfiler.cpp",
+        "src/ActivityProfilerController.cpp",
+        "src/Config.cpp",
+        "src/ConfigLoader.cpp",
+        "src/CuptiActivityInterface.cpp",
+        "src/CuptiEventInterface.cpp",
+        "src/CuptiMetricInterface.cpp",
+        "src/Demangle.cpp",
+        "src/EventProfiler.cpp",
+        "src/EventProfilerController.cpp",
+        "src/Logger.cpp",
+        "src/ProcessInfo.cpp",
+        "src/ThreadName.cpp",
+        "src/cupti_runtime_cbid_names.cpp",
+        "src/libkineto.cpp",
+        "src/output_csv.cpp",
+        "src/output_json.cpp",
+    ]
+
+def get_libkineto_public_headers():
+    return ["include/external_api.h"]


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.