### PR TITLE
Fix cbid name lookup bounds check and remove static assert

### DIFF
--- a/libkineto/src/cupti_strings.cpp
+++ b/libkineto/src/cupti_strings.cpp
@@ -475,9 +475,9 @@ static const char* runtimeCbidNames[] = {
 };
 
 const char* runtimeCbidName(CUpti_CallbackId cbid) {
-  static_assert(CUPTI_RUNTIME_TRACE_CBID_SIZE <
-      (sizeof(runtimeCbidNames) / sizeof(runtimeCbidNames[0])));
-  if (cbid < 0 || cbid > CUPTI_RUNTIME_TRACE_CBID_SIZE) {
+  constexpr int names_size =
+      sizeof(runtimeCbidNames) / sizeof(runtimeCbidNames[0]);
+  if (cbid < 0 || cbid >= names_size) {
     return runtimeCbidNames[CUPTI_RUNTIME_TRACE_CBID_INVALID];
   }
   return runtimeCbidNames[cbid];

--- a/libkineto/test/CuptiStringsTest.cpp
+++ b/libkineto/test/CuptiStringsTest.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/cupti_strings.h"
+
+using namespace KINETO_NAMESPACE;
+
+TEST(CuptiStringsTest, Valid) {
+  ASSERT_STREQ(
+      runtimeCbidName(CUPTI_RUNTIME_TRACE_CBID_INVALID), "INVALID");
+  ASSERT_STREQ(
+      runtimeCbidName(CUPTI_RUNTIME_TRACE_CBID_cudaDriverGetVersion_v3020),
+      "cudaDriverGetVersion");
+  ASSERT_STREQ(runtimeCbidName
+      (CUPTI_RUNTIME_TRACE_CBID_cudaDeviceSynchronize_v3020),
+      "cudaDeviceSynchronize");
+  ASSERT_STREQ(
+      runtimeCbidName(CUPTI_RUNTIME_TRACE_CBID_cudaStreamSetAttribute_ptsz_v11000),
+      "cudaStreamSetAttribute_ptsz");
+}
+
+TEST(CuptiStringsTest, Invalid) {
+  ASSERT_STREQ(runtimeCbidName(-1), "INVALID");
+  // We can't actually use CUPTI_RUNTIME_TRACE_CBID_SIZE here until we
+  // auto-generate the string table, since it may have more entries than
+  // the enum in the version used to compile.
+  ASSERT_STREQ(runtimeCbidName(1000), "INVALID");
+}

--- a/libkineto/test/PidInfoTest.cpp
+++ b/libkineto/test/PidInfoTest.cpp
@@ -42,13 +42,9 @@ TEST(ThreadNameTest, otherThread) {
   std::thread thread([&stop_flag, &tid]() {
       setThreadName("New Thread");
       tid = syscall(SYS_gettid);
-      while (!stop_flag) {
-        sleep(1);
-      }
+      while (!stop_flag) {}
   });
-  while (!tid) {
-    sleep(1);
-  }
+  while (!tid) {}
   EXPECT_EQ(getThreadName(tid), "New Thread");
   stop_flag = true;
   thread.join();
@@ -60,15 +56,16 @@ TEST(ThreadNameTest, deadThread) {
   std::thread thread([&stop_flag, &tid]() {
       setThreadName("New Thread");
       tid = syscall(SYS_gettid);
-      while (!stop_flag) {
-        sleep(1);
-      }
+      while (!stop_flag) {}
   });
-  while (!tid) {
-    sleep(1);
-  }
+  while (!tid) {}
   stop_flag = true;
   thread.join();
-  EXPECT_EQ(getThreadName(tid), "Unknown");
+  // There appears to be a delay before the thread info is
+  // removed from proc - we can therefore expect either
+  // "Unknown" or "New Thread" to be returned.
+  std::string name = getThreadName(tid);
+  EXPECT_TRUE(name == "Unknown" || name == "New Thread")
+    << "Where name = " << name;
 }
 


### PR DESCRIPTION
Summary:
The static assert adds additional work for PyTorch folks when updating the PyTorch Cuda version.

Note: It was added to notify us when the table needs updating, which is when PyTorch adds support for a new version of Cuda.
But if not using this approach we need another automatic reminder to add the support.

Also, the bounds check should use the names array size not the enum size, as otherwise it will break when running a version compiled for one version of Cuda on a newer version.

Differential Revision: D27084725

