### PR TITLE
Get rid of tautological check

### DIFF
--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -158,7 +158,7 @@ ConfigLoader::ConfigLoader(LibkinetoApi& api)
   config_.parse(readConfigFromConfigFile(configFileName_));
   SET_LOG_VERBOSITY_LEVEL(config_.verboseLogLevel(), config_.verboseLogModules());
   setupSignalHandler(config_.sigUsr2Enabled());
-  if (daemonConfigLoaderFactory && daemonConfigLoaderFactory()) {
+  if (daemonConfigLoaderFactory()) {
     daemonConfigLoader_ = daemonConfigLoaderFactory()();
     daemonConfigLoader_->setCommunicationFabric(config_.ipcFabricEnabled());
   }


### PR DESCRIPTION
`daemonConfigLoaderFactory` is a function and therefore always non-null

Fixes following clang warning:
```
../third_party/kineto/libkineto/src/ConfigLoader.cpp:161:7: warning: address of function 'daemonConfigLoaderFactory' will always evaluate to 'true' [-Wpointer-bool-conversion]
  if (daemonConfigLoaderFactory && daemonConfigLoaderFactory()) {
      ^~~~~~~~~~~~~~~~~~~~~~~~~ ~~
```