### PR TITLE
Add CuptiActivityInterface to OSS cpu-only build

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -37,6 +37,7 @@ def get_libkineto_cpu_only_srcs():
         "src/ActivityProfilerProxy.cpp",
         "src/Config.cpp",
         "src/ConfigLoader.cpp",
+        "src/CuptiActivityInterface.cpp",
         "src/Demangle.cpp",
         "src/GenericTraceActivity.cpp",
         "src/Logger.cpp",

--- a/libkineto/src/cupti_call.h
+++ b/libkineto/src/cupti_call.h
@@ -32,7 +32,7 @@
 
 #else
 
-#define CUPTI_CALL(call) CUPTI_ERROR_NOT_INITIALIZED
-#define CUPTI_CALL_NOWARN(call) CUPTI_ERROR_NOT_INITIALIZED
+#define CUPTI_CALL(call)
+#define CUPTI_CALL_NOWARN(call)
 
 #endif // HAS_CUPTI


### PR DESCRIPTION
Summary:
PyTorch Profiler uses push and popCorrelationId which results in calls to CuptiActivityInterface. We also store a singleton to this in the ActivityProfilerController.

This is a quick fix to enable cpu-only build and will be followed up by a refactoring diff.

Differential Revision: D26286075

