### PR TITLE
Avoid unecessary string construction in Config constructor

### DIFF
--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -123,8 +123,7 @@ void Config::addConfigFactory(
 }
 
 static string defaultTraceFileName() {
-  const string kDefaultLogFileFmt = "/tmp/libkineto_activities_{}.json";
-  return fmt::format(kDefaultLogFileFmt, processId());
+  return fmt::format("/tmp/libkineto_activities_{}.json", processId());
 }
 
 Config::Config()


### PR DESCRIPTION
Summary: Minor fix to remove superfluous std::string construction introduced in D29231802 (https://github.com/pytorch/kineto/commit/7929ccd311f21d5abaaa6fa588b6ee926ff4d147).

Differential Revision: D29246319

