### PR TITLE
Fix intermittent CUDA activity flush issue

### DIFF
--- a/libkineto/src/CuptiActivityInterface.cpp
+++ b/libkineto/src/CuptiActivityInterface.cpp
@@ -144,7 +144,7 @@ std::unique_ptr<std::list<CuptiActivityBuffer>> CuptiActivityInterface::activity
   if (VLOG_IS_ON(1)) {
     t1 = high_resolution_clock::now();
   }
-  CUPTI_CALL(cuptiActivityFlushAll(0));
+  CUPTI_CALL(cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
   if (VLOG_IS_ON(1)) {
     flushOverhead =
         duration_cast<microseconds>(high_resolution_clock::now() - t1).count();


### PR DESCRIPTION
Summary:
We recently observed that no Cuda activities appears in libkineto traces for certain setups.
The issue is that cuptiActivityFlushAll sometimes produces no buffers.
Setting the CUPTI_ACTIVITY_FLAG_FLUSH_FORCED appears to give us consistent results.

We're still figuring out which setups are affected.

Differential Revision: D26717258

