### PR TITLE
Fix empty metadata invalid json

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -171,19 +171,23 @@ void ChromeTraceLogger::handleCpuActivity(
     return;
   }
 
+  auto metadata = op.getMetadata();
+  if (!metadata.empty()) {
+    metadata += ",";
+  }
   // clang-format off
   traceOf_ << fmt::format(R"JSON(
   {{
     "ph": "X", "cat": "Operator", {},
     "args": {{
-       {},
-       "Device": {}, "External id": {}, 
+       {}
+       "Device": {}, "External id": {},
        "Trace name": "{}", "Trace iteration": {}
     }}
   }},)JSON",
       traceActivityJson(op, ""),
       // args
-      op.getMetadata(),
+      metadata,
       op.device, op.correlation,
       span.name, span.iteration);
   // clang-format on


### PR DESCRIPTION
Summary: Fix a case of invalid json when metadata is empty

Differential Revision: D27837639

