### PR TITLE
fix bug: ProfilerStep is missed from building module view (#77)

### DIFF
--- a/tb_plugin/tensorboard_plugin_torch_profiler/profiler/module_parser.py
+++ b/tb_plugin/tensorboard_plugin_torch_profiler/profiler/module_parser.py
@@ -251,7 +251,7 @@ class ModuleParser:
                 if not tid in tid2list:
                     tid2list[tid] = []
                 tid2list[tid].append(rt_node)
-            elif event.type in [EventTypes.PYTHON, EventTypes.OPERATOR]:
+            elif event.type in [EventTypes.PYTHON, EventTypes.OPERATOR, EventTypes.PROFILER_STEP]:
                 if event.type == EventTypes.PROFILER_STEP:
                     op_node = ProfilerStepNode()
                 else:


### PR DESCRIPTION
ProfilerStep SHOULD be put into module view's tree. If not, the Runtime directly called by ProfilerStep will warn that its external id is not same as father's external id.
This is cherry-pick of local commit: https://github.com/guyang3532/pytorch_profiler/pull/77
