### PR TITLE
add dumping stack traces to chrome tracing file

### DIFF
--- a/libkineto/include/ClientTraceActivity.h
+++ b/libkineto/include/ClientTraceActivity.h
@@ -69,6 +69,7 @@ struct ClientTraceActivity : TraceActivity {
   std::string outputTypes;
   std::string inputNames;
   std::string outputNames;
+  std::string stackTraces;
 };
 
 } // namespace libkineto

--- a/libkineto/include/ClientTraceActivity.h
+++ b/libkineto/include/ClientTraceActivity.h
@@ -69,7 +69,7 @@ struct ClientTraceActivity : TraceActivity {
   std::string outputTypes;
   std::string inputNames;
   std::string outputNames;
-  std::string stackTraces;
+  std::string callStack;
 };
 
 } // namespace libkineto

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -189,6 +189,7 @@ void ChromeTraceLogger::handleCpuActivity(
        "Input dims": {}, "Input type": {}, "Input names": {},
        "Output dims": {}, "Output type": {}, "Output names": {},
        "Device": {}, "External id": {}, "Extra arguments": {},
+       "Stack traces": "{}",
        "Trace name": "{}", "Trace iteration": {}
     }}
   }},)JSON",
@@ -197,6 +198,7 @@ void ChromeTraceLogger::handleCpuActivity(
       op.inputDims, op.inputTypes, op.inputNames,
       op.outputDims, op.outputTypes, op.outputNames,
       op.device, op.correlation, op.arguments,
+      op.stackTraces,
       span.name, span.iteration);
   // clang-format on
 }

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -189,7 +189,7 @@ void ChromeTraceLogger::handleCpuActivity(
        "Input dims": {}, "Input type": {}, "Input names": {},
        "Output dims": {}, "Output type": {}, "Output names": {},
        "Device": {}, "External id": {}, "Extra arguments": {},
-       "Stack traces": "{}",
+       "Call stack": "{}",
        "Trace name": "{}", "Trace iteration": {}
     }}
   }},)JSON",
@@ -198,7 +198,7 @@ void ChromeTraceLogger::handleCpuActivity(
       op.inputDims, op.inputTypes, op.inputNames,
       op.outputDims, op.outputTypes, op.outputNames,
       op.device, op.correlation, op.arguments,
-      op.stackTraces,
+      op.callStack,
       span.name, span.iteration);
   // clang-format on
 }


### PR DESCRIPTION
In order to show stack-traces in tensorboard plugin, we have to dump stack traces to chrome tracing file.
If this is merged, we will submit PR to torch/csrc/autograd/profiler_kineto.cpp, mainly adding following code into finalizeCPUTrace:
      if (kineto_events_[idx].hasStack()) {
        cpu_trace->activities[idx].callStack = stacksToStr(kineto_events_[idx].stack());
      }