### PR TITLE
tb_plugin: fix startup hang when no profile data

### DIFF
--- a/tb_plugin/test/test_plugin.py
+++ b/tb_plugin/test/test_plugin.py
@@ -1,0 +1,15 @@
+import unittest
+
+from tensorboard.plugins.base_plugin import TBContext
+
+from torch_tb_profiler.plugin import TorchProfilerPlugin
+
+
+class TestPlugin(unittest.TestCase):
+    def test_is_active_returns_false_when_no_data(self):
+        """Verifies that the plugin correctly reports is_active() == False when no data is available."""
+
+        context = TBContext(logdir="/tmp/nonexistent_logdir/")
+        plugin = TorchProfilerPlugin(context)
+
+        self.assertFalse(plugin.is_active())


### PR DESCRIPTION
When starting up tensorboard and the plugin in a directory where there
is no profile data, `TorchProfilerPlugin.is_active()` hangs forever. This
makes the tensorboard server hang, and client-side webpage remain blank.

This commit fixes the issue by ensuring that the thread monitoring the
run directories for data notifies the `_is_active_initialized_event`
flag not only when data is found, but also when the search is complete
and no data was found.

A simple unit test is added which validates the fix: without this
commit, the test hangs indefinitely.