### PR TITLE
Fix bandwidth calculation for 0-length mem ops

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -326,6 +326,10 @@ void ChromeTraceLogger::handleGpuActivity(
   handleLinkEnd(activity);
 }
 
+static std::string bandwidth(uint64_t bytes, uint64_t duration) {
+  return duration == 0 ? "N/A" : fmt::format("{}", bytes * 1.0 / duration);
+}
+
 // GPU side memcpy activity
 void ChromeTraceLogger::handleGpuActivity(
     const GpuActivity<CUpti_ActivityMemcpy>& activity) {
@@ -349,7 +353,7 @@ void ChromeTraceLogger::handleGpuActivity(
       // args
       memcpy.deviceId, memcpy.contextId,
       memcpy.streamId, memcpy.correlationId, ext.correlationId(),
-      memcpy.bytes, memcpy.bytes * 1.0 / (memcpy.end - memcpy.start));
+      memcpy.bytes, bandwidth(memcpy.bytes, memcpy.end - memcpy.start));
   // clang-format on
 
   handleLinkEnd(activity);
@@ -379,7 +383,7 @@ void ChromeTraceLogger::handleGpuActivity(
       memcpy.srcDeviceId, memcpy.deviceId, memcpy.dstDeviceId,
       memcpy.srcContextId, memcpy.contextId, memcpy.dstContextId,
       memcpy.streamId, memcpy.correlationId, ext.correlationId(),
-      memcpy.bytes, memcpy.bytes * 1.0 / (memcpy.end - memcpy.start));
+      memcpy.bytes, bandwidth(memcpy.bytes, memcpy.end - memcpy.start));
   // clang-format on
 
   handleLinkEnd(activity);
@@ -406,7 +410,7 @@ void ChromeTraceLogger::handleGpuActivity(
       // args
       memset.deviceId, memset.contextId,
       memset.streamId, memset.correlationId, ext.correlationId(),
-      memset.bytes, memset.bytes * 1.0 / (memset.end - memset.start));
+      memset.bytes, bandwidth(memset.bytes, memset.end - memset.start));
   // clang-format on
 
   handleLinkEnd(activity);


### PR DESCRIPTION
Summary:
If memops durations are rounded down to 0ms then we get a division by zero when computing bandwidth.
Instead show "N/A" when this happens.

Differential Revision: D26810180

