### PR TITLE
split is_gpu_used into 3 switches

### DIFF
--- a/tb_plugin/test/test_profiler.py
+++ b/tb_plugin/test/test_profiler.py
@@ -98,7 +98,7 @@ class TestProfiler(unittest.TestCase):
 
         self.assertTrue(profile.has_runtime)
         self.assertTrue(profile.has_kernel)
-        self.assertTrue(profile.has_memory)
+        self.assertTrue(profile.has_memcpy_or_memset)
         step = profile.steps_costs[0]
         self.assertEqual(step.kernel_cost, 15)
         self.assertEqual(step.memcpy_cost, 10)
@@ -467,7 +467,7 @@ class TestProfiler(unittest.TestCase):
 
         self.assertTrue(profile.has_runtime)
         self.assertTrue(profile.has_kernel)
-        self.assertTrue(not profile.has_memory)
+        self.assertTrue(not profile.has_memcpy_or_memset)
         self.assertEqual(len(profile.steps_costs), 1)
         step = profile.steps_costs[0]
         self.assertEqual(step.kernel_cost, 100)
@@ -577,7 +577,7 @@ class TestProfiler(unittest.TestCase):
 
         self.assertTrue(profile.has_runtime)
         self.assertTrue(profile.has_kernel)
-        self.assertTrue(profile.has_memory)
+        self.assertTrue(profile.has_memcpy_or_memset)
         self.assertEqual(len(profile.steps_costs), 2)
         step = profile.steps_costs[0]
         self.assertEqual(step.kernel_cost, 0)

--- a/tb_plugin/test/test_profiler.py
+++ b/tb_plugin/test/test_profiler.py
@@ -96,7 +96,9 @@ class TestProfiler(unittest.TestCase):
         profile = parse_json_trace(json_content)
         profile.process()
 
-        self.assertTrue(profile.is_gpu_used)
+        self.assertTrue(profile.has_runtime)
+        self.assertTrue(profile.has_kernel)
+        self.assertTrue(profile.has_memory)
         step = profile.steps_costs[0]
         self.assertEqual(step.kernel_cost, 15)
         self.assertEqual(step.memcpy_cost, 10)
@@ -463,7 +465,9 @@ class TestProfiler(unittest.TestCase):
         profile = parse_json_trace(json_content)
         profile.process()
 
-        self.assertTrue(profile.is_gpu_used)
+        self.assertTrue(profile.has_runtime)
+        self.assertTrue(profile.has_kernel)
+        self.assertTrue(not profile.has_memory)
         self.assertEqual(len(profile.steps_costs), 1)
         step = profile.steps_costs[0]
         self.assertEqual(step.kernel_cost, 100)
@@ -571,7 +575,9 @@ class TestProfiler(unittest.TestCase):
         profile = parse_json_trace(json_content)
         profile.process()
 
-        self.assertTrue(profile.is_gpu_used)
+        self.assertTrue(profile.has_runtime)
+        self.assertTrue(profile.has_kernel)
+        self.assertTrue(profile.has_memory)
         self.assertEqual(len(profile.steps_costs), 2)
         step = profile.steps_costs[0]
         self.assertEqual(step.kernel_cost, 0)

--- a/tb_plugin/torch_tb_profiler/plugin.py
+++ b/tb_plugin/torch_tb_profiler/plugin.py
@@ -179,7 +179,7 @@ class TorchProfilerPlugin(base_plugin.TBPlugin):
         run = self.get_run(name)
         profile = run.get_profile(worker)
         data = profile.overview
-        is_gpu_used = profile.has_runtime or profile.has_kernel or profile.has_memory
+        is_gpu_used = profile.has_runtime or profile.has_kernel or profile.has_memcpy_or_memset
         data["environments"] = [{"title": "Number of Worker(s)", "value": str(len(run.workers))},
                                 {"title": "Device Type", "value": "GPU" if is_gpu_used else "CPU"}]
         if is_gpu_used:

