### PR TITLE
Invert ConfigLoader -> profiler dependency (take 2) (#271)

### DIFF
--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -36,6 +36,7 @@ extern "C" {
 namespace libkineto {
 
 class Config;
+class ConfigLoader;
 
 struct CpuTraceBuffer {
   TraceSpan span{0, 0, "none"};
@@ -45,6 +46,9 @@ struct CpuTraceBuffer {
 
 class LibkinetoApi {
  public:
+
+  LibkinetoApi(ConfigLoader& configLoader) : configLoader_(configLoader) {
+  }
 
   // Called by client that supports tracing API.
   // libkineto can still function without this.
@@ -92,11 +96,17 @@ class LibkinetoApi {
     suppressLibkinetoLogMessages();
   }
 
+  // Provides access to profier configuration manaegement
+  ConfigLoader& configLoader() {
+    return configLoader_;
+  }
+
  private:
 
   // Client is initialized once both it and libkineto has registered
   void initClientIfRegistered();
 
+  ConfigLoader& configLoader_;
   std::unique_ptr<ActivityProfilerInterface> activityProfiler_{};
   ClientInterface* client_{};
   int32_t clientRegisterThread_{0};

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -25,11 +25,18 @@ namespace KINETO_NAMESPACE {
 
 constexpr milliseconds kProfilerIntervalMsecs(1000);
 
-ActivityProfilerController::ActivityProfilerController(bool cpuOnly) {
-  profiler_ = std::make_unique<ActivityProfiler>(CuptiActivityInterface::singleton(), cpuOnly);
+ActivityProfilerController::ActivityProfilerController(
+    ConfigLoader& configLoader, bool cpuOnly)
+    : configLoader_(configLoader) {
+  profiler_ = std::make_unique<ActivityProfiler>(
+      CuptiActivityInterface::singleton(), cpuOnly);
+  configLoader_.addHandler(ConfigLoader::ConfigKind::ActivityProfiler, this);
 }
 
 ActivityProfilerController::~ActivityProfilerController() {
+  LOG(INFO) << "ActivityProfilerController::~ActivityProfilerController()";
+  configLoader_.removeHandler(
+      ConfigLoader::ConfigKind::ActivityProfiler, this);
   if (profilerThread_) {
     // signaling termination of the profiler loop
     stopRunloop_ = true;
@@ -63,6 +70,17 @@ static std::unique_ptr<ActivityLogger> makeLogger(const Config& config) {
     return std::make_unique<MemoryTraceLogger>(config);
   }
   return loggerFactory().makeLogger(config.activitiesLogUrl());
+}
+
+bool ActivityProfilerController::canAcceptConfig() {
+  return !profiler_->isActive();
+}
+
+void ActivityProfilerController::acceptConfig(const Config& config) {
+  VLOG(1) << "acceptConfig";
+  if (config.activityProfilerEnabled()) {
+    scheduleTrace(config);
+  }
 }
 
 void ActivityProfilerController::profilerLoop() {
@@ -107,6 +125,11 @@ void ActivityProfilerController::profilerLoop() {
 }
 
 void ActivityProfilerController::scheduleTrace(const Config& config) {
+  VLOG(1) << "scheduleTrace";
+  if (profiler_->isActive()) {
+    LOG(ERROR) << "Ignored request - profiler busy";
+    return;
+  }
   std::lock_guard<std::mutex> lock(asyncConfigLock_);
   asyncRequestConfig_ = config.clone();
   // start a profilerLoop() thread to handle request

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -9,21 +9,23 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <thread>
 
 #include "ActivityLoggerFactory.h"
 #include "ActivityProfiler.h"
 #include "ActivityProfilerInterface.h"
 #include "ActivityTraceInterface.h"
+#include "ConfigLoader.h"
 #include "CuptiActivityInterface.h"
 
 namespace KINETO_NAMESPACE {
 
 class Config;
 
-class ActivityProfilerController {
+class ActivityProfilerController : public ConfigLoader::ConfigHandler {
  public:
-  explicit ActivityProfilerController(bool cpuOnly);
+  explicit ActivityProfilerController(ConfigLoader& configLoader, bool cpuOnly);
   ActivityProfilerController(const ActivityProfilerController&) = delete;
   ActivityProfilerController& operator=(const ActivityProfilerController&) =
       delete;
@@ -33,6 +35,9 @@ class ActivityProfilerController {
   static void addLoggerFactory(
       const std::string& protocol,
       ActivityLoggerFactory::FactoryFunc factory);
+
+  bool canAcceptConfig() override;
+  void acceptConfig(const Config& config) override;
 
   void scheduleTrace(const Config& config);
 
@@ -72,6 +77,7 @@ class ActivityProfilerController {
   std::unique_ptr<ActivityLogger> logger_;
   std::thread* profilerThread_{nullptr};
   std::atomic_bool stopRunloop_{false};
+  ConfigLoader& configLoader_;
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -13,15 +13,20 @@
 
 namespace KINETO_NAMESPACE {
 
-void ActivityProfilerProxy::init() {
-  if (!controller_) {
-    controller_ = new ActivityProfilerController(cpuOnly_);
-  }
+ActivityProfilerProxy::ActivityProfilerProxy(
+    bool cpuOnly, ConfigLoader& configLoader)
+  : cpuOnly_(cpuOnly), configLoader_(configLoader) {
 }
 
 ActivityProfilerProxy::~ActivityProfilerProxy() {
   delete controller_;
 };
+
+void ActivityProfilerProxy::init() {
+  if (!controller_) {
+    controller_ = new ActivityProfilerController(configLoader_, cpuOnly_);
+  }
+}
 
 void ActivityProfilerProxy::scheduleTrace(const std::string& configStr) {
   Config config;

--- a/libkineto/src/ActivityProfilerProxy.h
+++ b/libkineto/src/ActivityProfilerProxy.h
@@ -26,11 +26,12 @@ using namespace libkineto;
 
 class ActivityProfilerController;
 class Config;
+class ConfigLoader;
 
 class ActivityProfilerProxy : public ActivityProfilerInterface {
 
  public:
-  ActivityProfilerProxy(bool cpuOnly) : cpuOnly_(cpuOnly) {}
+  ActivityProfilerProxy(bool cpuOnly, ConfigLoader& configLoader);
   ~ActivityProfilerProxy() override;
 
   void init() override;
@@ -64,6 +65,7 @@ class ActivityProfilerProxy : public ActivityProfilerInterface {
 
  private:
   bool cpuOnly_{true};
+  ConfigLoader& configLoader_;
   ActivityProfilerController* controller_{nullptr};
 };
 

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -148,6 +148,7 @@ Config::Config()
           kDefaultActivitiesExternalAPINetSizeThreshold),
       activitiesExternalAPIGpuOpCountThreshold_(
           kDefaultActivitiesExternalAPIGpuOpCountThreshold),
+      activitiesOnDemandTimestamp_(milliseconds(0)),
       requestTimestamp_(milliseconds(0)),
       enableSigUsr2_(true),
       enableIpcFabric_(false) {

--- a/libkineto/src/Config.h
+++ b/libkineto/src/Config.h
@@ -45,7 +45,8 @@ class Config : public AbstractConfig {
   }
 
   bool activityProfilerEnabled() const {
-    return activityProfilerEnabled_;
+    return activityProfilerEnabled_ ||
+      activitiesOnDemandTimestamp_.time_since_epoch().count() > 0;
   }
 
   // Log activitiy trace to this file

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -15,8 +15,6 @@
 #include <chrono>
 #include <fstream>
 
-#include "libkineto.h"
-#include "ActivityProfilerProxy.h"
 #include "DaemonConfigLoader.h"
 
 #include "Logger.h"
@@ -120,7 +118,7 @@ void ConfigLoader::setDaemonConfigLoaderFactory(
 }
 
 ConfigLoader& ConfigLoader::instance() {
-  static ConfigLoader config_loader(libkineto::api());
+  static ConfigLoader config_loader;
   return config_loader;
 }
 
@@ -130,9 +128,8 @@ std::string ConfigLoader::readOnDemandConfigFromDaemon(
   if (!daemonConfigLoader_) {
     return "";
   }
-  bool events =
-      now > onDemandEventProfilerConfig_->eventProfilerOnDemandEndTime();
-  bool activities = !libkinetoApi_.activityProfiler().isActive();
+  bool events = canHandlerAcceptConfig(ConfigKind::EventProfiler);
+  bool activities = canHandlerAcceptConfig(ConfigKind::ActivityProfiler);
   return daemonConfigLoader_->readOnDemandConfig(events, activities);
 }
 
@@ -144,30 +141,29 @@ int ConfigLoader::contextCountForGpu(uint32_t device) {
   return daemonConfigLoader_->gpuContextCount(device);
 }
 
-ConfigLoader::ConfigLoader(LibkinetoApi& api)
-    : libkinetoApi_(api),
-      onDemandEventProfilerConfig_(new Config()),
-      configUpdateIntervalSecs_(kConfigUpdateIntervalSecs),
+ConfigLoader::ConfigLoader()
+    : configUpdateIntervalSecs_(kConfigUpdateIntervalSecs),
       onDemandConfigUpdateIntervalSecs_(kOnDemandConfigUpdateIntervalSecs),
       stopFlag_(false),
       onDemandSignal_(false) {
-  configFileName_ = getenv(kConfigFileEnvVar.data());
-  if (configFileName_ == nullptr) {
-    configFileName_ = kConfigFile.data();
+}
+
+void ConfigLoader::startThread() {
+  if (!updateThread_) {
+    initBaseConfig();
+    if (daemonConfigLoaderFactory()) {
+      daemonConfigLoader_ = daemonConfigLoaderFactory()();
+      daemonConfigLoader_->setCommunicationFabric(config_.ipcFabricEnabled());
+    }
+    updateThread_ =
+        std::make_unique<std::thread>(&ConfigLoader::updateConfigThread, this);
+
+    setupSignalHandler(config_.sigUsr2Enabled());
   }
-  if (daemonConfigLoaderFactory()) {
-    daemonConfigLoader_ = daemonConfigLoaderFactory()();
-  }
-  updateBaseConfig();
-  SET_LOG_VERBOSITY_LEVEL(config_.verboseLogLevel(), config_.verboseLogModules());
-  if (daemonConfigLoader_) {
-    daemonConfigLoader_->setCommunicationFabric(config_.ipcFabricEnabled());
-  }
-  updateThread_ =
-      std::make_unique<std::thread>(&ConfigLoader::updateConfigThread, this);
 }
 
 ConfigLoader::~ConfigLoader() {
+  LOG(INFO) << "ConfigLoader::~ConfigLoader()";
   if (updateThread_) {
     stopFlag_ = true;
     {
@@ -183,6 +179,16 @@ void ConfigLoader::handleOnDemandSignal() {
   {
     std::lock_guard<std::mutex> lock(updateThreadMutex_);
     updateThreadCondVar_.notify_one();
+  }
+}
+
+void ConfigLoader::initBaseConfig() {
+  if (!configFileName_) {
+    configFileName_ = getenv(kConfigFileEnvVar.data());
+    if (configFileName_ == nullptr) {
+      configFileName_ = kConfigFile.data();
+    }
+    updateBaseConfig();
   }
 }
 
@@ -220,51 +226,23 @@ void ConfigLoader::configureFromSignal(
   if (daemonConfigLoader_) {
     daemonConfigLoader_->setCommunicationFabric(config_.ipcFabricEnabled());
   }
-  if (eventProfilerRequest(config)) {
-    if (now > onDemandEventProfilerConfig_->eventProfilerOnDemandEndTime()) {
-      LOG(INFO) << "Starting on-demand event profiling from signal";
-      std::lock_guard<std::mutex> lock(configLock_);
-      onDemandEventProfilerConfig_ = config.clone();
-    } else {
-      LOG(ERROR) << "On-demand event profiler is busy";
-    }
-  }
-  // Initiate a trace by default, even when not specified in the config.
-  // Set trace duration and iterations to 0 to suppress.
-  config.updateActivityProfilerRequestReceivedTime();
-  try {
-    auto& profiler = dynamic_cast<ActivityProfilerProxy&>(
-        libkinetoApi_.activityProfiler());
-    profiler.scheduleTrace(config);
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "Failed to schedule profiler request (busy?)";
-  }
+  notifyHandlers(config);
 }
 
 void ConfigLoader::configureFromDaemon(
     time_point<system_clock> now,
     Config& config) {
   const std::string config_str = readOnDemandConfigFromDaemon(now);
-  LOG_IF(INFO, !config_str.empty()) << "Received config from dyno:\n"
-                                    << config_str;
+  if (config_str.empty()) {
+    return;
+  }
+
+  LOG(INFO) << "Received config from dyno:\n" << config_str;
   config.parse(config_str);
   if (daemonConfigLoader_) {
     daemonConfigLoader_->setCommunicationFabric(config_.ipcFabricEnabled());
   }
-  if (eventProfilerRequest(config)) {
-    std::lock_guard<std::mutex> lock(configLock_);
-    onDemandEventProfilerConfig_ = config.clone();
-  }
-  if (config_.activityProfilerEnabled() &&
-      config.activityProfilerRequestReceivedTime() > now) {
-    try {
-      auto& profiler = dynamic_cast<ActivityProfilerProxy&>(
-          libkinetoApi_.activityProfiler());
-      profiler.scheduleTrace(config);
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "Failed to schedule profiler request (busy?)";
-    }
-  }
+  notifyHandlers(config);
 }
 
 void ConfigLoader::updateConfigThread() {
@@ -323,12 +301,6 @@ void ConfigLoader::updateConfigThread() {
 bool ConfigLoader::hasNewConfig(const Config& oldConfig) {
   std::lock_guard<std::mutex> lock(configLock_);
   return config_.timestamp() > oldConfig.timestamp();
-}
-
-bool ConfigLoader::hasNewEventProfilerOnDemandConfig(const Config& oldConfig) {
-  std::lock_guard<std::mutex> lock(configLock_);
-  return onDemandEventProfilerConfig_->eventProfilerOnDemandStartTime() >
-      oldConfig.eventProfilerOnDemandStartTime();
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -27,20 +28,61 @@ class DaemonConfigLoader;
 
 class ConfigLoader {
  public:
+
   static ConfigLoader& instance();
+
+  enum ConfigKind {
+    ActivityProfiler = 0,
+    EventProfiler,
+    NumConfigKinds
+  };
+
+  struct ConfigHandler {
+    virtual ~ConfigHandler() {}
+    virtual bool canAcceptConfig() = 0;
+    virtual void acceptConfig(const Config& cfg) = 0;
+  };
+
+  void addHandler(ConfigKind kind, ConfigHandler* handler) {
+    std::lock_guard<std::mutex> lock(updateThreadMutex_);
+    handlers_[kind].push_back(handler);
+    startThread();
+  }
+
+  void removeHandler(ConfigKind kind, ConfigHandler* handler) {
+    std::lock_guard<std::mutex> lock(updateThreadMutex_);
+    auto it = std::find(
+        handlers_[kind].begin(), handlers_[kind].end(), handler);
+    if (it != handlers_[kind].end()) {
+      handlers_[kind].erase(it);
+    }
+  }
+
+  void notifyHandlers(const Config& cfg) {
+    std::lock_guard<std::mutex> lock(updateThreadMutex_);
+    for (auto& key_val : handlers_) {
+      for (ConfigHandler* handler : key_val.second) {
+        handler->acceptConfig(cfg);
+      }
+    }
+  }
+
+  bool canHandlerAcceptConfig(ConfigKind kind) {
+    for (ConfigHandler* handler : handlers_[kind]) {
+      if (!handler->canAcceptConfig()) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   inline std::unique_ptr<Config> getConfigCopy() {
     std::lock_guard<std::mutex> lock(configLock_);
+    initBaseConfig();
     return config_.clone();
   }
 
-  inline std::unique_ptr<Config> getEventProfilerOnDemandConfigCopy() {
-    std::lock_guard<std::mutex> lock(configLock_);
-    return onDemandEventProfilerConfig_->clone();
-  }
-
   bool hasNewConfig(const Config& oldConfig);
-  bool hasNewEventProfilerOnDemandConfig(const Config& oldConfig);
   int contextCountForGpu(uint32_t gpu);
 
   void handleOnDemandSignal();
@@ -49,9 +91,11 @@ class ConfigLoader {
       std::function<std::unique_ptr<DaemonConfigLoader>()> factory);
 
  private:
-  explicit ConfigLoader(libkineto::LibkinetoApi& api);
+  ConfigLoader();
   ~ConfigLoader();
 
+  void initBaseConfig();
+  void startThread();
   void updateConfigThread();
   void updateBaseConfig();
 
@@ -65,21 +109,14 @@ class ConfigLoader {
       std::chrono::time_point<std::chrono::system_clock> now,
       Config& config);
 
-  inline bool eventProfilerRequest(const Config& config) {
-    return (
-        config.eventProfilerOnDemandStartTime() >
-        onDemandEventProfilerConfig_->eventProfilerOnDemandStartTime());
-  }
-
   std::string readOnDemandConfigFromDaemon(
       std::chrono::time_point<std::chrono::system_clock> now);
 
-  LibkinetoApi& libkinetoApi_;
   std::mutex configLock_;
-  const char* configFileName_;
+  const char* configFileName_{nullptr};
   Config config_;
-  std::unique_ptr<Config> onDemandEventProfilerConfig_;
   std::unique_ptr<DaemonConfigLoader> daemonConfigLoader_;
+  std::map<ConfigKind, std::vector<ConfigHandler*>> handlers_;
 
   std::chrono::seconds configUpdateIntervalSecs_;
   std::chrono::seconds onDemandConfigUpdateIntervalSecs_;

--- a/libkineto/src/EventProfiler.h
+++ b/libkineto/src/EventProfiler.h
@@ -19,7 +19,6 @@
 #include <cupti.h>
 
 #include "Config.h"
-#include "ConfigLoader.h"
 #include "CuptiEventInterface.h"
 #include "CuptiMetricInterface.h"
 #include "SampleListener.h"
@@ -208,7 +207,11 @@ class EventProfiler {
   EventProfiler& operator=(const EventProfiler&) = delete;
   ~EventProfiler();
 
-  void configure(Config& config, Config& onDemandConfig);
+  void configure(Config& config, Config* onDemandConfig);
+
+  bool isOnDemandActive() {
+    return !!onDemandConfig_;
+  }
 
   // Print the counter sets. Multiple sets will be multiplexed.
   void printSets(std::ostream& s) const;
@@ -261,7 +264,8 @@ class EventProfiler {
 
   void eraseReportedSamples() {
     int erase_count = baseSamples_;
-    if (onDemandConfig_->eventProfilerOnDemandDuration().count() > 0) {
+    if (onDemandConfig_ &&
+        onDemandConfig_->eventProfilerOnDemandDuration().count() > 0) {
       erase_count = std::min(baseSamples_, onDemandSamples_);
     }
     eraseSamples(erase_count);
@@ -306,7 +310,7 @@ class EventProfiler {
     }
   }
 
-  void updateLoggers(Config& config, Config& on_demand_config);
+  void updateLoggers(Config& config, Config* on_demand_config);
 
   // Print all collected samples since last clear.
   void printAllSamples(std::ostream& s, CUdevice device) const;

--- a/libkineto/src/EventProfilerController.cpp
+++ b/libkineto/src/EventProfilerController.cpp
@@ -181,11 +181,11 @@ void reportLateSample(
 }
 
 void configureHeartbeatMonitor(
-    detail::HeartbeatMonitor& monitor, const Config& base, const Config& onDemand) {
+    detail::HeartbeatMonitor& monitor, const Config& base, const Config* onDemand) {
   seconds base_period =
       base.eventProfilerHeartbeatMonitorPeriod();
-  seconds on_demand_period =
-      onDemand.eventProfilerHeartbeatMonitorPeriod();
+  seconds on_demand_period = !onDemand ? seconds(0) :
+      onDemand->eventProfilerHeartbeatMonitorPeriod();
   monitor.setPeriod(
       on_demand_period > seconds(0) ? on_demand_period : base_period);
 }
@@ -210,6 +210,8 @@ EventProfilerController::EventProfilerController(
   auto cupti_events = std::make_unique<CuptiEventInterface>(context);
   auto cupti_metrics =
       std::make_unique<CuptiMetricInterface>(cupti_events->device());
+  configLoader_.addHandler(
+      ConfigLoader::ConfigKind::EventProfiler, this);
   auto config = configLoader.getConfigCopy();
   profiler_ = std::make_unique<EventProfiler>(
       std::move(cupti_events),
@@ -226,19 +228,40 @@ EventProfilerController::~EventProfilerController() {
     stopRunloop_ = true;
     profilerThread_->join();
   }
+  configLoader_.removeHandler(
+      ConfigLoader::ConfigKind::EventProfiler, this);
   VLOG(0) << "Stopped event profiler";
 }
 
 // Must be called under lock
-void EventProfilerController::start(CUcontext ctx) {
+void EventProfilerController::start(CUcontext ctx, ConfigLoader& configLoader) {
   profilerMap()[ctx] = unique_ptr<EventProfilerController>(
       new EventProfilerController(
-          ctx, ConfigLoader::instance(), detail::HeartbeatMonitor::instance()));
+          ctx, configLoader, detail::HeartbeatMonitor::instance()));
 }
 
 // Must be called under lock
 void EventProfilerController::stop(CUcontext ctx) {
   profilerMap()[ctx] = nullptr;
+}
+
+bool EventProfilerController::canAcceptConfig() {
+  std::lock_guard<std::mutex> guard(mutex_);
+  return !newOnDemandConfig_;
+}
+
+void EventProfilerController::acceptConfig(const Config& config) {
+  if (config.eventProfilerOnDemandDuration().count() == 0) {
+    // Ignore - not for this profiler
+    return;
+  }
+  std::lock_guard<std::mutex> guard(mutex_);
+  if (newOnDemandConfig_) {
+    LOG(ERROR) << "On demand request already queued - ignoring new request";
+    return;
+  }
+  newOnDemandConfig_ = config.clone();
+  LOG(INFO) << "Received new on-demand config";
 }
 
 bool EventProfilerController::enableForDevice(Config& cfg) {
@@ -271,12 +294,11 @@ void EventProfilerController::profilerLoop() {
   VLOG(0) << "Starting Event Profiler for GPU " << profiler_->device();
   setThreadName("CUPTI Event Profiler");
 
-  auto on_demand_config = std::make_unique<Config>();
-
   time_point<system_clock> next_sample_time;
   time_point<system_clock> next_report_time;
   time_point<system_clock> next_on_demand_report_time;
   time_point<system_clock> next_multiplex_time;
+  std::unique_ptr<Config> on_demand_config = nullptr;
   bool reconfigure = true;
   bool restart = true;
   int report_count = 0;
@@ -289,25 +311,29 @@ void EventProfilerController::profilerLoop() {
       report_count = 0;
       reconfigure = true;
     }
-    if (configLoader_.hasNewEventProfilerOnDemandConfig(*on_demand_config)) {
-      on_demand_config = configLoader_.getEventProfilerOnDemandConfigCopy();
-      LOG(INFO) << "Received new on-demand config";
-      on_demand_report_count = 0;
-      reconfigure = true;
-    }
 
     auto now = system_clock::now();
-    if (on_demand_config->eventProfilerOnDemandDuration().count() > 0 &&
+    if (on_demand_config &&
         now > (on_demand_config->eventProfilerOnDemandStartTime() +
                on_demand_config->eventProfilerOnDemandDuration())) {
-      on_demand_config->setEventProfilerOnDemandDuration(seconds(0));
+      on_demand_config = nullptr;
       LOG(INFO) << "On-demand profiling complete";
       reconfigure = true;
     }
 
+    if (!profiler_->isOnDemandActive()) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (newOnDemandConfig_) {
+        VLOG(0) << "Received on-demand config, reconfiguring";
+        on_demand_config = std::move(newOnDemandConfig_);
+        reconfigure = true;
+        on_demand_report_count = 0;
+      }
+    }
+
     if (reconfigure) {
       try {
-        profiler_->configure(*config, *on_demand_config);
+        profiler_->configure(*config, on_demand_config.get());
       } catch (const std::exception& ex) {
         LOG(ERROR) << "Encountered error while configuring event profiler: "
             << ex.what();
@@ -315,7 +341,8 @@ void EventProfilerController::profilerLoop() {
         // as it indicates a serious problem or bug.
         break;
       }
-      configureHeartbeatMonitor(heartbeatMonitor_, *config, *on_demand_config);
+      configureHeartbeatMonitor(
+          heartbeatMonitor_, *config, on_demand_config.get());
       reconfigure = false;
       restart = true;
     }
@@ -359,8 +386,7 @@ void EventProfilerController::profilerLoop() {
       profiler_->reportSamples();
       next_report_time += profiler_->reportPeriod();
     }
-    if (on_demand_config->eventProfilerOnDemandDuration().count() > 0 &&
-        now > next_on_demand_report_time) {
+    if (on_demand_report_count && now > next_on_demand_report_time) {
       VLOG(1) << "OnDemand Report #" << on_demand_report_count++;
       profiler_->reportOnDemandSamples();
       next_on_demand_report_time += profiler_->onDemandReportPeriod();

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -30,7 +30,6 @@
 
 #include "ActivityProfilerProxy.h"
 #include "Config.h"
-#include "ConfigLoader.h"
 #ifdef HAS_CUPTI
 #include "EventProfilerController.h"
 #endif
@@ -52,7 +51,8 @@ static void initProfilers(CUcontext ctx) {
     initialized = true;
     VLOG(0) << "libkineto profilers activated";
   }
-  EventProfilerController::start(ctx);
+  ConfigLoader& config_loader = libkineto::api().configLoader();
+  EventProfilerController::start(ctx, config_loader);
 }
 
 static void stopProfiler(CUcontext ctx) {
@@ -131,8 +131,9 @@ bool libkineto_init(bool cpuOnly, bool logOnError) {
   }
 #endif // HAS_CUPTI
 
+  ConfigLoader& config_loader = libkineto::api().configLoader();
   libkineto::api().registerProfiler(
-      std::make_unique<ActivityProfilerProxy>(cpuOnly));
+      std::make_unique<ActivityProfilerProxy>(cpuOnly, config_loader));
 
   return success;
 }

--- a/libkineto/src/libkineto_api.cpp
+++ b/libkineto/src/libkineto_api.cpp
@@ -7,12 +7,14 @@
 
 #include "libkineto.h"
 
+#include "ConfigLoader.h"
 #include "ThreadUtil.h"
 
 namespace libkineto {
 
 LibkinetoApi& api() {
-  static LibkinetoApi instance;
+  //static ConfigLoader config_loader;
+  static LibkinetoApi instance(ConfigLoader::instance());
   return instance;
 }
 

--- a/libkineto/test/EventProfilerTest.cpp
+++ b/libkineto/test/EventProfilerTest.cpp
@@ -343,8 +343,8 @@ TEST_F(EventProfilerTest, ConfigureFailure) {
 
   // Default config has no counters enabled.
   // Check that profiler remains disabled.
-  Config cfg, on_demand_cfg;
-  profiler_->configure(cfg, on_demand_cfg);
+  Config cfg;
+  profiler_->configure(cfg, nullptr);
 
   EXPECT_FALSE(profiler_->enabled());
 
@@ -364,7 +364,7 @@ TEST_F(EventProfilerTest, ConfigureFailure) {
       .Times(2)
       .WillRepeatedly(Throw(
           std::system_error(EINVAL, std::generic_category(), "Event ID")));
-  profiler_->configure(cfg, on_demand_cfg);
+  profiler_->configure(cfg, nullptr);
 
   EXPECT_FALSE(profiler_->enabled());
 }
@@ -373,7 +373,7 @@ TEST_F(EventProfilerTest, ConfigureBase) {
   using namespace testing;
 
   // Test normal path, simple base config
-  Config cfg, on_demand_cfg;
+  Config cfg;
   bool parsed = cfg.parse("EVENTS = elapsed_cycles_sm");
   EXPECT_TRUE(parsed);
 
@@ -394,7 +394,7 @@ TEST_F(EventProfilerTest, ConfigureBase) {
       .WillOnce(Return(ids));
   EXPECT_CALL(*cuptiEvents_, enableGroupSet(_)).Times(1);
 
-  profiler_->configure(cfg, on_demand_cfg);
+  profiler_->configure(cfg, nullptr);
 
   EXPECT_TRUE(profiler_->enabled());
 }
@@ -461,7 +461,7 @@ TEST_F(EventProfilerTest, ConfigureOnDemand) {
       .WillOnce(Return(ids_g3));
   EXPECT_CALL(*cuptiEvents_, enableGroupSet(_)).Times(1);
 
-  profiler_->configure(cfg, on_demand_cfg);
+  profiler_->configure(cfg, &on_demand_cfg);
 
   EXPECT_TRUE(profiler_->enabled());
   EXPECT_EQ(profiler_->samplePeriod().count(), 250);
@@ -523,7 +523,7 @@ TEST_F(EventProfilerTest, ReportSample) {
       .WillRepeatedly(Return(ids_g3));
   EXPECT_CALL(*cuptiEvents_, enableGroupSet(_)).Times(1);
 
-  profiler_->configure(cfg, on_demand_cfg);
+  profiler_->configure(cfg, &on_demand_cfg);
 
   EXPECT_TRUE(profiler_->enabled());
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/kineto/pull/271

Change direction of dependency from ConfigLoader -> profiler to profiler -> ConfigLoader. This way, the profiler is able to lazily initialize config loader and also move towards the pluggable profiler design.

Differential Revision: D28976077

