### PR TITLE
Refactor trace activities

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -7,16 +7,29 @@
 
 #pragma once
 
+#include <array>
+#include <string>
+
 namespace libkineto {
 
 enum class ActivityType {
     CPU_OP = 0, // cpu side ops
+    USER_ANNOTATION,
+    GPU_USER_ANNOTATION,
     GPU_MEMCPY,
     GPU_MEMSET,
     CONCURRENT_KERNEL, // on-device kernels
     EXTERNAL_CORRELATION,
     CUDA_RUNTIME, // host side cuda runtime events
     CPU_INSTANT_EVENT, // host side point-like events
+    ENUM_COUNT
 };
+
+const char* toString(ActivityType t);
+ActivityType toActivityType(const std::string& str);
+
+// Return an array of all activity types except COUNT
+constexpr int activityTypeCount = (int)ActivityType::ENUM_COUNT;
+const std::array<ActivityType, activityTypeCount> activityTypes();
 
 } // namespace libkineto

--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -14,19 +14,28 @@
 
 #include "ThreadUtil.h"
 #include "TraceActivity.h"
+#include "TraceSpan.h"
 
 namespace libkineto {
 
 // @lint-ignore-every CLANGTIDY cppcoreguidelines-non-private-member-variables-in-classes
 // @lint-ignore-every CLANGTIDY cppcoreguidelines-pro-type-member-init
-struct GenericTraceActivity : TraceActivity {
+class GenericTraceActivity : public TraceActivity {
+
+ public:
+  GenericTraceActivity() = delete;
+
+  GenericTraceActivity(
+      const TraceSpan& trace, ActivityType type, const std::string& name)
+      : activityType(type), activityName(name), traceSpan_(&trace) {
+  }
 
   int64_t deviceId() const override {
     return device;
   }
 
   int64_t resourceId() const override {
-    return sysThreadId;
+    return resource;
   }
 
   int64_t timestamp() const override {
@@ -38,7 +47,7 @@ struct GenericTraceActivity : TraceActivity {
   }
 
   int64_t correlationId() const override {
-    return correlation;
+    return id;
   }
 
   ActivityType type() const override {
@@ -51,6 +60,10 @@ struct GenericTraceActivity : TraceActivity {
 
   const TraceActivity* linkedActivity() const override {
     return nullptr;
+  }
+
+  const TraceSpan* traceSpan() const override {
+    return traceSpan_;
   }
 
   void log(ActivityLogger& logger) const override;
@@ -68,13 +81,14 @@ struct GenericTraceActivity : TraceActivity {
 
   int64_t startTime{0};
   int64_t endTime{0};
-  int64_t correlation{0};
-  int device{-1};
-  int32_t sysThreadId{0};
-  std::string activityName;
+  int32_t id{0};
+  int32_t device{0};
+  int32_t resource{0};
   ActivityType activityType;
+  std::string activityName;
 
  private:
+  const TraceSpan* traceSpan_;
   std::vector<std::string> metadata_;
 };
 

--- a/libkineto/include/TraceActivity.h
+++ b/libkineto/include/TraceActivity.h
@@ -14,6 +14,7 @@
 namespace libkineto {
 
 class ActivityLogger;
+struct TraceSpan;
 
 // Generic activity interface is borrowed from tensorboard protobuf format.
 struct TraceActivity {
@@ -33,6 +34,8 @@ struct TraceActivity {
   virtual const std::string name() const = 0;
   // Optional linked activity
   virtual const TraceActivity* linkedActivity() const = 0;
+  // Optional containing trace object
+  virtual const TraceSpan* traceSpan() const = 0;
   // Log activity
   virtual void log(ActivityLogger& logger) const = 0;
 

--- a/libkineto/include/TraceSpan.h
+++ b/libkineto/include/TraceSpan.h
@@ -7,12 +7,26 @@
 
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <thread>
 
 namespace libkineto {
 
 struct TraceSpan {
+  TraceSpan() = delete;
+  TraceSpan(
+      int64_t startTime, int64_t endTime, std::string name)
+      : startTime(startTime), endTime(endTime), name(std::move(name)) {
+  }
+  TraceSpan(
+      int opCount, int it, std::string name, std::string prefix)
+      : opCount(opCount),
+        iteration(it),
+        name(std::move(name)),
+        prefix(std::move(prefix)) {
+  }
+
   // FIXME: change to duration?
   int64_t startTime{0};
   int64_t endTime{0};
@@ -20,8 +34,10 @@ struct TraceSpan {
   int iteration{-1};
   // Name is used to identify timeline
   std::string name;
-  // Prefix used to distinguish sub-nets on the same timeline
+  // Prefix used to distinguish trace spans on the same timeline
   std::string prefix;
+  // Tracked by profiler for iteration trigger
+  bool tracked{false};
 };
 
 } // namespace libkineto

--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -38,7 +38,7 @@ namespace libkineto {
 class Config;
 
 struct CpuTraceBuffer {
-  TraceSpan span;
+  TraceSpan span{0, 0, "none"};
   int gpuOpCount;
   std::vector<GenericTraceActivity> activities;
 };

--- a/libkineto/src/ActivityProfiler.cpp
+++ b/libkineto/src/ActivityProfiler.cpp
@@ -38,7 +38,7 @@ using std::string;
 namespace KINETO_NAMESPACE {
 
 bool ActivityProfiler::iterationTargetMatch(
-    const libkineto::CpuTraceBuffer& trace) {
+    libkineto::CpuTraceBuffer& trace) {
   const string& name = trace.span.name;
   bool match = (name == netIterationsTarget_);
   if (!match && applyNetFilterInternal(name) &&
@@ -53,6 +53,7 @@ bool ActivityProfiler::iterationTargetMatch(
     }
     if (match) {
       netIterationsTarget_ = name;
+      trace.span.tracked = true;
       LOG(INFO) << "Tracking net " << name << " for "
                 << netIterationsTargetCount_ << " iterations";
     }
@@ -163,8 +164,7 @@ void ActivityProfiler::processTraceInternal(ActivityLogger& logger) {
 
 ActivityProfiler::CpuGpuSpanPair& ActivityProfiler::recordTraceSpan(
     TraceSpan& span, int gpuOpCount) {
-  TraceSpan gpu_span{
-      0, 0, gpuOpCount, span.iteration, span.name, "GPU: "};
+  TraceSpan gpu_span(gpuOpCount, span.iteration, span.name, "GPU: ");
   auto& iterations = traceSpans_[span.name];
   iterations.push_back({span, gpu_span});
   return iterations.back();
@@ -183,8 +183,8 @@ void ActivityProfiler::processCpuTrace(
   TraceSpan& cpu_span = span_pair.first;
   for (auto const& act : cpuTrace.activities) {
     VLOG(2) << act.correlationId() << ": OP " << act.activityName;
-    if (logTrace) {
-      logger.handleCpuActivity(act, cpu_span);
+    if (logTrace && config_->selectedActivityTypes().count(act.type())) {
+      act.log(logger);
     }
     // Stash event so we can look it up later when processing GPU trace
     externalEvents_.insertEvent(&act);
@@ -192,9 +192,6 @@ void ActivityProfiler::processCpuTrace(
   }
   if (logTrace) {
     logger.handleTraceSpan(cpu_span);
-    if (cpu_span.name == netIterationsTarget_) {
-      logger.handleIterationStart(cpu_span);
-    }
   } else {
     disabledTraceSpans_.insert(cpu_span.name);
   }
@@ -203,41 +200,21 @@ void ActivityProfiler::processCpuTrace(
 #ifdef HAS_CUPTI
 inline void ActivityProfiler::handleCorrelationActivity(
     const CUpti_ActivityExternalCorrelation* correlation) {
-  switch(correlation->externalKind) {
-    case CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM0:
-      externalEvents_.addCorrelation(
-        correlation->externalId,
-        correlation->correlationId,
-        ExternalEventMap::CorrelationFlowType::Default);
-      break;
-    case CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM1:
-      externalEvents_.addCorrelation(
-        correlation->externalId,
-        correlation->correlationId,
-        ExternalEventMap::CorrelationFlowType::User);
-      break;
-    default:
-      LOG(ERROR) << "Received correlation activity with undefined kind: "
-        << correlation->externalKind;
-      break;
-  }
-  VLOG(2) << correlation->correlationId
-          << ": CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION";
+    externalEvents_.addCorrelation(
+        correlation->externalId, correlation->correlationId);
 }
 #endif // HAS_CUPTI
 
 const libkineto::GenericTraceActivity&
-ActivityProfiler::ExternalEventMap::getGenericTraceActivity(
-  uint32_t id, CorrelationFlowType flowType) {
-  static const libkineto::GenericTraceActivity nullOp_{};
+ActivityProfiler::ExternalEventMap::correlatedActivity(uint32_t id) {
+  static const libkineto::GenericTraceActivity nullOp_(
+      defaultTraceSpan().first, ActivityType::CPU_OP, "NULL");
 
-  auto& correlationMap = getCorrelationMap(flowType);
-
-  auto* res = events_[correlationMap[id]];
+  auto* res = events_[correlationMap_[id]];
   if (res == nullptr) {
     // Entry may be missing because cpu trace hasn't been processed yet
     // Insert a dummy element so that we can check for this in insertEvent
-    events_[correlationMap[id]] = &nullOp_;
+    events_[correlationMap_[id]] = &nullOp_;
     res = &nullOp_;
   }
   return *res;
@@ -253,52 +230,59 @@ void ActivityProfiler::ExternalEventMap::insertEvent(
 }
 
 void ActivityProfiler::ExternalEventMap::addCorrelation(
-  uint64_t external_id, uint32_t cuda_id, CorrelationFlowType flowType) {
-  switch(flowType){
-    case Default:
-      defaultCorrelationMap_[cuda_id] = external_id;
-      break;
-    case User:
-      userCorrelationMap_[cuda_id] = external_id;
-      break;
-  }
+    uint64_t external_id, uint32_t cuda_id) {
+  correlationMap_[cuda_id] = external_id;
 }
 
-static void initUserGpuSpan(GenericTraceActivity& userTraceActivity,
-  const libkineto::TraceActivity& cpuTraceActivity,
-  const libkineto::TraceActivity& gpuTraceActivity) {
-  userTraceActivity.device = gpuTraceActivity.deviceId();
-  userTraceActivity.startTime = gpuTraceActivity.timestamp();
-  userTraceActivity.sysThreadId = gpuTraceActivity.resourceId();
-  userTraceActivity.endTime = gpuTraceActivity.timestamp() + gpuTraceActivity.duration();
-  userTraceActivity.correlation = cpuTraceActivity.correlationId();
-  userTraceActivity.activityType = cpuTraceActivity.type();
-  userTraceActivity.activityName = cpuTraceActivity.name();
+static GenericTraceActivity createUserGpuSpan(
+    const libkineto::TraceActivity& cpuTraceActivity,
+    const libkineto::TraceActivity& gpuTraceActivity) {
+  GenericTraceActivity res(
+      *cpuTraceActivity.traceSpan(),
+      ActivityType::GPU_USER_ANNOTATION,
+      cpuTraceActivity.name());
+  res.startTime = gpuTraceActivity.timestamp();
+  res.device = gpuTraceActivity.deviceId();
+  res.resource = gpuTraceActivity.resourceId();
+  res.endTime =
+      gpuTraceActivity.timestamp() + gpuTraceActivity.duration();
+  res.id = cpuTraceActivity.correlationId();
+  return res;
 }
 
 void ActivityProfiler::GpuUserEventMap::insertOrExtendEvent(
-  const TraceActivity& cpuTraceActivity,
-  const TraceActivity& gpuTraceActivity) {
-  StreamKey key(gpuTraceActivity.deviceId(), gpuTraceActivity.resourceId());
-  CorrelationSpanMap& correlationSpanMap = streamSpanMap[key];
-  if (correlationSpanMap.count(cpuTraceActivity.correlationId()) == 0) {
-    GenericTraceActivity& userTraceActivity = correlationSpanMap[cpuTraceActivity.correlationId()];
-    initUserGpuSpan(userTraceActivity, cpuTraceActivity, gpuTraceActivity);
+    const TraceActivity&,
+    const TraceActivity& gpuActivity) {
+  const TraceActivity& cpuActivity = *gpuActivity.linkedActivity();
+  StreamKey key(gpuActivity.deviceId(), gpuActivity.resourceId());
+  CorrelationSpanMap& correlationSpanMap = streamSpanMap_[key];
+  auto it = correlationSpanMap.find(cpuActivity.correlationId());
+  if (it == correlationSpanMap.end()) {
+    auto it_success = correlationSpanMap.insert({
+        cpuActivity.correlationId(), createUserGpuSpan(cpuActivity, gpuActivity)
+    });
+    it = it_success.first;
   }
-  GenericTraceActivity& userTraceActivity = correlationSpanMap[cpuTraceActivity.correlationId()];
-  if (gpuTraceActivity.timestamp() < userTraceActivity.startTime || userTraceActivity.startTime == 0) {
-    userTraceActivity.startTime = gpuTraceActivity.timestamp();
+  GenericTraceActivity& span = it->second;
+  if (gpuActivity.timestamp() < span.startTime || span.startTime == 0) {
+    span.startTime = gpuActivity.timestamp();
   }
-  if ((gpuTraceActivity.timestamp() + gpuTraceActivity.duration()) > userTraceActivity.endTime) {
-    userTraceActivity.endTime = gpuTraceActivity.timestamp() + gpuTraceActivity.duration();
+  int64_t gpu_activity_end = gpuActivity.timestamp() + gpuActivity.duration();
+  if (gpu_activity_end > span.endTime) {
+    span.endTime = gpu_activity_end;
   }
 }
 
+const ActivityProfiler::CpuGpuSpanPair& ActivityProfiler::defaultTraceSpan() {
+  static TraceSpan span(0, 0, "Unknown", "");
+  static CpuGpuSpanPair span_pair(span, span);
+  return span_pair;
+}
+
 void ActivityProfiler::GpuUserEventMap::logEvents(ActivityLogger *logger) {
-  for (auto const& streamMapPair : streamSpanMap) {
+  for (auto const& streamMapPair : streamSpanMap_) {
     for (auto const& correlationSpanPair : streamMapPair.second) {
-      logger->handleGenericActivity(
-        correlationSpanPair.second);
+      correlationSpanPair.second.log(*logger);
     }
   }
 }
@@ -330,8 +314,7 @@ inline void ActivityProfiler::handleRuntimeActivity(
           << ": CUPTI_ACTIVITY_KIND_RUNTIME, cbid=" << activity->cbid
           << " tid=" << activity->threadId;
   const GenericTraceActivity& ext =
-    externalEvents_.getGenericTraceActivity(activity->correlationId,
-      ExternalEventMap::CorrelationFlowType::Default);
+      externalEvents_.correlatedActivity(activity->correlationId);
   int32_t tid = activity->threadId;
   const auto& it = threadInfo_.find(tid);
   if (it != threadInfo_.end()) {
@@ -395,26 +378,31 @@ inline void ActivityProfiler::handleGpuActivity(
   if (!loggingDisabled(ext)) {
     act.log(*logger);
     updateGpuNetSpan(act);
+    /*
     const GenericTraceActivity& extUser =
-      externalEvents_.getGenericTraceActivity(act.correlationId(),
-        ExternalEventMap::CorrelationFlowType::User);
+        externalEvents_.correlatedActivity(act.correlationId());
     // Correlated CPU activity cannot have timestamp greater than the GPU activity's
     if (!timestampsInCorrectOrder(extUser, act)) {
       return;
     }
-
     if (extUser.correlationId() != 0) {
       VLOG(2) << extUser.correlationId() << "," << act.correlationId()
               << " (user): "<< act.name();
-      gpuUserEventMap_.insertOrExtendEvent(extUser, act);
+*/
+    if (config_->selectedActivityTypes().count(ActivityType::GPU_USER_ANNOTATION) &&
+        act.linkedActivity() &&
+        act.linkedActivity()->type() == ActivityType::USER_ANNOTATION) {
+      //gpuUserEventMap_.insertOrExtendEvent(act, act);
     }
+//    }
   }
 }
 
 template <class T>
-inline void ActivityProfiler::handleGpuActivity(const T* act, ActivityLogger* logger) {
-  const GenericTraceActivity& extDefault = externalEvents_.getGenericTraceActivity(act->correlationId,
-      ExternalEventMap::CorrelationFlowType::Default);
+inline void ActivityProfiler::handleGpuActivity(
+    const T* act, ActivityLogger* logger) {
+  const GenericTraceActivity& extDefault =
+      externalEvents_.correlatedActivity(act->correlationId);
   handleGpuActivity(GpuActivity<T>(act, extDefault), logger);
 }
 

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ActivityType.h"
+
+#include <fmt/format.h>
+
+namespace libkineto {
+
+struct ActivityTypeName {
+  const char* name;
+  ActivityType type;
+};
+
+static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
+    {"cpu_op", ActivityType::CPU_OP},
+    {"user_annotation", ActivityType::USER_ANNOTATION},
+    {"gpu_user_Annotation", ActivityType::GPU_USER_ANNOTATION},
+    {"gpu_memcpy", ActivityType::GPU_MEMCPY},
+    {"gpu_memset", ActivityType::GPU_MEMSET},
+    {"kernel", ActivityType::CONCURRENT_KERNEL},
+    {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
+    {"cuda_runtime", ActivityType::CUDA_RUNTIME},
+    {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
+    {"ENUM_COUNT", ActivityType::ENUM_COUNT}
+}};
+
+static constexpr bool matchingOrder(int idx = 0) {
+  return map[idx].type == ActivityType::ENUM_COUNT ||
+    ((idx == (int) map[idx].type) && matchingOrder(idx + 1));
+}
+static_assert(matchingOrder(), "ActivityTypeName map is out of order");
+
+const char* toString(ActivityType t) {
+  return map[(int)t].name;
+}
+
+ActivityType toActivityType(const std::string& str) {
+  for (int i = 0; i < activityTypeCount; i++) {
+    if (str == map[i].name) {
+      return map[i].type;
+    }
+  }
+  throw std::invalid_argument(fmt::format("Invalid activity type: {}", str));
+}
+
+const std::array<ActivityType, activityTypeCount> activityTypes() {
+  std::array<ActivityType, activityTypeCount> res;
+  for (int i = 0; i < activityTypeCount; i++) {
+    res[i] = map[i].type;
+  }
+  return res;
+}
+
+} // namespace libkineto

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -73,14 +73,6 @@ const string kActivitiesWarmupDurationSecsKey = "ACTIVITIES_WARMUP_PERIOD_SECS";
 const string kActivitiesMaxGpuBufferSizeKey =
     "ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB";
 
-// Valid configuration file entries for activity types
-const string kActivityCpuOp = "cpu_op";
-const string kActivityMemcpy = "gpu_memcpy";
-const string kActivityMemset = "gpu_memset";
-const string kActivityConcurrentKernel = "concurrent_kernel";
-const string kActivityExternalCorrelation = "external_correlation";
-const string kActivityRuntime = "cuda_runtime";
-
 const string kDefaultLogFileFmt = "/tmp/libkineto_activities_{}.json";
 
 // Common
@@ -206,24 +198,8 @@ void Config::setActivityTypes(
     for (const auto& activity : selected_activities) {
       if (activity == "") {
         continue;
-      } else if (activity == kActivityCpuOp) {
-        selectedActivityTypes_.insert(ActivityType::CPU_OP);
-      } else if (activity == kActivityMemcpy) {
-        selectedActivityTypes_.insert(ActivityType::GPU_MEMCPY);
-      } else if (activity == kActivityMemset) {
-        selectedActivityTypes_.insert(ActivityType::GPU_MEMSET);
-      } else if (activity == kActivityConcurrentKernel) {
-        selectedActivityTypes_.insert(ActivityType::CONCURRENT_KERNEL);
-      } else if (activity == kActivityExternalCorrelation) {
-        selectedActivityTypes_.insert(ActivityType::EXTERNAL_CORRELATION);
-      } else if (activity == kActivityRuntime) {
-        selectedActivityTypes_.insert(ActivityType::CUDA_RUNTIME);
-      } else {
-        throw std::invalid_argument(fmt::format(
-          "Invalid activity type selected: {}",
-          activity
-        ));
       }
+      selectedActivityTypes_.insert(toActivityType(activity));
     }
   }
 }
@@ -236,9 +212,6 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   } else if (name == kMetricsKey) {
     vector<string> metric_names = splitAndTrim(val, ',');
     metricNames_.insert(metric_names.begin(), metric_names.end());
-  } else if (name == kActivityTypesKey) {
-    vector<string> activity_types = splitAndTrim(toLower(val), ',');
-    setActivityTypes(activity_types);
   } else if (name == kSamplePeriodKey) {
     samplePeriod_ = milliseconds(toInt32(val));
   } else if (name == kMultiplexPeriodKey) {
@@ -265,6 +238,9 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     activitiesOnDemandDuration_ =
         duration_cast<milliseconds>(seconds(toInt32(val)));
     activitiesOnDemandTimestamp_ = timestamp();
+  } else if (name == kActivityTypesKey) {
+    vector<string> activity_types = splitAndTrim(toLower(val), ',');
+    setActivityTypes(activity_types);
   } else if (name == kActivitiesDurationMsecsKey) {
     activitiesOnDemandDuration_ = milliseconds(toInt32(val));
     activitiesOnDemandTimestamp_ = timestamp();
@@ -404,33 +380,12 @@ void Config::printActivityProfilerConfig(std::ostream& s) const {
   s << "Max GPU buffer size: " << activitiesMaxGpuBufferSize() / 1024 / 1024
     << "MB" << std::endl;
 
-  s << "Enabled activities: ";
+  std::vector<const char*> activities;
   for (const auto& activity : selectedActivityTypes_) {
-    switch(activity){
-      case ActivityType::CPU_OP:
-        s << kActivityCpuOp << " ";
-        break;
-      case ActivityType::GPU_MEMCPY:
-        s << kActivityMemcpy << " ";
-        break;
-      case ActivityType::GPU_MEMSET:
-        s << kActivityMemset << " ";
-        break;
-      case ActivityType::CONCURRENT_KERNEL:
-        s << kActivityConcurrentKernel << " ";
-        break;
-      case ActivityType::EXTERNAL_CORRELATION:
-        s << kActivityExternalCorrelation << " ";
-        break;
-      case ActivityType::CUDA_RUNTIME:
-        s << kActivityRuntime << " ";
-        break;
-      default:
-        s << "UNKNOWN_ACTIVITY_NAME" << " ";
-        break;
-    }
+    activities.push_back(toString(activity));
   }
-  s << std::endl;
+  s << "Enabled activities: "
+    << fmt::format("{}", fmt::join(activities, ",")) << std::endl;
 
   AbstractConfig::printActivityProfilerConfig(s);
 }

--- a/libkineto/src/Config.h
+++ b/libkineto/src/Config.h
@@ -303,12 +303,9 @@ class Config : public AbstractConfig {
   // Sets the default activity types to be traced
   void selectDefaultActivityTypes() {
     // If the user has not specified an activity list, add all types
-    selectedActivityTypes_.insert(ActivityType::CPU_OP);
-    selectedActivityTypes_.insert(ActivityType::GPU_MEMCPY);
-    selectedActivityTypes_.insert(ActivityType::GPU_MEMSET);
-    selectedActivityTypes_.insert(ActivityType::CONCURRENT_KERNEL);
-    selectedActivityTypes_.insert(ActivityType::EXTERNAL_CORRELATION);
-    selectedActivityTypes_.insert(ActivityType::CUDA_RUNTIME);
+    for (ActivityType t : activityTypes()) {
+      selectedActivityTypes_.insert(t);
+    }
   }
 
   int verboseLogLevel_;

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -20,6 +20,7 @@ namespace libkineto {
 namespace KINETO_NAMESPACE {
 
 using namespace libkineto;
+struct TraceSpan;
 
 // These classes wrap the various CUPTI activity types
 // into subclasses of TraceActivity so that they can all be accessed
@@ -39,6 +40,7 @@ struct CuptiActivity : public TraceActivity {
   int64_t correlationId() const override {return activity_.correlationId;}
   const T& raw() const {return activity_;}
   const TraceActivity* linkedActivity() const override {return &linked_;}
+  const TraceSpan* traceSpan() const override {return nullptr;}
 
  protected:
   const T& activity_;

--- a/libkineto/src/CuptiActivityInterface.h
+++ b/libkineto/src/CuptiActivityInterface.h
@@ -84,6 +84,7 @@ class CuptiActivityInterface {
   CuptiActivityBufferMap allocatedGpuTraceBuffers_;
   std::unique_ptr<CuptiActivityBufferMap> readyGpuTraceBuffers_;
   std::mutex mutex_;
+  bool externalCorrelationEnabled_{false};
 
  protected:
 #ifdef HAS_CUPTI

--- a/libkineto/src/GenericTraceActivity.cpp
+++ b/libkineto/src/GenericTraceActivity.cpp
@@ -10,11 +10,6 @@
 
 namespace libkineto {
   void GenericTraceActivity::log(ActivityLogger& logger) const {
-    // TODO(T89833634): Merge handleGenericTraceActivity and handleCpuActivity
-    if (activityType == ActivityType::CPU_OP) {
-      return;
-    }
-
     logger.handleGenericActivity(*this);
   }
 } // namespace libkineto

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -44,14 +44,8 @@ class ActivityLogger {
 
   virtual void handleTraceSpan(const TraceSpan& span) = 0;
 
-  virtual void handleIterationStart(const TraceSpan& span) = 0;
-
-  virtual void handleCpuActivity(
-      const libkineto::GenericTraceActivity& activity,
-      const TraceSpan& span) = 0;
-
   virtual void handleGenericActivity(
-      const GenericTraceActivity& activity) = 0;
+      const libkineto::GenericTraceActivity& activity) = 0;
 
 #ifdef HAS_CUPTI
   virtual void handleRuntimeActivity(const RuntimeActivity& activity) = 0;

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -41,14 +41,7 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
 
   void handleTraceSpan(const TraceSpan& span) override;
 
-  void handleIterationStart(const TraceSpan& span) override;
-
-  void handleCpuActivity(
-      const libkineto::GenericTraceActivity& activity,
-      const TraceSpan& span) override;
-
-  void handleGenericActivity(
-      const GenericTraceActivity& activity) override;
+  void handleGenericActivity(const GenericTraceActivity& activity) override;
 
 #ifdef HAS_CUPTI
   void handleRuntimeActivity(
@@ -79,6 +72,8 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   void handleLinkStart(const RuntimeActivity& s);
   void handleLinkEnd(const TraceActivity& e);
 #endif // HAS_CUPTI
+
+  void addIterationMarker(const TraceSpan& span);
 
   void openTraceFile();
 

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -47,22 +47,10 @@ class MemoryTraceLogger : public ActivityLogger {
   }
 
   void handleTraceSpan(const TraceSpan& span) override {
-    traceSpanList_.push_back(span);
+    // Handled separately
   }
 
-  void handleIterationStart(const TraceSpan& span) override {
-    iterationList_.push_back(span);
-  }
-
-  void handleCpuActivity(
-      const libkineto::GenericTraceActivity& activity,
-      const TraceSpan& span) override {
-    activities_.push_back(
-        std::make_unique<CpuActivityDecorator>(activity, span));
-  }
-
-  void handleGenericActivity(
-      const GenericTraceActivity& activity) override {
+  void handleGenericActivity(const GenericTraceActivity& activity) override {
     activities_.push_back(
         std::make_unique<GenericTraceActivity>(activity));
   }
@@ -115,11 +103,8 @@ class MemoryTraceLogger : public ActivityLogger {
     for (auto& p : threadInfoList_) {
       logger.handleThreadInfo(p.first, p.second);
     }
-    for (auto& span : traceSpanList_) {
-      logger.handleTraceSpan(span);
-    }
-    for (auto& it : iterationList_) {
-      logger.handleIterationStart(it);
+    for (auto& cpu_trace_buffer : buffers_->cpu) {
+      logger.handleTraceSpan(cpu_trace_buffer->span);
     }
     // Hold on to the buffers
     logger.finalizeTrace(*config_, nullptr, endTime_);
@@ -127,35 +112,11 @@ class MemoryTraceLogger : public ActivityLogger {
 
  private:
 
-  struct CpuActivityDecorator : public libkineto::TraceActivity {
-    CpuActivityDecorator(
-        const libkineto::GenericTraceActivity& activity,
-        const TraceSpan& span)
-        : wrappee_(activity), span_(span) {}
-    int64_t deviceId() const override {return wrappee_.deviceId();}
-    int64_t resourceId() const override {return wrappee_.resourceId();}
-    int64_t timestamp() const override {return wrappee_.timestamp();}
-    int64_t duration() const override {return wrappee_.duration();}
-    int64_t correlationId() const override {return wrappee_.correlationId();}
-    ActivityType type() const override {return wrappee_.type();}
-    const std::string name() const override {return wrappee_.name();}
-    const TraceActivity* linkedActivity() const override {
-      return wrappee_.linkedActivity();
-    }
-    void log(ActivityLogger& logger) const override {
-      logger.handleCpuActivity(wrappee_, span_);
-    }
-    const libkineto::GenericTraceActivity& wrappee_;
-    const TraceSpan span_;
-  };
-
   std::unique_ptr<Config> config_;
   // Optimization: Remove unique_ptr by keeping separate vector per type
   std::vector<std::unique_ptr<TraceActivity>> activities_;
   std::vector<std::pair<ProcessInfo, int64_t>> processInfoList_;
   std::vector<std::pair<ThreadInfo, int64_t>> threadInfoList_;
-  std::vector<TraceSpan> traceSpanList_;
-  std::vector<TraceSpan> iterationList_;
   std::unique_ptr<ActivityBuffers> buffers_;
   std::unordered_map<std::string, std::string> metadata_;
   int64_t endTime_{0};

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -72,13 +72,9 @@ TEST(ParseTest, Format) {
 TEST(ParseTest, DefaultActivityTypes) {
   Config cfg;
   cfg.validate();
+  auto all_activities = activityTypes();
   EXPECT_EQ(cfg.selectedActivityTypes(),
-    std::set<ActivityType>({ActivityType::CPU_OP,
-                            ActivityType::GPU_MEMCPY,
-                            ActivityType::GPU_MEMSET,
-                            ActivityType::CONCURRENT_KERNEL,
-                            ActivityType::EXTERNAL_CORRELATION,
-                            ActivityType::CUDA_RUNTIME}));
+    std::set<ActivityType>(all_activities.begin(), all_activities.end()));
 }
 
 TEST(ParseTest, ActivityTypes) {
@@ -89,6 +85,9 @@ TEST(ParseTest, ActivityTypes) {
 
   EXPECT_EQ(cfg.selectedActivityTypes(),
     std::set<ActivityType>({ActivityType::CPU_OP,
+                            ActivityType::CPU_INSTANT_EVENT,
+                            ActivityType::USER_ANNOTATION,
+                            ActivityType::GPU_USER_ANNOTATION,
                             ActivityType::GPU_MEMCPY,
                             ActivityType::GPU_MEMSET,
                             ActivityType::CONCURRENT_KERNEL,
@@ -96,7 +95,7 @@ TEST(ParseTest, ActivityTypes) {
                             ActivityType::CUDA_RUNTIME}));
 
   Config cfg2;
-  EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES=gpu_memcpy,gpu_MeMsEt,concurrent_kernel"));
+  EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES=gpu_memcpy,gpu_MeMsEt,kernel"));
   EXPECT_EQ(cfg2.selectedActivityTypes(),
     std::set<ActivityType>({ActivityType::GPU_MEMCPY,
                             ActivityType::GPU_MEMSET,


### PR DESCRIPTION
Summary:
Replace ClientTraceActivity with GenericActivity.
In addition:
* Add a couple of new activity types for user annotations
* Simplify code for GPU-side user annotations
* Add accessor to containing trace span object in activities. Later we can replace this with a trace context / trace session object.
* Simplified MemoryTraceLogger
* Added early exit for cupti push/pop correlation ID

Differential Revision: D28231675