--- a/tb_plugin/torch_tb_profiler/plugin.py
+++ b/tb_plugin/torch_tb_profiler/plugin.py
@@ -179,9 +179,10 @@ class TorchProfilerPlugin(base_plugin.TBPlugin):
         run = self.get_run(name)
         profile = run.get_profile(worker)
         data = profile.overview
+        is_gpu_used = profile.has_runtime or profile.has_kernel or profile.has_memory
         data["environments"] = [{"title": "Number of Worker(s)", "value": str(len(run.workers))},
-                                {"title": "Device Type", "value": "GPU" if profile.is_gpu_used else "CPU"}]
-        if profile.is_gpu_used:
+                                {"title": "Device Type", "value": "GPU" if is_gpu_used else "CPU"}]
+        if is_gpu_used:
             data["environments"].append({"title": "Number of Device(s)", "value": "1"})
         return self.respond_as_json(data)
 

--- a/tb_plugin/torch_tb_profiler/profiler/data.py
+++ b/tb_plugin/torch_tb_profiler/profiler/data.py
@@ -36,7 +36,7 @@ class RunProfileData(object):
         self.trace_file_path = None
         self.has_runtime = False
         self.has_kernel = False
-        self.has_memory = False
+        self.has_memcpy_or_memset = False
         self.steps_costs = None
         self.steps_names = None
         self.avg_costs = None
@@ -97,7 +97,7 @@ class RunProfileData(object):
         overall_parser.parse_events(self.events)
         self.has_runtime = overall_parser.has_runtime
         self.has_kernel = overall_parser.has_kernel
-        self.has_memory = overall_parser.has_memory
+        self.has_memcpy_or_memset = overall_parser.has_memcpy_or_memset
         self.steps_costs = overall_parser.steps_costs
         self.steps_names = overall_parser.steps_names
         self.avg_costs = overall_parser.avg_costs

--- a/tb_plugin/torch_tb_profiler/profiler/data.py
+++ b/tb_plugin/torch_tb_profiler/profiler/data.py
@@ -34,7 +34,9 @@ class RunProfileData(object):
         self.data_schema_version = None
         self.events = None
         self.trace_file_path = None
-        self.is_gpu_used = False
+        self.has_runtime = False
+        self.has_kernel = False
+        self.has_memory = False
         self.steps_costs = None
         self.steps_names = None
         self.avg_costs = None
@@ -93,7 +95,9 @@ class RunProfileData(object):
         logger.debug("OverallParser")
         overall_parser = OverallParser()
         overall_parser.parse_events(self.events)
-        self.is_gpu_used = overall_parser.is_gpu_used
+        self.has_runtime = overall_parser.has_runtime
+        self.has_kernel = overall_parser.has_kernel
+        self.has_memory = overall_parser.has_memory
         self.steps_costs = overall_parser.steps_costs
         self.steps_names = overall_parser.steps_names
         self.avg_costs = overall_parser.avg_costs
@@ -105,7 +109,7 @@ class RunProfileData(object):
         self.op_list_groupby_name_input = module_parser.op_list_groupby_name_input
         self.kernel_list_groupby_name_op = module_parser.kernel_list_groupby_name_op
 
-        if self.is_gpu_used:
+        if self.has_kernel:
             logger.debug("KernelParser")
             kernel_parser = KernelParser()
             kernel_parser.parse_events(self.events)

--- a/tb_plugin/torch_tb_profiler/profiler/module_parser.py
+++ b/tb_plugin/torch_tb_profiler/profiler/module_parser.py
@@ -297,7 +297,7 @@ class ModuleParser:
         def parse_kernels(kernel_list):
             name_op_to_agg = {}
             for kernel in kernel_list:
-                op_name = "<None>" if kernel.op_node is None else kernel.op_node.name
+                op_name = "N/A" if kernel.op_node is None else kernel.op_node.name
                 key = kernel.name + "###" + op_name
                 if key not in name_op_to_agg:
                     name_op_to_agg[key] = KernelAggByNameOp()

