### PR TITLE
remove the Record Window End event

### DIFF
--- a/tb_plugin/torch_tb_profiler/profiler/data.py
+++ b/tb_plugin/torch_tb_profiler/profiler/data.py
@@ -6,7 +6,6 @@ import io as sysio
 import json
 import re
 import tempfile
-from collections import OrderedDict
 from json.decoder import JSONDecodeError
 
 from .. import io, utils
@@ -105,6 +104,7 @@ class RunProfileData(object):
         if trace_path.endswith('.gz'):
             data = gzip.decompress(data)
 
+        json_reencode = False
         try:
             trace_json = json.loads(data)
         except JSONDecodeError as e:
@@ -118,12 +118,33 @@ class RunProfileData(object):
                     # only replace the N/A without surrounding double quote
                     fout.write(re.sub(r'(?<!")N/A(?!")', "\"N/A\"", str_data))
                     trace_json = json.loads(fout.getvalue())
+                    logger.warning("Get JSONDecodeError: %s, Re-encode it to temp file" % e.msg)
+                    json_reencode = True
 
+        # work-around to remove the "Record Window End" events to avoid the huge end timestamp
+        event_list = trace_json["traceEvents"]
+        end_index = None
+        start_index = None
+        for i in reversed(range(len(event_list))):
+            if event_list[i]["name"] == "Record Window End":
+                end_index = i
+            elif event_list[i]["name"].startswith("Iteration Start:"):
+                start_index = i
+            if start_index is not None and end_index is not None:
+                break
+
+        if start_index is not None and end_index is not None:
+            dur = event_list[end_index]["ts"] - event_list[start_index]["ts"]
+            print(dur)
+            if dur > 24 * 3600 * 1000:
+                del trace_json["traceEvents"][end_index]
+                json_reencode = True
+
+        if json_reencode:
             fp = tempfile.NamedTemporaryFile('w+t', suffix='.json.gz', delete=False)
             fp.close()
             with gzip.open(fp.name, mode='wt') as fzip:
                 fzip.write(json.dumps(trace_json))
-            logger.warning("Get JSONDecodeError: %s, Re-encode it to temp file: %s", e.msg, fp.name)
             caches.add_file(local_file, fp.name)
             trace_path = fp.name
 

--- a/tb_plugin/torch_tb_profiler/profiler/data.py
+++ b/tb_plugin/torch_tb_profiler/profiler/data.py
@@ -135,7 +135,6 @@ class RunProfileData(object):
 
         if start_index is not None and end_index is not None:
             dur = event_list[end_index]["ts"] - event_list[start_index]["ts"]
-            print(dur)
             if dur > 24 * 3600 * 1000:
                 del trace_json["traceEvents"][end_index]
                 json_reencode = True


### PR DESCRIPTION
remove the Record Window End event if the duration is larger than 1 day to workaround the high resolution clock bug in pytorch profiler

