### PR TITLE
round kernel_op table avg duration to integer

### DIFF
--- a/tb_plugin/torch_tb_profiler/profiler/run_generator.py
+++ b/tb_plugin/torch_tb_profiler/profiler/run_generator.py
@@ -312,7 +312,7 @@ class RunGenerator(object):
                              reverse=True)
         for agg_by_name_op in kernel_list:
             kernel_op_row = [agg_by_name_op.name, agg_by_name_op.op_name, agg_by_name_op.calls,
-                             agg_by_name_op.total_duration, agg_by_name_op.avg_duration,
+                             agg_by_name_op.total_duration, round(agg_by_name_op.avg_duration),
                              agg_by_name_op.max_duration, agg_by_name_op.min_duration]
             if sum(self.profile_data.blocks_per_sm_count) > 0:
                 kernel_op_row.append(round(agg_by_name_op.avg_blocks_per_sm, 2))


### PR DESCRIPTION
Fix the many digits problem:
![image](https://user-images.githubusercontent.com/10429114/121467556-d69c5800-c9eb-11eb-97f8-9fedd9e422c5.png)