--- a/tb_plugin/torch_tb_profiler/profiler/overall_parser.py
+++ b/tb_plugin/torch_tb_profiler/profiler/overall_parser.py
@@ -169,7 +169,9 @@ class OverallParser(object):
         self.cpuop_ranges = []
         self.steps = []
         self.steps_names = []
-        self.is_gpu_used = False
+        self.has_runtime = False
+        self.has_kernel = False
+        self.has_memory = False
         self.min_ts = sys.maxsize
         self.max_ts = -sys.maxsize - 1
         self.steps_costs = []
@@ -238,12 +240,16 @@ class OverallParser(object):
         evt_type = event.type
         if evt_type == EventTypes.KERNEL:
             self.kernel_ranges.append((ts, ts + dur))
+            self.has_kernel = True
         elif evt_type == EventTypes.MEMCPY:
             self.memcpy_ranges.append((ts, ts + dur))
+            self.has_memory = True
         elif evt_type == EventTypes.MEMSET:
             self.memset_ranges.append((ts, ts + dur))
+            self.has_memory = True
         elif evt_type == EventTypes.RUNTIME:
             self.runtime_ranges.append((ts, ts + dur))
+            self.has_runtime = True
         elif evt_type == EventTypes.OPERATOR and event.name.startswith("enumerate(DataLoader)#") \
                 and event.name.endswith(".__next__"):
             self.dataloader_ranges.append((ts, ts + dur))
@@ -252,9 +258,6 @@ class OverallParser(object):
             self.steps_names.append(str(event.step))
         elif evt_type in [EventTypes.PYTHON, EventTypes.OPERATOR]:
             self.cpuop_ranges.append((ts, ts + dur))
-
-        if evt_type == EventTypes.RUNTIME:
-            self.is_gpu_used = True
 
         if ts < self.min_ts:
             self.min_ts = ts

--- a/tb_plugin/torch_tb_profiler/profiler/overall_parser.py
+++ b/tb_plugin/torch_tb_profiler/profiler/overall_parser.py
@@ -171,7 +171,7 @@ class OverallParser(object):
         self.steps_names = []
         self.has_runtime = False
         self.has_kernel = False
-        self.has_memory = False
+        self.has_memcpy_or_memset = False
         self.min_ts = sys.maxsize
         self.max_ts = -sys.maxsize - 1
         self.steps_costs = []
@@ -243,10 +243,10 @@ class OverallParser(object):
             self.has_kernel = True
         elif evt_type == EventTypes.MEMCPY:
             self.memcpy_ranges.append((ts, ts + dur))
-            self.has_memory = True
+            self.has_memcpy_or_memset = True
         elif evt_type == EventTypes.MEMSET:
             self.memset_ranges.append((ts, ts + dur))
-            self.has_memory = True
+            self.has_memcpy_or_memset = True
         elif evt_type == EventTypes.RUNTIME:
             self.runtime_ranges.append((ts, ts + dur))
             self.has_runtime = True

--- a/tb_plugin/torch_tb_profiler/profiler/run_generator.py
+++ b/tb_plugin/torch_tb_profiler/profiler/run_generator.py
@@ -19,7 +19,7 @@ class RunGenerator(object):
         profile_run = RunProfile(self.worker)
         profile_run.has_runtime = self.profile_data.has_runtime
         profile_run.has_kernel = self.profile_data.has_kernel
-        profile_run.has_memory = self.profile_data.has_memory
+        profile_run.has_memcpy_or_memset = self.profile_data.has_memcpy_or_memset
         profile_run.views.append(consts.OVERALL_VIEW)
         profile_run.overview = self._generate_overview()
 
@@ -58,7 +58,7 @@ class RunGenerator(object):
                          "extra": round(100 * part_cost / self.profile_data.avg_costs.step_total_cost, 2)}
             return cost_dict
 
