### PR TITLE
deprecate metdata args from ClientTraceActivity

### DIFF
--- a/libkineto/include/ClientTraceActivity.h
+++ b/libkineto/include/ClientTraceActivity.h
@@ -76,14 +76,6 @@ struct ClientTraceActivity : TraceActivity {
   pthread_t pthreadId{};
   int32_t sysThreadId{0};
   std::string opType;
-  std::string inputDims;
-  std::string inputTypes;
-  std::string arguments;
-  std::string outputDims;
-  std::string outputTypes;
-  std::string inputNames;
-  std::string outputNames;
-  std::string callStack;
 
  private:
   std::vector<std::string> metadata_;

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -176,19 +176,15 @@ void ChromeTraceLogger::handleCpuActivity(
   {{
     "ph": "X", "cat": "Operator", {},
     "args": {{
-       "Input dims": {}, "Input type": {}, "Input names": {},
-       "Output dims": {}, "Output type": {}, "Output names": {},
-       "Device": {}, "External id": {}, "Extra arguments": {},
-       "Call stack": "{}",
+       {},
+       "Device": {}, "External id": {}, 
        "Trace name": "{}", "Trace iteration": {}
     }}
   }},)JSON",
       traceActivityJson(op, ""),
       // args
-      op.inputDims, op.inputTypes, op.inputNames,
-      op.outputDims, op.outputTypes, op.outputNames,
-      op.device, op.correlation, op.arguments,
-      op.callStack,
+      op.getMetadata(),
+      op.device, op.correlation,
       span.name, span.iteration);
   // clang-format on
 }


### PR DESCRIPTION
Summary: as part of the ClientTraceActivity -> GenericTraceActivity migration, move all the metadata fields to JSON encoded string

Reviewed By: gdankel

Differential Revision: D27340314

