### PR TITLE
Rename theoretical occupancy to est. achieved occupancy

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -372,7 +372,7 @@ void ChromeTraceLogger::handleGpuActivity(
       "warps per SM": {},
       "grid": [{}, {}, {}],
       "block": [{}, {}, {}],
-      "theoretical occupancy %": {}
+      "est. achieved occupancy %": {}
     }}
   }},)JSON",
       traceActivityJson(activity, "stream "),


### PR DESCRIPTION
Summary:
Theoretical occupancy is used in Nvidia docs to mean the occupancy a kernel could achieve given sufficient input parallelism (grid size).

It's more interesting in a trace to know what occupancy is actually achieved. Then if it's low, theoretical occupancy can be studied for each kernel to estimate improvement from increasing grid size. But that's something we can do as part of a recommendation or tutorial.

Reviewed By: ilia-cher

Differential Revision: D28327605