-        show_gpu = self.profile_data.has_runtime or self.profile_data.has_kernel or self.profile_data.has_memory
+        show_gpu = self.profile_data.has_runtime or self.profile_data.has_kernel or self.profile_data.has_memcpy_or_memset
 
         column_tootip = {"type": "string", "role": "tooltip", "p": {"html": "true"}}
         data = {}
@@ -199,7 +199,7 @@ class RunGenerator(object):
         return data
 
     def _generate_op_table(self, group_by_input_shape=False):
-        show_gpu = self.profile_data.has_kernel or self.profile_data.has_memory
+        show_gpu = self.profile_data.has_kernel or self.profile_data.has_memcpy_or_memset
 
         columns = [{"type": "string", "name": "Name"}]
         if group_by_input_shape:

--- a/tb_plugin/torch_tb_profiler/profiler/run_generator.py
+++ b/tb_plugin/torch_tb_profiler/profiler/run_generator.py
@@ -17,7 +17,9 @@ class RunGenerator(object):
 
     def generate_run_profile(self):
         profile_run = RunProfile(self.worker)
-        profile_run.is_gpu_used = self.profile_data.is_gpu_used
+        profile_run.has_runtime = self.profile_data.has_runtime
+        profile_run.has_kernel = self.profile_data.has_kernel
+        profile_run.has_memory = self.profile_data.has_memory
         profile_run.views.append(consts.OVERALL_VIEW)
         profile_run.overview = self._generate_overview()
 
@@ -27,7 +29,7 @@ class RunGenerator(object):
         profile_run.operation_pie_by_name_input = self._generate_op_pie(True)
         profile_run.operation_table_by_name_input = self._generate_op_table(True)
 
-        if self.profile_data.is_gpu_used:
+        if self.profile_data.has_kernel:
             profile_run.views.append(consts.KERNEL_VIEW)
             profile_run.kernel_op_table = self._generate_kernel_op_table()
             profile_run.kernel_pie = self._generate_kernel_pie()
@@ -56,7 +58,7 @@ class RunGenerator(object):
                          "extra": round(100 * part_cost / self.profile_data.avg_costs.step_total_cost, 2)}
             return cost_dict
 
-        show_gpu = self.profile_data.is_gpu_used
+        show_gpu = self.profile_data.has_runtime or self.profile_data.has_kernel or self.profile_data.has_memory
 
         column_tootip = {"type": "string", "role": "tooltip", "p": {"html": "true"}}
         data = {}
@@ -197,7 +199,7 @@ class RunGenerator(object):
         return data
 
     def _generate_op_table(self, group_by_input_shape=False):
-        show_gpu = self.profile_data.is_gpu_used
+        show_gpu = self.profile_data.has_kernel or self.profile_data.has_memory
 
         columns = [{"type": "string", "name": "Name"}]
         if group_by_input_shape:

--- a/tb_plugin/torch_tb_profiler/run.py
+++ b/tb_plugin/torch_tb_profiler/run.py
@@ -50,7 +50,7 @@ class RunProfile(object):
         self.views = []
         self.has_runtime = False
         self.has_kernel = False
-        self.has_memory = False
+        self.has_memcpy_or_memset = False
         self.overview = None
         self.operation_pie_by_name = None
         self.operation_table_by_name = None

--- a/tb_plugin/torch_tb_profiler/run.py
+++ b/tb_plugin/torch_tb_profiler/run.py
@@ -48,7 +48,9 @@ class RunProfile(object):
     def __init__(self, worker):
         self.worker = worker
         self.views = []
-        self.is_gpu_used = False
+        self.has_runtime = False
+        self.has_kernel = False
+        self.has_memory = False
         self.overview = None
         self.operation_pie_by_name = None
         self.operation_table_by_name = None


### PR DESCRIPTION
Use has_runtime, has_kernel, has_memory to control GPU components in UI, in order to deal with more boundary cases.