### PR TITLE
Update ci to install pytorch stable

### DIFF
--- a/.github/workflows/tb_plugin_ci.yml
+++ b/.github/workflows/tb_plugin_ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
         cuda-version: [cpu, cu101, cu102, cu111]
-        pytorch-version: [nightly, 1.8rc]
+        pytorch-version: [nightly, 1.8rc, stable]
 
     steps:
       - uses: actions/checkout@v2

--- a/tb_plugin/ci_scripts/install_env.sh
+++ b/tb_plugin/ci_scripts/install_env.sh
@@ -26,7 +26,9 @@ if [ "$PYTORCH_VERSION" = "nightly" ]; then
     pip install --pre torchvision --no-deps -f "https://download.pytorch.org/whl/nightly/$CUDA_VERSION/torch_nightly.html"
 elif [ "$PYTORCH_VERSION" = "1.8rc" ]; then
     pip install --pre torch -f "https://download.pytorch.org/whl/test/$CUDA_VERSION/torch_test.html"
-    pip install --pre torchvision --no-deps -f "https://download.pytorch.org/whl/test/$CUDA_VERSION/torch_nightly.html"
+    pip install --pre torchvision --no-deps -f "https://download.pytorch.org/whl/test/$CUDA_VERSION/torch_test.html"
+elif [ "$PYTORCH_VERSION" = "stable" ]; then
+    pip install torch torchvision
 fi
 
 python -c "import torch; print(torch.__version__); from torch.autograd import kineto_available; print(kineto_available())"


### PR DESCRIPTION
Since the pytorch1.8 has released, update ci script from installing pytorch1.8rc to pytorch stable.