### PR TITLE
Add weak acc_get_device_type symbol

### DIFF
--- a/libkineto/src/WeakSymbols.cpp
+++ b/libkineto/src/WeakSymbols.cpp
@@ -1,0 +1,12 @@
+#include <stdexcept>
+
+#ifndef _MSC_VER
+extern "C" {
+// This function is needed to avoid superflous dependency on GNU OpenMP library when cuPTI is linked statically
+// For more details see https://github.com/pytorch/pytorch/issues/51026
+__attribute__((weak)) int acc_get_device_type() {
+  throw std::runtime_error("Dummy implementation of acc_get_device_type is not supposed to be called!");
+}
+
+} // extern "C"
+#endif


### PR DESCRIPTION
Summary: cuPTI has a weak dependency on acc_get_device_type symbol, which might accidentally get resolved against OpenMP library

Differential Revision: D26256093

