### PR TITLE
Change to safe thread name implementation

### DIFF
--- a/libkineto/src/ActivityProfiler.h
+++ b/libkineto/src/ActivityProfiler.h
@@ -260,7 +260,7 @@ class ActivityProfiler {
     if (threadInfo_.find((int32_t)pthreadId) == threadInfo_.end()) {
       threadInfo_.emplace(
           (int32_t)pthreadId,
-          ThreadInfo((int32_t) tid, getThreadName(pthreadId)));
+          ThreadInfo((int32_t) tid, getThreadName(tid)));
     }
   }
 

--- a/libkineto/src/ThreadName.cpp
+++ b/libkineto/src/ThreadName.cpp
@@ -5,9 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <string>
-
+#include <fmt/format.h>
 #include <pthread.h>
+#include <sys/types.h>
+#include <string>
+#include <unistd.h>
+
+#include "Logger.h"
 
 namespace KINETO_NAMESPACE {
 
@@ -17,12 +21,21 @@ bool setThreadName(const std::string& name) {
   return 0 == pthread_setname_np(pthread_self(), name.c_str());
 }
 
-std::string getThreadName(pthread_t id) {
-  char buf[kMaxThreadNameLength];
-  if (0 == pthread_getname_np(id, buf, sizeof(buf))) {
-    return buf;
+std::string getThreadName(pid_t tid) {
+  char buf[kMaxThreadNameLength] = "Unknown";
+  std::string filename = fmt::format("/proc/{}/task/{}/comm", getpid(), tid);
+  FILE* comm_file = fopen(filename.c_str(), "r");
+  if (comm_file) {
+    size_t len = fread(buf, 1, kMaxThreadNameLength, comm_file);
+    fclose(comm_file);
+    // Remove newline
+    if (len > 0) {
+      buf[len - 1] = '\0';
+    }
+  } else {
+    LOG(WARNING) << "Failed to open " << filename;
   }
-  return "Unknown";
+  return buf;
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/ThreadName.h
+++ b/libkineto/src/ThreadName.h
@@ -14,6 +14,6 @@
 namespace KINETO_NAMESPACE {
 
 bool setThreadName(const std::string& name);
-std::string getThreadName(pthread_t id);
+std::string getThreadName(pid_t tid);
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/test/PidInfoTest.cpp
+++ b/libkineto/test/PidInfoTest.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "src/ThreadName.h"
+
+#include <atomic>
+#include <sys/syscall.h>
+#include <thread>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+using namespace KINETO_NAMESPACE;
+
+TEST(ThreadNameTest, setAndGet) {
+  setThreadName("ThreadNameTest");
+  EXPECT_EQ(getThreadName(getpid()), "ThreadNameTest");
+
+  setThreadName("");
+  EXPECT_EQ(getThreadName(getpid()), "");
+
+  // Spaces etc are ok
+  setThreadName("Name w/ spaces");
+  EXPECT_EQ(getThreadName(getpid()), "Name w/ spaces");
+
+  // More than 16 chars is not OK
+  setThreadName("More than 16 characters");
+  EXPECT_EQ(getThreadName(getpid()), "Name w/ spaces");
+}
+
+TEST(ThreadNameTest, invalidThread) {
+  EXPECT_EQ(getThreadName(123456789), "Unknown");
+}
+
+TEST(ThreadNameTest, otherThread) {
+  std::atomic_bool stop_flag;
+  std::atomic_int tid = 0;
+  std::thread thread([&stop_flag, &tid]() {
+      setThreadName("New Thread");
+      tid = syscall(SYS_gettid);
+      while (!stop_flag) {
+        sleep(1);
+      }
+  });
+  while (!tid) {
+    sleep(1);
+  }
+  EXPECT_EQ(getThreadName(tid), "New Thread");
+  stop_flag = true;
+  thread.join();
+}
+
+TEST(ThreadNameTest, deadThread) {
+  std::atomic_bool stop_flag;
+  std::atomic_int tid = 0;
+  std::thread thread([&stop_flag, &tid]() {
+      setThreadName("New Thread");
+      tid = syscall(SYS_gettid);
+      while (!stop_flag) {
+        sleep(1);
+      }
+  });
+  while (!tid) {
+    sleep(1);
+  }
+  stop_flag = true;
+  thread.join();
+  EXPECT_EQ(getThreadName(tid), "Unknown");
+}
+


### PR DESCRIPTION
Summary:
Passing an invalid thread handle to pthread_getname_np may crash the process. This can happen when we try to get the name for a thread that has exited.

Switch to a robust implementation - which unfortunately is linux specific.
We can re-evaluate this later - another approach is to get the thread names from within the threads themselves as they are logging events.

Differential Revision: D27003592

