### PR TITLE
Use linux tid for thread id

### DIFF
--- a/libkineto/include/ClientTraceActivity.h
+++ b/libkineto/include/ClientTraceActivity.h
@@ -25,7 +25,7 @@ struct ClientTraceActivity : TraceActivity {
   }
 
   int64_t resourceId() const override {
-    return threadId;
+    return sysThreadId;
   }
 
   int64_t timestamp() const override {
@@ -56,11 +56,13 @@ struct ClientTraceActivity : TraceActivity {
     // Unimplemented by default
   }
 
-  int64_t startTime;
-  int64_t endTime;
-  int64_t correlation;
-  int device;
-  pthread_t threadId;
+  int64_t startTime{0};
+  int64_t endTime{0};
+  int64_t correlation{0};
+  int device{-1};
+  // TODO: Add OS abstraction
+  pthread_t pthreadId{};
+  int32_t sysThreadId{0};
   std::string opType;
   std::string inputDims;
   std::string inputTypes;

--- a/libkineto/src/ActivityProfiler.h
+++ b/libkineto/src/ActivityProfiler.h
@@ -260,9 +260,9 @@ class ActivityProfiler {
         disabledTraceSpans_.end();
   }
 
-  inline void recordThreadName(pthread_t pthreadId) {
-    if (threadNames_.find(pthreadId) == threadNames_.end()) {
-      threadNames_[pthreadId] = getThreadName(pthreadId);
+  inline void recordThreadName(pid_t tid, pthread_t pthreadId) {
+    if (threadNames_.find((int32_t)pthreadId) == threadNames_.end()) {
+      threadNames_[(int32_t)pthreadId] = {getThreadName(pthreadId), tid};
     }
   }
 
@@ -311,8 +311,10 @@ class ActivityProfiler {
   // Maps correlation id -> TraceSpan* held by traceSpans_.
   std::unordered_map<int64_t, CpuGpuSpanPair*> clientActivityTraceMap_;
 
-  // Cache thread names for pthread ids
-  std::unordered_map<uint64_t, std::string> threadNames_;
+  // Cache thread names and system thread ids for pthread ids
+  // Note we're using the lower 32 bits of the (opaque) pthread id
+  // as key, because that's what CUPTI records.
+  std::unordered_map<int32_t, std::pair<std::string, int32_t>> threadNames_;
 
   // Which trace spans are disabled. Together with the operator -> net id map
   // this allows us to determine whether a GPU or CUDA API event should

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -46,13 +46,19 @@ struct CuptiActivity : public TraceActivity {
 
 // CUpti_ActivityAPI - CUDA runtime activities
 struct RuntimeActivity : public CuptiActivity<CUpti_ActivityAPI> {
-  explicit RuntimeActivity(const CUpti_ActivityAPI* activity, const TraceActivity& linked)
-      : CuptiActivity(activity, linked) {}
+  explicit RuntimeActivity(
+      const CUpti_ActivityAPI* activity,
+      const TraceActivity& linked,
+      int32_t threadId)
+      : CuptiActivity(activity, linked), threadId_(threadId) {}
   int64_t deviceId() const override {return cachedPid();}
-  int64_t resourceId() const override {return activity_.threadId;}
+  int64_t resourceId() const override {return threadId_;}
   ActivityType type() const override {return ActivityType::CUDA_RUNTIME;}
   const std::string name() const override {return runtimeCbidName(activity_.cbid);}
   void log(ActivityLogger& logger) const override;
+
+ private:
+  const int32_t threadId_;
 };
 
 // Base class for GPU activities.

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -55,19 +55,6 @@ ChromeTraceLogger::ChromeTraceLogger(const std::string& traceFileName)
   smCount_ = CuptiActivityInterface::singleton().smCount();
 }
 
-int ChromeTraceLogger::renameThreadID(uint32_t tid) {
-  // the tid here is the thread ID that schedules the operator
-  static int curr_tid = 0;
-
-  // Note this function is not thread safe; The user of this ChromeTraceLogger
-  // need to maintain thread safety
-  if (tidMap_.count(tid)) {
-    return tidMap_[tid];
-  } else {
-    return tidMap_[tid] = curr_tid++;
-  }
-}
-
 static int64_t us(int64_t timestamp) {
   // It's important that this conversion is the same here and in the CPU trace.
   // No rounding!
@@ -121,8 +108,8 @@ void ChromeTraceLogger::handleThreadInfo(
       "name": "thread {} ({})"
     }}
   }},)JSON",
-      time, pid_, (uint32_t)threadInfo.tid,
-      renameThreadID((uint32_t)threadInfo.tid), threadInfo.name);
+      time, pid_, threadInfo.tid,
+      threadInfo.tid, threadInfo.name);
   // clang-format on
 }
 

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -71,12 +71,6 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   std::string fileName_;
   std::ofstream traceOf_;
 
-  // store the mapping of thread id vs. showing on the trace
-  std::unordered_map<uint32_t, int> tidMap_;
-
-  // get a cleaner thread id
-  int renameThreadID(uint32_t tid);
-
   // Cache pid to avoid repeated calls to getpid()
   pid_t pid_;
 


### PR DESCRIPTION
Summary:
Using linux tid makes it easier to merge Kineto traces with traces from other sources. Specifically, we want to collect eBPF traces and other system traces.
Having the same pid, tid pair (as well as same timestamp format) allows us to align the timelines across different traces without additional effort.

Differential Revision: D25808415

