### PR TITLE
Auto-enable for tw tasks and mast jobs

### DIFF
--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -29,7 +29,7 @@
 
 extern "C" {
   void suppressLibkinetoLogMessages();
-  void libkineto_init(bool cpuOnly = false);
+  void libkineto_init(bool cpuOnly);
 }
 
 namespace libkineto {


### PR DESCRIPTION
Summary: Currently we only enable event profiling for chronos jobs. Enabling for TW tasks and MAST jobs as well to cover inference and TC use case.

Differential Revision: D26704932

