### PR TITLE
Handle off by one error in maxGPUBufferCount limit

### DIFF
--- a/libkineto/src/CuptiActivityInterface.cpp
+++ b/libkineto/src/CuptiActivityInterface.cpp
@@ -122,7 +122,7 @@ void CUPTIAPI CuptiActivityInterface::bufferRequestedTrampoline(
 }
 
 void CuptiActivityInterface::bufferRequested(uint8_t** buffer, size_t* size, size_t* maxNumRecords) {
-  if (allocatedGpuBufferCount > maxGpuBufferCount_) {
+  if (allocatedGpuBufferCount >= maxGpuBufferCount_) {
     stopCollection = true;
     LOG(WARNING) << "Exceeded max GPU buffer count ("
                  << allocatedGpuBufferCount

--- a/libkineto/test/ActivityProfilerTest.cpp
+++ b/libkineto/test/ActivityProfilerTest.cpp
@@ -370,7 +370,7 @@ TEST_F(ActivityProfilerTest, BufferSizeLimitTestWarmup) {
 
   auto now = system_clock::now();
 
-  int maxBufferSizeMB = 1;
+  int maxBufferSizeMB = 3;
   std::string maxBufferSizeMBStr = std::to_string(maxBufferSizeMB);
   cfg_->handleOption("ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB", maxBufferSizeMBStr);
 
@@ -378,7 +378,7 @@ TEST_F(ActivityProfilerTest, BufferSizeLimitTestWarmup) {
   profiler.configure(*cfg_, now);
   EXPECT_TRUE(profiler.isActive());
 
-  for (size_t i = 0; i <= maxBufferSizeMB + 1; i++) {
+  for (size_t i = 0; i < maxBufferSizeMB; i++) {
     uint8_t* buf;
     size_t gpuBufferSize;
     size_t maxNumRecords;


### PR DESCRIPTION
Summary: while adding tests for handling buffer count limit, I realized that we stop collection on `maxGPUBufferCount + 1`, when it should stop once it reaches `maxGPUBufferCount`

Reviewed By: gdankel, leitian

Differential Revision: D26602152

