### PR TITLE
Do not leak file descriptors in processName()

### DIFF
--- a/libkineto/src/ThreadUtil.cpp
+++ b/libkineto/src/ThreadUtil.cpp
@@ -141,6 +141,7 @@ std::string processName(int32_t pid) {
   if (cmdfile != nullptr) {
     char* command = nullptr;
     int scanned = fscanf(cmdfile, "%ms", &command);
+    fclose(cmdfile);
     if (scanned > 0 && command) {
       std::string ret(basename(command));
       free(command);


### PR DESCRIPTION
Each `fopen()` must be followed by `fclose()`