### PR TITLE
Remove distinction between active and inactive profiler interval

### DIFF
--- a/libkineto/include/ClientTraceActivity.h
+++ b/libkineto/include/ClientTraceActivity.h
@@ -60,8 +60,7 @@ struct ClientTraceActivity : TraceActivity {
 
   // Encode client side metadata as a key/value string.
   void addMetadata(const std::string& key, const std::string& value) {
-    auto kv = fmt::format("\"{}\": {}", key, value);
-    metadata_.push_back(std::move(kv));
+    metadata_.push_back(fmt::format("\"{}\": {}", key, value));
   }
 
   const std::string getMetadata() const {

--- a/libkineto/src/ActivityBuffers.h
+++ b/libkineto/src/ActivityBuffers.h
@@ -10,7 +10,6 @@
 
 #include <list>
 #include <memory>
-#include <vector>
 
 #include "libkineto.h"
 #include "CuptiActivityBuffer.h"
@@ -19,7 +18,7 @@ namespace KINETO_NAMESPACE {
 
 struct ActivityBuffers {
   std::list<std::unique_ptr<libkineto::CpuTraceBuffer>> cpu;
-  std::unique_ptr<std::list<CuptiActivityBuffer>> gpu;
+  std::unique_ptr<CuptiActivityBufferMap> gpu;
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/ActivityProfiler.cpp
+++ b/libkineto/src/ActivityProfiler.cpp
@@ -592,6 +592,7 @@ const time_point<system_clock> ActivityProfiler::performRunLoopStep(
         stopTraceInternal(now);
         resetInternal();
         VLOG(0) << "Warmup -> WaitForRequest";
+        break;
       }
 #endif // HAS_CUPTI
 

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -22,8 +22,7 @@ using namespace std::chrono;
 
 namespace KINETO_NAMESPACE {
 
-constexpr milliseconds kDefaultInactiveProfilerIntervalMsecs(1000);
-constexpr milliseconds kDefaultActiveProfilerIntervalMsecs(200);
+constexpr milliseconds kProfilerIntervalMsecs(1000);
 
 ActivityProfilerController::ActivityProfilerController(bool cpuOnly) {
   profiler_ = std::make_unique<ActivityProfiler>(CuptiActivityInterface::singleton(), cpuOnly);
@@ -62,17 +61,12 @@ static std::unique_ptr<ActivityLogger> makeLogger(const Config& config) {
       CuptiActivityInterface::singleton().smCount());
 }
 
-static milliseconds profilerInterval(bool profilerActive) {
-  return profilerActive ? kDefaultActiveProfilerIntervalMsecs
-                        : kDefaultInactiveProfilerIntervalMsecs;
-}
-
 void ActivityProfilerController::profilerLoop() {
   setThreadName("Kineto Activity Profiler");
   VLOG(0) << "Entering activity profiler loop";
 
   auto now = system_clock::now();
-  auto next_wakeup_time = now + profilerInterval(false);
+  auto next_wakeup_time = now + kProfilerIntervalMsecs;
 
   while (!stopRunloop_) {
     now = system_clock::now();
@@ -94,7 +88,7 @@ void ActivityProfilerController::profilerLoop() {
     }
 
     while (next_wakeup_time < now) {
-      next_wakeup_time += kDefaultActiveProfilerIntervalMsecs;
+      next_wakeup_time += kProfilerIntervalMsecs;
     }
 
     if (profiler_->isActive()) {

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -34,7 +34,7 @@ constexpr int kDefaultActivitiesExternalAPIIterations(3);
 constexpr int kDefaultActivitiesExternalAPINetSizeThreshold(0);
 constexpr int kDefaultActivitiesExternalAPIGpuOpCountThreshold(0);
 constexpr int kDefaultActivitiesMaxGpuBufferSize(128 * 1024 * 1024);
-constexpr seconds kDefaultActivitiesWarmupDurationSecs(15);
+constexpr seconds kDefaultActivitiesWarmupDurationSecs(5);
 constexpr seconds kDefaultReportPeriodSecs(1);
 constexpr int kDefaultSamplesPerReport(1);
 constexpr int kDefaultMaxEventProfilersPerGpu(1);

--- a/libkineto/src/Config.h
+++ b/libkineto/src/Config.h
@@ -289,11 +289,12 @@ class Config : public AbstractConfig {
 
   // Adds valid activity types from the user defined string list in the
   // configuration file
-  void addActivityTypes(const std::vector<std::string>& selected_activities);
+  void setActivityTypes(const std::vector<std::string>& selected_activities);
 
   // Sets the default activity types to be traced
   void selectDefaultActivityTypes() {
     // If the user has not specified an activity list, add all types
+    selectedActivityTypes_.insert(ActivityType::CPU_OP);
     selectedActivityTypes_.insert(ActivityType::GPU_MEMCPY);
     selectedActivityTypes_.insert(ActivityType::GPU_MEMSET);
     selectedActivityTypes_.insert(ActivityType::CONCURRENT_KERNEL);

--- a/libkineto/src/CuptiActivityBuffer.h
+++ b/libkineto/src/CuptiActivityBuffer.h
@@ -7,29 +7,45 @@
 
 #pragma once
 
-#include <stdlib.h>
-#include <sys/types.h>
-#include <unistd.h>
+#include <assert.h>
 #include <cstdint>
+#include <map>
+#include <memory>
+#include <sys/types.h>
+#include <vector>
 
 namespace KINETO_NAMESPACE {
 
 class CuptiActivityBuffer {
  public:
-  // data must be allocated using malloc.
-  // Ownership is transferred to this object.
-  CuptiActivityBuffer(uint8_t* data, size_t validSize)
-      : data(data), validSize(validSize) {}
+  explicit CuptiActivityBuffer(size_t size) : size_(size) {
+    buf_.reserve(size);
+  }
+  CuptiActivityBuffer() = delete;
+  CuptiActivityBuffer& operator=(const CuptiActivityBuffer&) = delete;
+  CuptiActivityBuffer(CuptiActivityBuffer&&) = default;
+  CuptiActivityBuffer& operator=(CuptiActivityBuffer&&) = default;
 
-  ~CuptiActivityBuffer() {
-    free(data);
+  size_t size() const {
+    return size_;
   }
 
-  // Allocated by malloc
-  uint8_t* data{nullptr};
+  void setSize(size_t size) {
+    assert(size <= buf_.capacity());
+    size_ = size;
+  }
 
-  // Number of bytes used
-  size_t validSize;
+  uint8_t* data() {
+    return buf_.data();
+  }
+
+ private:
+
+  std::vector<uint8_t> buf_;
+  size_t size_;
 };
+
+using CuptiActivityBufferMap =
+    std::map<uint8_t*, std::unique_ptr<CuptiActivityBuffer>>;
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiActivityInterface.cpp
+++ b/libkineto/src/CuptiActivityInterface.cpp
@@ -7,6 +7,7 @@
 
 #include "CuptiActivityInterface.h"
 
+#include <assert.h>
 #include <chrono>
 
 #include "cupti_call.h"
@@ -121,27 +122,36 @@ void CUPTIAPI CuptiActivityInterface::bufferRequestedTrampoline(
   singleton().bufferRequested(buffer, size, maxNumRecords);
 }
 
-void CuptiActivityInterface::bufferRequested(uint8_t** buffer, size_t* size, size_t* maxNumRecords) {
-  if (allocatedGpuBufferCount >= maxGpuBufferCount_) {
+void CuptiActivityInterface::bufferRequested(
+    uint8_t** buffer, size_t* size, size_t* maxNumRecords) {
+  std::lock_guard<std::mutex> guard(mutex_);
+  if (allocatedGpuTraceBuffers_.size() >= maxGpuBufferCount_) {
     stopCollection = true;
     LOG(WARNING) << "Exceeded max GPU buffer count ("
-                 << allocatedGpuBufferCount
+                 << allocatedGpuTraceBuffers_.size()
+                 << " > " << maxGpuBufferCount_
                  << ") - terminating tracing";
   }
 
+  auto buf = std::make_unique<CuptiActivityBuffer>(kBufSize);
+  *buffer = buf->data();
   *size = kBufSize;
+
+  allocatedGpuTraceBuffers_[*buffer] = std::move(buf);
+
   *maxNumRecords = 0;
-
-  // TODO(xdwang): create a list of buffers in advance so that we can reuse.
-  // This saves time to dynamically allocate new buffers (which could be costly
-  // if we allocated new space from the heap)
-  *buffer = (uint8_t*) malloc(kBufSize);
-
-  allocatedGpuBufferCount++;
 }
 #endif
 
-std::unique_ptr<std::list<CuptiActivityBuffer>> CuptiActivityInterface::activityBuffers() {
+std::unique_ptr<CuptiActivityBufferMap>
+CuptiActivityInterface::activityBuffers() {
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (allocatedGpuTraceBuffers_.empty()) {
+      return nullptr;
+    }
+  }
+
 #ifdef HAS_CUPTI
   VLOG(1) << "Flushing GPU activity buffers";
   time_point<high_resolution_clock> t1;
@@ -154,7 +164,8 @@ std::unique_ptr<std::list<CuptiActivityBuffer>> CuptiActivityInterface::activity
         duration_cast<microseconds>(high_resolution_clock::now() - t1).count();
   }
 #endif
-  return std::move(gpuTraceBuffers_);
+  std::lock_guard<std::mutex> guard(mutex_);
+  return std::move(readyGpuTraceBuffers_);
 }
 
 #ifdef HAS_CUPTI
@@ -175,35 +186,34 @@ int CuptiActivityInterface::processActivitiesForBuffer(
 #endif
 
 const std::pair<int, int> CuptiActivityInterface::processActivities(
-    std::list<CuptiActivityBuffer>& buffers,
+    CuptiActivityBufferMap& buffers,
     std::function<void(const CUpti_Activity*)> handler) {
   std::pair<int, int> res{0, 0};
 #ifdef HAS_CUPTI
-  for (auto& buf : buffers) {
+  for (auto& pair : buffers) {
     // No lock needed - only accessed from this thread
-    res.first += processActivitiesForBuffer(buf.data, buf.validSize, handler);
-    res.second += buf.validSize;
+    auto& buf = pair.second;
+    res.first += processActivitiesForBuffer(buf->data(), buf->size(), handler);
+    res.second += buf->size();
   }
 #endif
   return res;
 }
 
 void CuptiActivityInterface::clearActivities() {
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (allocatedGpuTraceBuffers_.empty()) {
+      return;
+    }
+  }
   CUPTI_CALL(cuptiActivityFlushAll(0));
   // FIXME: We might want to make sure we reuse
   // the same memory during warmup and tracing.
   // Also, try to use the amount of memory required
   // for active tracing during warmup.
-  if (gpuTraceBuffers_) {
-    gpuTraceBuffers_->clear();
-  }
-}
-
-void CuptiActivityInterface::addActivityBuffer(uint8_t* buffer, size_t validSize) {
-  if (!gpuTraceBuffers_) {
-    gpuTraceBuffers_ = std::make_unique<std::list<CuptiActivityBuffer>>();
-  }
-  gpuTraceBuffers_->emplace_back(buffer, validSize);
+  std::lock_guard<std::mutex> guard(mutex_);
+  readyGpuTraceBuffers_ = nullptr;
 }
 
 #ifdef HAS_CUPTI
@@ -222,12 +232,22 @@ void CuptiActivityInterface::bufferCompleted(
     uint8_t* buffer,
     size_t /* unused */,
     size_t validSize) {
-  allocatedGpuBufferCount--;
 
-  // lock should be uncessary here, because gpuTraceBuffers is read/written by
-  // profilerLoop only. CUPTI should handle the cuptiActivityFlushAll and
-  // bufferCompleted, so that there is no concurrency issues
-  addActivityBuffer(buffer, validSize);
+  std::lock_guard<std::mutex> guard(mutex_);
+  auto it = allocatedGpuTraceBuffers_.find(buffer);
+  if (it == allocatedGpuTraceBuffers_.end()) {
+    LOG(ERROR) << "bufferCompleted called with unknown buffer: "
+               << (void*) buffer;
+    return;
+  }
+
+  if (!readyGpuTraceBuffers_) {
+    readyGpuTraceBuffers_ = std::make_unique<CuptiActivityBufferMap>();
+  }
+  // Set valid size of buffer before moving to ready map
+  it->second->setSize(validSize);
+  (*readyGpuTraceBuffers_)[it->first] = std::move(it->second);
+  allocatedGpuTraceBuffers_.erase(it);
 
   // report any records dropped from the queue; to avoid unnecessary cupti
   // API calls, we make it report only in verbose mode (it doesn't happen

--- a/libkineto/src/CuptiActivityInterface.h
+++ b/libkineto/src/CuptiActivityInterface.h
@@ -17,6 +17,7 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <set>
 
 namespace KINETO_NAMESPACE {
@@ -52,11 +53,10 @@ class CuptiActivityInterface {
     const std::set<ActivityType>& selected_activities);
   void clearActivities();
 
-  void addActivityBuffer(uint8_t* buffer, size_t validSize);
-  virtual std::unique_ptr<std::list<CuptiActivityBuffer>> activityBuffers();
+  virtual std::unique_ptr<CuptiActivityBufferMap> activityBuffers();
 
   virtual const std::pair<int, int> processActivities(
-      std::list<CuptiActivityBuffer>& buffers,
+      CuptiActivityBufferMap&,
       std::function<void(const CUpti_Activity*)> handler);
 
   void setMaxBufferSize(int size);
@@ -81,8 +81,9 @@ class CuptiActivityInterface {
 #endif // HAS_CUPTI
 
   int maxGpuBufferCount_{0};
-  int allocatedGpuBufferCount{0};
-  std::unique_ptr<std::list<CuptiActivityBuffer>> gpuTraceBuffers_;
+  CuptiActivityBufferMap allocatedGpuTraceBuffers_;
+  std::unique_ptr<CuptiActivityBufferMap> readyGpuTraceBuffers_;
+  std::mutex mutex_;
 
  protected:
 #ifdef HAS_CUPTI

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -191,23 +191,20 @@ void ChromeTraceLogger::handleCpuActivity(
     return;
   }
 
-  auto metadata = op.getMetadata();
-  if (!metadata.empty()) {
-    metadata += ",";
-  }
+  const std::string metadata = op.getMetadata();
   // clang-format off
   traceOf_ << fmt::format(R"JSON(
   {{
     "ph": "X", "cat": "Operator", {},
     "args": {{
-       {}
+       {}{}
        "Device": {}, "External id": {},
        "Trace name": "{}", "Trace iteration": {}
     }}
   }},)JSON",
       traceActivityJson(op, ""),
       // args
-      metadata,
+      metadata, metadata.empty() ? "" : ",",
       op.device, op.correlation,
       span.name, span.iteration);
   // clang-format on

--- a/libkineto/test/ActivityProfilerTest.cpp
+++ b/libkineto/test/ActivityProfilerTest.cpp
@@ -128,7 +128,7 @@ class MockCuptiActivities : public CuptiActivityInterface {
   }
 
   virtual const std::pair<int, int> processActivities(
-      std::list<CuptiActivityBuffer>& /*unused*/,
+      CuptiActivityBufferMap&, /*unused*/
       std::function<void(const CUpti_Activity*)> handler) override {
     for (CUpti_Activity* act : activityBuffer->activities) {
       handler(act);
@@ -136,11 +136,13 @@ class MockCuptiActivities : public CuptiActivityInterface {
     return {activityBuffer->activities.size(), 100};
   }
 
-  virtual std::unique_ptr<std::list<CuptiActivityBuffer>>
+  virtual std::unique_ptr<CuptiActivityBufferMap>
   activityBuffers() override {
-    auto list = std::make_unique<std::list<CuptiActivityBuffer>>();
-    list->emplace_back(nullptr, 100);
-    return list;
+    auto map = std::make_unique<CuptiActivityBufferMap>();
+    auto buf = std::make_unique<CuptiActivityBuffer>(100);
+    uint8_t* addr = buf->data();
+    (*map)[addr] = std::move(buf);
+    return map;
   }
 
   void bufferRequestedOverride(uint8_t** buffer, size_t* size, size_t* maxNumRecords) {
@@ -158,12 +160,6 @@ class ActivityProfilerTest : public ::testing::Test {
     profiler_ = std::make_unique<ActivityProfiler>(
         cuptiActivities_, /*cpu only*/ false);
     cfg_ = std::make_unique<Config>();
-  }
-
-  std::list<CuptiActivityBuffer> createCuptiActivityBuffers() {
-    std::list<CuptiActivityBuffer> res;
-    res.emplace_back(nullptr, 100);
-    return res;
   }
 
   std::unique_ptr<Config> cfg_;
@@ -386,9 +382,6 @@ TEST_F(ActivityProfilerTest, BufferSizeLimitTestWarmup) {
     size_t gpuBufferSize;
     size_t maxNumRecords;
     cuptiActivities_.bufferRequestedOverride(&buf, &gpuBufferSize, &maxNumRecords);
-
-    // we don't actually do anything with the buf so just free it to prevent leaks in tests
-    free(buf);
   }
 
   profiler.performRunLoopStep(now, now);


### PR DESCRIPTION
Summary: Previously tracing buffers were being cleared frequently during warmup in order to stay under the buffer memory limit. But most use cases need at least 1-2s active trace time to capture multiple iterations and so clearing the buffers every 1s seems sufficient.

Reviewed By: chaekit

Differential Revision: D28094676

