### PR TITLE
refactor CUPTI static callbacks into protected member functions

### DIFF
--- a/libkineto/src/ActivityProfiler.cpp
+++ b/libkineto/src/ActivityProfiler.cpp
@@ -388,6 +388,7 @@ inline void ActivityProfiler::handleGpuActivity(
   if (ext.timestamp() == 0 && outOfRange(act)) {
     return;
   }
+  // Correlated GPU runtime activity cannot have timestamp greater than the GPU activity's
   if (!timestampsInCorrectOrder(ext, act)) {
     //return;
   }
@@ -400,6 +401,11 @@ inline void ActivityProfiler::handleGpuActivity(
     const ClientTraceActivity& extUser =
       externalEvents_.getClientTraceActivity(act.correlationId(),
         ExternalEventMap::CorrelationFlowType::User);
+    // Correlated CPU activity cannot have timestamp greater than the GPU activity's
+    if (!timestampsInCorrectOrder(extUser, act)) {
+      return;
+    }
+
     if (extUser.correlationId() != 0) {
       VLOG(2) << extUser.correlationId() << "," << act.correlationId()
               << " (user): "<< act.name();

--- a/libkineto/src/CuptiActivityInterface.h
+++ b/libkineto/src/CuptiActivityInterface.h
@@ -71,8 +71,8 @@ class CuptiActivityInterface {
       size_t validSize,
       std::function<void(const CUpti_Activity*)> handler);
   static void CUPTIAPI
-  bufferRequested(uint8_t** buffer, size_t* size, size_t* maxNumRecords);
-  static void CUPTIAPI bufferCompleted(
+  bufferRequestedTrampoline(uint8_t** buffer, size_t* size, size_t* maxNumRecords);
+  static void CUPTIAPI bufferCompletedTrampoline(
       CUcontext ctx,
       uint32_t streamId,
       uint8_t* buffer,
@@ -83,6 +83,17 @@ class CuptiActivityInterface {
   int maxGpuBufferCount_{0};
   int allocatedGpuBufferCount{0};
   std::unique_ptr<std::list<CuptiActivityBuffer>> gpuTraceBuffers_;
+
+ protected:
+#ifdef HAS_CUPTI
+  void bufferRequested(uint8_t** buffer, size_t* size, size_t* maxNumRecords);
+  void bufferCompleted(
+      CUcontext ctx,
+      uint32_t streamId,
+      uint8_t* buffer,
+      size_t /* unused */,
+      size_t validSize);
+#endif
 };
 
 } // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Summary:
We want to be able to mock CUPTI callback calls for unit tests in the future. This changes allow one to manually call
a CUPTI callback to simulate interaction with CUPTI.

Reviewed By: gdankel

Differential Revision: D26588777

