### PR TITLE
Add eventprofiler thread monitor

### DIFF
--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -38,6 +38,7 @@ constexpr seconds kDefaultActivitiesWarmupDurationSecs(15);
 constexpr seconds kDefaultReportPeriodSecs(1);
 constexpr int kDefaultSamplesPerReport(1);
 constexpr int kDefaultMaxEventProfilersPerGpu(1);
+constexpr int kDefaultEventProfilerHearbeatMonitorPeriod(0);
 constexpr seconds kMaxRequestAge(10);
 
 // Event Profiler
@@ -51,6 +52,8 @@ const string kEventsLogFileKey = "EVENTS_LOG_FILE";
 const string kEventsEnabledDevicesKey = "EVENTS_ENABLED_DEVICES";
 const string kOnDemandDurationKey = "EVENTS_DURATION_SECS";
 const string kMaxEventProfilersPerGpuKey = "MAX_EVENT_PROFILERS_PER_GPU";
+const string kHeartbeatMonitorPeriodKey =
+    "EVENTS_HEARTBEAT_MONITOR_PERIOD_SECS";
 
 // Activity Profiler
 const string kActivitiesEnabledKey = "ACTIVITIES_ENABLED";
@@ -136,6 +139,8 @@ Config::Config()
       samplesPerReport_(kDefaultSamplesPerReport),
       eventProfilerOnDemandDuration_(seconds(0)),
       eventProfilerMaxInstancesPerGpu_(kDefaultMaxEventProfilersPerGpu),
+      eventProfilerHeartbeatMonitorPeriod_(
+          kDefaultEventProfilerHearbeatMonitorPeriod),
       multiplexPeriod_(kDefaultMultiplexPeriodMsecs),
       activityProfilerEnabled_(true),
       activitiesLogFile_(defaultTraceFileName()),
@@ -248,6 +253,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     eventProfilerOnDemandTimestamp_ = timestamp();
   } else if (name == kMaxEventProfilersPerGpuKey) {
     eventProfilerMaxInstancesPerGpu_ = toInt32(val);
+  } else if (name == kHeartbeatMonitorPeriodKey) {
+    eventProfilerHeartbeatMonitorPeriod_ = seconds(toInt32(val));
   }
 
   // Activity Profiler

--- a/libkineto/src/Config.h
+++ b/libkineto/src/Config.h
@@ -148,6 +148,14 @@ class Config : public AbstractConfig {
     return eventProfilerMaxInstancesPerGpu_;
   }
 
+  // On Cuda11 we've seen occasional hangs when reprogramming counters
+  // Monitor profiling threads and report when a thread is not responding
+  // for a given number of seconds.
+  // A period of 0 means disable.
+  std::chrono::seconds eventProfilerHeartbeatMonitorPeriod() const {
+    return eventProfilerHeartbeatMonitorPeriod_;
+  }
+
   // The types of activities selected in the configuration file
   const std::set<ActivityType>& selectedActivityTypes() const {
     return selectedActivityTypes_;
@@ -311,6 +319,10 @@ class Config : public AbstractConfig {
       eventProfilerOnDemandTimestamp_;
 
   int eventProfilerMaxInstancesPerGpu_;
+
+  // Monitor whether event profiler threads are stuck
+  // at this frequency
+  std::chrono::seconds eventProfilerHeartbeatMonitorPeriod_;
 
   // These settings can not be changed on-demand
   std::string eventLogFile_;

--- a/libkineto/src/EventProfilerController.h
+++ b/libkineto/src/EventProfilerController.h
@@ -21,6 +21,10 @@ class ConfigLoader;
 class EventProfiler;
 class SampleListener;
 
+namespace {
+class HeartbeatMonitor;
+}
+
 class EventProfilerController {
  public:
   EventProfilerController(const EventProfilerController&) = delete;
@@ -40,11 +44,13 @@ class EventProfilerController {
  private:
   explicit EventProfilerController(
       CUcontext context,
-      ConfigLoader& config_loader);
+      ConfigLoader& configLoader,
+      HeartbeatMonitor& heartbeatMonitor);
   bool enableForDevice(Config& cfg);
   void profilerLoop();
 
   ConfigLoader& configLoader_;
+  HeartbeatMonitor& heartbeatMonitor_;
   std::unique_ptr<EventProfiler> profiler_;
   std::unique_ptr<std::thread> profilerThread_;
   std::atomic_bool stopRunloop_{false};


### PR DESCRIPTION
Summary:
Event profiler sometimes causes hangs on Cuda11. We suspect it's somewhere during counter reprogramming.

Add a thread heartbeat monitor for the profiling threads and print error messages when threads appear stuck.

Differential Revision: D27041768

