### PR TITLE
remove accidentally readded initializer

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -50,7 +50,7 @@ static void openTraceFile(std::string& name, std::ofstream& stream) {
 }
 
 ChromeTraceLogger::ChromeTraceLogger(const std::string& traceFileName, int smCount)
-    : fileName_(traceFileName), pid_(getpid()), smCount_(smCount) {
+    : fileName_(traceFileName), pid_(getpid()) {
   traceOf_.clear(std::ios_base::badbit);
   openTraceFile(fileName_, traceOf_);
 #ifdef HAS_CUPTI


### PR DESCRIPTION
Summary: smCount_ initalizer was removed to be guarded with `HAS_CUPTI` but was accidentally readded with D26094792 (https://github.com/pytorch/kineto/commit/c0086142a335687ee0f3d1b068ee4f6a4a464050), which caused Github OSS to break

Differential Revision: D26379661

