### PR TITLE
Workaround: update example to speedup

### DIFF
--- a/tb_plugin/examples/resnet50_profiler_api.py
+++ b/tb_plugin/examples/resnet50_profiler_api.py
@@ -31,12 +31,12 @@ with torch.profiler.profile(
         torch.profiler.ProfilerActivity.CPU,
         torch.profiler.ProfilerActivity.CUDA],
     schedule=torch.profiler.schedule(
-        wait=2,
-        warmup=3,
-        active=6),
+        wait=1,
+        warmup=1,
+        active=2),
     on_trace_ready=torch.profiler.tensorboard_trace_handler('./result', worker_name='worker0'),
     record_shapes=True,
-    profile_memory=True,
+    profile_memory=True,  # This will take 1 to 2 minutes. Setting it to False could greatly speedup.
     with_stack=True
 ) as p:
     for step, data in enumerate(trainloader, 0):
@@ -49,6 +49,6 @@ with torch.profiler.profile(
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
-        if step + 1 >= 22:
+        if step + 1 >= 4:
             break
         p.step()


### PR DESCRIPTION
The original example takes about 6 minutes at the end of 6 active steps. And 12 minutes for the 12steps in total. This is too long for user to wait.
The cause is "profile_memory=True". In PyTorch code, this [line](https://github.com/pytorch/pytorch/blob/c19acf816f984124bb00fa7d32f4376d2d76c331/torch/autograd/profiler.py#L1136) and this [line](https://github.com/pytorch/pytorch/blob/c19acf816f984124bb00fa7d32f4376d2d76c331/torch/autograd/profiler.py#L1147) leads to O(M*N) time complexity, M is op events count and N is memory events count. We should optimize it.

Community user also complains this: https://github.com/pytorch/kineto/issues/308
We should fix it quickly.
Here I just add a comment and reduce to 2 active steps to reduce profiling time to 40s.

Before fix, overhead is about 360s * 2:
![image](https://user-images.githubusercontent.com/10429114/122664610-0c53f480-d1d5-11eb-93c4-f109e45d9c5f.png)
After fix, overhead is about 40s:
![image](https://user-images.githubusercontent.com/10429114/122664636-28f02c80-d1d5-11eb-8ee9-628e5ce10caf.png)

