### PR TITLE
Remove ConfigLoader destruction order assumption

### DIFF
--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -47,7 +47,7 @@ struct CpuTraceBuffer {
 class LibkinetoApi {
  public:
 
-  explicit LibkinetoApi(ConfigLoader& configLoader)
+  explicit LibkinetoApi(std::shared_ptr<ConfigLoader> configLoader)
       : configLoader_(configLoader) {
   }
 
@@ -99,7 +99,7 @@ class LibkinetoApi {
 
   // Provides access to profier configuration manaegement
   ConfigLoader& configLoader() {
-    return configLoader_;
+    return *configLoader_;
   }
 
  private:
@@ -107,7 +107,7 @@ class LibkinetoApi {
   // Client is initialized once both it and libkineto has registered
   void initClientIfRegistered();
 
-  ConfigLoader& configLoader_;
+  std::shared_ptr<ConfigLoader> configLoader_;
   std::unique_ptr<ActivityProfilerInterface> activityProfiler_{};
   ClientInterface* client_{};
   int32_t clientRegisterThread_{0};

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -59,7 +59,7 @@ static bool hasOriginalSignalHandler() {
 static void handle_signal(int signal) {
 #ifdef __linux__
   if (signal == SIGUSR2) {
-    ConfigLoader::instance().handleOnDemandSignal();
+    ConfigLoader::instance()->handleOnDemandSignal();
     if (hasOriginalSignalHandler()) {
       // Invoke original handler and reinstate ours
       struct sigaction act;
@@ -117,8 +117,8 @@ void ConfigLoader::setDaemonConfigLoaderFactory(
   daemonConfigLoaderFactory() = factory;
 }
 
-ConfigLoader& ConfigLoader::instance() {
-  static ConfigLoader config_loader;
+std::shared_ptr<ConfigLoader> ConfigLoader::instance() {
+  static std::shared_ptr<ConfigLoader> config_loader(new ConfigLoader());
   return config_loader;
 }
 

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -29,7 +29,7 @@ class DaemonConfigLoader;
 class ConfigLoader {
  public:
 
-  static ConfigLoader& instance();
+  static std::shared_ptr<ConfigLoader> instance();
 
   enum ConfigKind {
     ActivityProfiler = 0,
@@ -42,6 +42,8 @@ class ConfigLoader {
     virtual bool canAcceptConfig() = 0;
     virtual void acceptConfig(const Config& cfg) = 0;
   };
+
+  ~ConfigLoader();
 
   void addHandler(ConfigKind kind, ConfigHandler* handler) {
     std::lock_guard<std::mutex> lock(updateThreadMutex_);
@@ -92,7 +94,6 @@ class ConfigLoader {
 
  private:
   ConfigLoader();
-  ~ConfigLoader();
 
   const char* configFileName();
   DaemonConfigLoader* daemonConfigLoader();


### PR DESCRIPTION
Summary: Keep ConfigLoader in a shared pointer such that lifetime does not depend on init & destruction order.

Reviewed By: leitian

Differential Revision: D29387204

