### PR TITLE
Add missing quotes in json output

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -327,7 +327,7 @@ void ChromeTraceLogger::handleGpuActivity(
 }
 
 static std::string bandwidth(uint64_t bytes, uint64_t duration) {
-  return duration == 0 ? "N/A" : fmt::format("{}", bytes * 1.0 / duration);
+  return duration == 0 ? "\"N/A\"" : fmt::format("{}", bytes * 1.0 / duration);
 }
 
 // GPU side memcpy activity


### PR DESCRIPTION
Summary:
Forgot to put "N/A" in quotes, leading to json parsing error.
This is definitely a disadvantage of using manual json dumping + lack of tests.

Differential Revision: D27292513

