### PR TITLE
add surrounding quote for N/A to make sure it can be loaded by chrome…

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -327,7 +327,7 @@ void ChromeTraceLogger::handleGpuActivity(
 }
 
 static std::string bandwidth(uint64_t bytes, uint64_t duration) {
-  return duration == 0 ? "N/A" : fmt::format("{}", bytes * 1.0 / duration);
+  return duration == 0 ? "\"N/A\"" : fmt::format("{}", bytes * 1.0 / duration);
 }
 
 // GPU side memcpy activity


### PR DESCRIPTION
Add double quote to fix the bug when loading tracing file in chrome tracing.