### PR TITLE
Add basic CI github build action fo libkineto

### DIFF
--- a/.github/workflows/libkineto_ci.yml
+++ b/.github/workflows/libkineto_ci.yml
@@ -1,0 +1,56 @@
+name: LIBKINETOCI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+
+    - name: Get env vars
+      run: |
+        echo GITHUB_WORKFLOW   = $GITHUB_WORKFLOW
+        echo HOME              = $HOME
+        echo GITHUB_ACTION     = $GITHUB_ACTION
+        echo GITHUB_ACTIONS    = $GITHUB_ACTIONS
+        echo GITHUB_REPOSITORY = $GITHUB_REPOSITORY
+        echo GITHUB_EVENT_NAME = $GITHUB_EVENT_NAME
+        echo GITHUB_EVENT_PATH = $GITHUB_EVENT_PATH
+        echo GITHUB_WORKSPACE  = $GITHUB_WORKSPACE
+        echo GITHUB_SHA        = $GITHUB_SHA
+        echo GITHUB_REF        = $GITHUB_REF
+        c++ --verbose
+
+    - name: Build static lib
+      run: |
+        set -e
+        mkdir build_static
+        cd build_static
+        # Figure out how to install cupti headers
+        cmake -DKINETO_LIBRARY_TYPE=static ../libkineto/
+        make -j
+
+    - name: Build shared lib
+      run: |
+        set -e
+        mkdir build_shared
+        cd build_shared
+        cmake -DKINETO_LIBRARY_TYPE=shared ../libkineto/
+        make -j

--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -20,7 +20,7 @@ endfunction()
 project(kineto VERSION 0.1 LANGUAGES CXX C)
 
 set(KINETO_LIBRARY_TYPE "default" CACHE STRING
-  "Type of library (default or shared) to build")
+  "Type of library (default, static or shared) to build")
 set_property(CACHE KINETO_LIBRARY_TYPE PROPERTY STRINGS default shared)
 option(KINETO_BUILD_TESTS "Build kineto unit tests" ON)
 


### PR DESCRIPTION
Summary: Add a build action for libkineto. This will build the cpu-only version, without cupti headers. Next, I'll figure out how to get a build with cupti which will allow us to enable unit tests.

Differential Revision: D26369353

