### PR TITLE
Log device properties to trace file

### DIFF
--- a/libkineto/src/CudaDeviceProperties.cpp
+++ b/libkineto/src/CudaDeviceProperties.cpp
@@ -7,6 +7,7 @@
 
 #include "CudaDeviceProperties.h"
 
+#include <fmt/format.h>
 #include <vector>
 
 #include <cuda_runtime.h>
@@ -41,6 +42,36 @@ std::vector<cudaOccDeviceProp> createOccDeviceProps() {
 const std::vector<cudaOccDeviceProp>& occDeviceProps() {
   static std::vector<cudaOccDeviceProp> occProps = createOccDeviceProps();
   return occProps;
+}
+
+static const std::string createComputePropertiesJson(
+    const cudaOccDeviceProp& props) {
+  return fmt::format(R"JSON(
+    {{
+      "computeMajor": {}, "computeMinor": {},
+      "maxThreadsPerBlock": {}, "maxThreadsPerMultiprocessor": {},
+      "regsPerBlock": {}, "regsPerMultiprocessor": {}, "warpSize": {},
+      "sharedMemPerBlock": {}, "sharedMemPerMultiprocessor": {},
+      "numSms": {}, "sharedMemPerBlockOptin": {}
+    }})JSON",
+      props.computeMajor, props.computeMinor,
+      props.maxThreadsPerBlock, props.maxThreadsPerMultiprocessor,
+      props.regsPerBlock, props.regsPerMultiprocessor, props.warpSize,
+      props.sharedMemPerBlock, props.sharedMemPerMultiprocessor,
+      props.numSms, props.sharedMemPerBlockOptin);
+}
+
+static const std::string createComputePropertiesJson() {
+  std::vector<std::string> computeProps;
+  for (const auto& props : occDeviceProps()) {
+    computeProps.push_back(createComputePropertiesJson(props));
+  }
+  return fmt::format("{}", fmt::join(computeProps, ",\n"));
+}
+
+const std::string& computePropertiesJson() {
+  static std::string computePropsJson = createComputePropertiesJson();
+  return computePropsJson;
 }
 
 float kernelOccupancy(

--- a/libkineto/src/CudaDeviceProperties.h
+++ b/libkineto/src/CudaDeviceProperties.h
@@ -8,9 +8,11 @@
 #pragma once
 
 #include <stdint.h>
+#include <string>
 
 namespace KINETO_NAMESPACE {
 
+// Return estimated achieved occupancy for a kernel
 float kernelOccupancy(
     uint32_t deviceId,
     uint16_t registersPerThread,
@@ -20,5 +22,8 @@ float kernelOccupancy(
     int32_t blockY,
     int32_t blockZ,
     float blocks_per_sm);
+
+// Return compute properties for each device as a json string
+const std::string& computePropertiesJson();
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -61,8 +61,8 @@ Logger::~Logger() {
     buf_ << " : " << strerror_r(errnum_, buf, sizeof(buf));
   }
 #endif
-  buf_ << std::ends;
-  out_ << buf_.str() << std::endl;
+  buf_ << std::endl;
+  out_ << buf_.str();
 }
 
 void Logger::setVerboseLogModules(const std::vector<std::string>& modules) {

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -39,21 +39,20 @@ void ChromeTraceLogger::handleTraceStart(
   )JSON", kSchemaVersion);
 
   if (!metadata.empty()) {
-    traceOf_ << R"JSON(
-  "metadata": {
-  )JSON";
-    bool first = true;
+    std::vector<std::string> vals;
     for (const auto& kv : metadata) {
-      if (!first) {
-        traceOf_ << ",\n";
-      }
-      traceOf_ << fmt::format(R"(    "{}": "{}")", kv.first, kv.second);
-      first = false;
+      vals.push_back(fmt::format(R"(    "{}": "{}")", kv.first, kv.second));
     }
-    traceOf_ << R"JSON(
-  },
-  )JSON";
+    traceOf_ << fmt::format(R"JSON(
+  "metadata": {{
+    {}
+  }},)JSON", fmt::join(vals, ",\n"));
   }
+
+  traceOf_ << fmt::format(R"JSON(
+  "computeProperties": [
+    {}
+  ],)JSON", computePropertiesJson());
 
   traceOf_ << R"JSON(
   "traceEvents": [

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -49,10 +49,12 @@ void ChromeTraceLogger::handleTraceStart(
   }},)JSON", fmt::join(vals, ",\n"));
   }
 
+#ifdef HAS_CUPTI
   traceOf_ << fmt::format(R"JSON(
   "computeProperties": [
     {}
   ],)JSON", computePropertiesJson());
+#endif // HAS_CUPTI
 
   traceOf_ << R"JSON(
   "traceEvents": [


### PR DESCRIPTION
Device properties are useful in any case, but especially for performing analysis on traces such as occupancy.

This patch is a re-implementation of #209 
And it added 2 fields "name" and "totalGlobalMem", to remove duplicate from PyTorch side dump.
It adds "ifdef" to ignore dumping these fields when build on pure cpu.