### PR TITLE
plugin: Fix hanging loading when no file exists

### DIFF
--- a/tb_plugin/torch_tb_profiler/plugin.py
+++ b/tb_plugin/torch_tb_profiler/plugin.py
@@ -290,7 +290,6 @@ class TorchProfilerPlugin(base_plugin.TBPlugin):
 
     def _monitor_runs(self):
         logger.info("Monitor runs begin")
-
         try:
             touched = set()
             while True:
@@ -311,6 +310,10 @@ class TorchProfilerPlugin(base_plugin.TBPlugin):
                             # Use threading to avoid UI stall and reduce data parsing time
                             t = threading.Thread(target=self._load_run, args=(run_dir,))
                             t.start()
+                    # Do not forget to set _is_active if no file exists
+                    if len(touched) == 0 and not self._is_active:
+                        self._is_active = False
+                        self._is_active_initialized_event.set()
                 except Exception as ex:
                     logger.warning("Failed to scan runs. Exception=%s", ex, exc_info=True)
 
@@ -333,6 +336,7 @@ class TorchProfilerPlugin(base_plugin.TBPlugin):
 
                 # Update is_active
                 if not self._is_active:
+                    logger.info("set true receive")
                     self._is_active = True
                     self._is_active_initialized_event.set()
 


### PR DESCRIPTION
Previous code was locking the requests from tb's `is_active` method until `_is_active` is set.
However, it was also missing setting it to false when there is no related trace files.

This fix basically sets the value to false if generator returns empty list, which will unlock tb request and return false.

Fixes #334, tensorflow/tensorboard#5076, tensorflow/tensorboard#5111.