### PR TITLE
Fix TraceActivity forward declaration

### DIFF
--- a/libkineto/include/ActivityTraceInterface.h
+++ b/libkineto/include/ActivityTraceInterface.h
@@ -12,7 +12,7 @@
 
 namespace libkineto {
 
-class TraceActivity;
+struct TraceActivity;
 
 class ActivityTraceInterface {
  public:


### PR DESCRIPTION
Types defined as `struct` should be forward declared as struct

https://github.com/pytorch/kineto/blob/5bc9386b6d60c3b34b77961ea2900947103304b9/libkineto/include/TraceActivity.h#L21

Find while working on making PyTorch clang-tidy compliant