### PR TITLE
Fix FBConfig clone bug

### DIFF
--- a/libkineto/src/AbstractConfig.h
+++ b/libkineto/src/AbstractConfig.h
@@ -28,7 +28,7 @@ class AbstractConfig {
   }
 
   // Return a copy of the full derived class
-  virtual AbstractConfig* cloneDerived() const = 0;
+  virtual AbstractConfig* cloneDerived(AbstractConfig& parent) const = 0;
 
   // Returns true if successfully parsed the config string
   bool parse(const std::string& conf);
@@ -98,7 +98,7 @@ class AbstractConfig {
 
   void cloneFeaturesInto(AbstractConfig& cfg) const {
     for (const auto& feature : featureConfigs_) {
-      cfg.featureConfigs_[feature.first] = feature.second->cloneDerived();
+      cfg.featureConfigs_[feature.first] = feature.second->cloneDerived(cfg);
     }
   }
 

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -34,7 +34,6 @@ ActivityProfilerController::ActivityProfilerController(
 }
 
 ActivityProfilerController::~ActivityProfilerController() {
-  LOG(INFO) << "ActivityProfilerController::~ActivityProfilerController()";
   configLoader_.removeHandler(
       ConfigLoader::ConfigKind::ActivityProfiler, this);
   if (profilerThread_) {

--- a/libkineto/src/Config.h
+++ b/libkineto/src/Config.h
@@ -289,7 +289,7 @@ class Config : public AbstractConfig {
  private:
   explicit Config(const Config& other) = default;
 
-  AbstractConfig* cloneDerived() const override {
+  AbstractConfig* cloneDerived(AbstractConfig& parent) const override {
     // Clone from AbstractConfig not supported
     assert(false);
     return nullptr;

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -174,35 +174,42 @@ void ConfigLoader::handleOnDemandSignal() {
   }
 }
 
-void ConfigLoader::initBaseConfig() {
+const char* ConfigLoader::configFileName() {
   if (!configFileName_) {
     configFileName_ = getenv(kConfigFileEnvVar.data());
     if (configFileName_ == nullptr) {
       configFileName_ = kConfigFile.data();
     }
-    updateBaseConfig();
   }
+  return configFileName_;
+}
+
+DaemonConfigLoader* ConfigLoader::daemonConfigLoader() {
+  if (!daemonConfigLoader_ && daemonConfigLoaderFactory()) {
+    daemonConfigLoader_ = daemonConfigLoaderFactory()();
+    daemonConfigLoader_->setCommunicationFabric(config_->ipcFabricEnabled());
+  }
+  return daemonConfigLoader_.get();
 }
 
 void ConfigLoader::updateBaseConfig() {
   // First try reading local config file
   // If that fails, read from daemon
   // TODO: Invert these once daemon path fully rolled out
-  std::string config_str = readConfigFromConfigFile(configFileName_);
-  if (config_str.empty() && daemonConfigLoader_) {
+  std::string config_str = readConfigFromConfigFile(configFileName());
+  if (config_str.empty() && daemonConfigLoader()) {
     // If local config file was not successfully loaded (e.g. not found)
     // then try the daemon
-    config_str = daemonConfigLoader_->readBaseConfig();
+    config_str = daemonConfigLoader()->readBaseConfig();
   }
-  if (config_str != config_.source()) {
+  if (config_str != config_->source()) {
     std::lock_guard<std::mutex> lock(configLock_);
-    config_.~Config();
-    new (&config_) Config();
-    config_.parse(config_str);
-    if (daemonConfigLoader_) {
-      daemonConfigLoader_->setCommunicationFabric(config_.ipcFabricEnabled());
+    config_ = std::make_unique<Config>();
+    config_->parse(config_str);
+    if (daemonConfigLoader()) {
+      daemonConfigLoader()->setCommunicationFabric(config_->ipcFabricEnabled());
     }
-    setupSignalHandler(config_.sigUsr2Enabled());
+    setupSignalHandler(config_->sigUsr2Enabled());
   }
 }
 
@@ -215,9 +222,6 @@ void ConfigLoader::configureFromSignal(
       readConfigFromConfigFile(kOnDemandConfigFile.data());
   config.parse(config_str);
   config.setSignalDefaults();
-  if (daemonConfigLoader_) {
-    daemonConfigLoader_->setCommunicationFabric(config_.ipcFabricEnabled());
-  }
   notifyHandlers(config);
 }
 
@@ -231,29 +235,20 @@ void ConfigLoader::configureFromDaemon(
 
   LOG(INFO) << "Received config from dyno:\n" << config_str;
   config.parse(config_str);
-  if (daemonConfigLoader_) {
-    daemonConfigLoader_->setCommunicationFabric(config_.ipcFabricEnabled());
-  }
   notifyHandlers(config);
 }
 
 void ConfigLoader::updateConfigThread() {
   auto now = system_clock::now();
-  auto next_config_load_time = now + configUpdateIntervalSecs_;
+  auto next_config_load_time = now;
   auto next_on_demand_load_time = now + onDemandConfigUpdateIntervalSecs_;
   auto next_log_level_reset_time = now;
   seconds interval = configUpdateIntervalSecs_;
   if (interval > onDemandConfigUpdateIntervalSecs_) {
     interval = onDemandConfigUpdateIntervalSecs_;
   }
+  config_ = std::make_unique<Config>();
   auto onDemandConfig = std::make_unique<Config>();
-
-  // Refresh config before starting loop
-  initBaseConfig();
-  if (daemonConfigLoaderFactory()) {
-    daemonConfigLoader_ = daemonConfigLoaderFactory()();
-    daemonConfigLoader_->setCommunicationFabric(config_.ipcFabricEnabled());
-  }
 
   // This can potentially sleep for long periods of time, so allow
   // the desctructor to wake it to avoid a 5-minute long destruct period.
@@ -271,7 +266,7 @@ void ConfigLoader::updateConfigThread() {
       next_config_load_time = now + configUpdateIntervalSecs_;
     }
     if (onDemandSignal_.exchange(false)) {
-      onDemandConfig = config_.clone();
+      onDemandConfig = config_->clone();
       configureFromSignal(now, *onDemandConfig);
     } else if (now > next_on_demand_load_time) {
       configureFromDaemon(now, *onDemandConfig);
@@ -289,14 +284,14 @@ void ConfigLoader::updateConfigThread() {
     if (now > next_log_level_reset_time) {
       VLOG(0) << "Resetting verbose level";
       SET_LOG_VERBOSITY_LEVEL(
-          config_.verboseLogLevel(), config_.verboseLogModules());
+          config_->verboseLogLevel(), config_->verboseLogModules());
     }
   }
 }
 
 bool ConfigLoader::hasNewConfig(const Config& oldConfig) {
   std::lock_guard<std::mutex> lock(configLock_);
-  return config_.timestamp() > oldConfig.timestamp();
+  return config_->timestamp() > oldConfig.timestamp();
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -79,7 +79,7 @@ class ConfigLoader {
 
   inline std::unique_ptr<Config> getConfigCopy() {
     std::lock_guard<std::mutex> lock(configLock_);
-    return config_.clone();
+    return config_->clone();
   }
 
   bool hasNewConfig(const Config& oldConfig);
@@ -94,7 +94,9 @@ class ConfigLoader {
   ConfigLoader();
   ~ConfigLoader();
 
-  void initBaseConfig();
+  const char* configFileName();
+  DaemonConfigLoader* daemonConfigLoader();
+
   void startThread();
   void updateConfigThread();
   void updateBaseConfig();
@@ -114,7 +116,7 @@ class ConfigLoader {
 
   std::mutex configLock_;
   std::atomic<const char*> configFileName_{nullptr};
-  Config config_;
+  std::unique_ptr<Config> config_;
   std::unique_ptr<DaemonConfigLoader> daemonConfigLoader_;
   std::map<ConfigKind, std::vector<ConfigHandler*>> handlers_;
 

--- a/libkineto/src/EventProfiler.cpp
+++ b/libkineto/src/EventProfiler.cpp
@@ -299,7 +299,7 @@ bool EventProfiler::initEventGroups() {
     eventGroupSets_ = nullptr;
   }
   if (events_.empty()) {
-    return false;
+    return true;
   }
 
   // Determine sets of groups to be collected
@@ -590,6 +590,7 @@ void EventProfiler::dispatchSamples(
 }
 
 void EventProfiler::configure(Config& config, Config* onDemandConfig) {
+  LOG(INFO) << "configure";
   if (!sets_.empty()) {
     sets_[curEnabledSet_].setEnabled(false);
     clearSamples();
@@ -619,7 +620,7 @@ void EventProfiler::configure(Config& config, Config* onDemandConfig) {
   if (!sets_.empty()) {
     sets_[0].setEnabled(true);
   } else {
-    LOG(WARNING) << "No counters profiled!";
+    VLOG(0) << "No counters profiled!";
   }
 
   baseSamples_ = 0;

--- a/libkineto/src/libkineto_api.cpp
+++ b/libkineto/src/libkineto_api.cpp
@@ -13,7 +13,6 @@
 namespace libkineto {
 
 LibkinetoApi& api() {
-  //static ConfigLoader config_loader;
   static LibkinetoApi instance(ConfigLoader::instance());
   return instance;
 }


### PR DESCRIPTION
Summary: Pass containing config object to cloneDerived() so that features can store a reference if they need to.

Reviewed By: briancoutinho

Differential Revision: D29348390

