### PR TITLE
Put HeartbeatMonitor in a detail namespace

### DIFF
--- a/libkineto/src/EventProfilerController.h
+++ b/libkineto/src/EventProfilerController.h
@@ -21,7 +21,7 @@ class ConfigLoader;
 class EventProfiler;
 class SampleListener;
 
-namespace {
+namespace detail {
 class HeartbeatMonitor;
 }
 
@@ -45,12 +45,12 @@ class EventProfilerController {
   explicit EventProfilerController(
       CUcontext context,
       ConfigLoader& configLoader,
-      HeartbeatMonitor& heartbeatMonitor);
+      detail::HeartbeatMonitor& heartbeatMonitor);
   bool enableForDevice(Config& cfg);
   void profilerLoop();
 
   ConfigLoader& configLoader_;
-  HeartbeatMonitor& heartbeatMonitor_;
+  detail::HeartbeatMonitor& heartbeatMonitor_;
   std::unique_ptr<EventProfiler> profiler_;
   std::unique_ptr<std::thread> profilerThread_;
   std::atomic_bool stopRunloop_{false};


### PR DESCRIPTION
Summary:
I'm not actually sure there's any potential negative consequence here,
but it's potentially harmful to use an anonymous namespace in a header, since
it creates a unique symbol for each translation unit which can lead to ODR
violations.

I happened to notice a warning for this while building OSS pytorch :-)

Reviewed By: gdankel

Differential Revision: D27383716

