### PR TITLE
Add basic CI github build action fo libkineto

### DIFF
--- a/.github/workflows/libkineto_ci.yml
+++ b/.github/workflows/libkineto_ci.yml
@@ -1,0 +1,57 @@
+name: LIBKINETOCI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+
+    - name: Get env vars
+      run: |
+        echo GITHUB_WORKFLOW   = $GITHUB_WORKFLOW
+        echo HOME              = $HOME
+        echo GITHUB_ACTION     = $GITHUB_ACTION
+        echo GITHUB_ACTIONS    = $GITHUB_ACTIONS
+        echo GITHUB_REPOSITORY = $GITHUB_REPOSITORY
+        echo GITHUB_EVENT_NAME = $GITHUB_EVENT_NAME
+        echo GITHUB_EVENT_PATH = $GITHUB_EVENT_PATH
+        echo GITHUB_WORKSPACE  = $GITHUB_WORKSPACE
+        echo GITHUB_SHA        = $GITHUB_SHA
+        echo GITHUB_REF        = $GITHUB_REF
+        c++ --verbose
+
+    - name: Build static lib
+      run: |
+        set -e
+        mkdir build_static
+        cd build_static
+        # Figure out how to install cupti headers
+        cmake -DKINETO_LIBRARY_TYPE=static ..
+        make -j
+
+    - name: Build shared lib
+      run: |
+        set -e
+        mkdir build_shared
+        cd build_shared
+        cmake -DKINETO_LIBRARY_TYPE=shared ..
+        make -j
+

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
 # Kineto
 
-Kineto is a PyTorch performance profiling library and framework focused on providing low-overhead full-system instrumentation for production workloads. For the moment, it consists of libkineto, an in-process profiling library integrated with PyTorch.
-Going forward however there will be other related components added such as infrastructure for dameon-based deployment and trace processing pipelines.
+Kineto is a PyTorch performance profiling library (libkineto) focused on providing low-overhead full-system instrumentation for production workloads.
+Libkineto is fully integrated with the PyToch Profiler, providing GPU profiling capabilities and in the future other system-level profiling.
+This repo also includes the PyTorch Profiler Tensorboard plugin, providing an easy-to-use end-to-end profiling experience.
 
-## What is libkineto?
-Libkineto, a component of the overall Kineto project, is an in-process profiling library which also provides a C++ API. Please refer to the [README](libkineto/README.md) file in the libkineto folder.
+## libkineto
+Libkineto is an in-process profiling library integrated with the PyTorch Profiler. Please refer to the [README](libkineto/README.md) file in the libkineto folder as well as documentation on the [new PyTorch Profiler API](https://pytorch.org/docs/master/profiler.html).
 
-## Planned for initial release:
-- libkineto, an in-process library providing CPU + GPU timeline tracing capabilities.
-- An API allowing the PyTorch profiler to control timeline trace collection.
-- Visualization in the Chrome browser using the chrome://tracing extension.
+## PyTorch Tensorboard Profiler
+The goal of the PyTorch Tensorboard plugin is to provide a seamless and intuitive end-to-end profiling experience, including straightforward collection from PyTorch and insightful visualizations and recommendations in the Tensorboard UI.
+Please refer to the [README](tb_plugin/README.md) file in the `tb_plugin` folder.
 
-## Future development:
-- Tensorboard integration 
-- Collaboration features
-- Daemon-based deployment for larger setups
-- Distributed tracing support
-- Trace processing and analysis pipeline
-- System-level events, multiple tracing sources
+## Future development direction:
+- Support for tracing distributed workloads
+- Trace processing, analysis and recommendation engine
+- System-level activities, multiple tracing sources
+- Profiling and monitoring daemon for larger scale deployments
 
 ## Releases and Contributing
 We will follow the PyTorch release schedule which roughly happens on an every 3 month basis.

--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -20,7 +20,7 @@ endfunction()
 project(kineto VERSION 0.1 LANGUAGES CXX C)
 
 set(KINETO_LIBRARY_TYPE "default" CACHE STRING
-  "Type of library (default or shared) to build")
+  "Type of library (default, static or shared) to build")
 set_property(CACHE KINETO_LIBRARY_TYPE PROPERTY STRINGS default shared)
 option(KINETO_BUILD_TESTS "Build kineto unit tests" ON)
 

--- a/libkineto/README.md
+++ b/libkineto/README.md
@@ -8,10 +8,6 @@ process, either via the library public API or by sending a signal, if enabled.
 
 Currently only NVIDIA GPUs are supported.
 
-## Examples
-
-TODO
-
 ## Build Notes
 Libkineto uses the standard CMAKE-based build flow.
 
@@ -59,21 +55,16 @@ make install
 ```
 
 ## How Libkineto works
-For a high-level overview, design philosophy and brief descriptions of various
-parts of Libkineto please see [our blog][4]. [TODO]
+We will provide a high-level overview, design philosophy and brief descriptions of various
+parts of Libkineto in upcoming blogs.
 
 ## Full documentation
-We have extensively used comments in our source files. The best and up-do-date
+We strive to keep our source files readable. The best and up-do-date
 documentation is available in the source files.
 
-## Join the Libkineto community
-See the [`CONTRIBUTING`](CONTRIBUTING.md) file for how to help out.
-
 ## License
-Libkineto is BSD licensed, as found in the [`LICENSE`](LICENSE) file.
-
+Libkineto is BSD licensed, as detailed in the [LICENSE](../LICENSE) file.
 
 [1]:https://developer.nvidia.com/CUPTI-CTK10_2
 [2]:https://github.com/fmt
 [3]:https://github.com/google/googletest
-[4]:https://code.fb.com/ml-applications/kineto


### PR DESCRIPTION
Summary: Add a build action for libkineto. This will build the cpu-only version, without cupti headers. Next, I'll figure out how to get a build with cupti which will allow us to enable unit tests.

Differential Revision: D26322147

