### PR TITLE
Move concurrency into contexts

### DIFF
--- a/tb_plugin/torch_tb_profiler/io/cache.py
+++ b/tb_plugin/torch_tb_profiler/io/cache.py
@@ -1,22 +1,23 @@
 # -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # -------------------------------------------------------------------------
-import multiprocessing as mp
 import os
 
 from .. import utils
 from .file import download_file, read
+from ..profiler.multiprocessing import KinetoContext
 
 logger = utils.get_logger()
 
 class Cache:
     def __init__(self):
-        self._lock = mp.Lock()
-        self._manager = mp.Manager()
+        ctx = KinetoContext()
+        self._lock = ctx.Lock()
+        self._manager = ctx.Manager()
         self._cache_dict = self._manager.dict()
 
     def __getstate__(self):
-        '''The multiprocessing module can start one of three ways: spawn, fork, or forkserver. 
+        '''The multiprocessing module can start one of three ways: spawn, fork, or forkserver.
         The default mode is fork in Unix and spawn on Windows and macOS.
         Therefore, the __getstate__ and __setstate__ are used to pickle/unpickle the state in spawn mode.
         '''
@@ -29,8 +30,8 @@ class Cache:
         return data
 
     def __setstate__(self, state):
-        '''The default logging level in new process is warning. Only warning and error log can be written to 
-        streams. 
+        '''The default logging level in new process is warning. Only warning and error log can be written to
+        streams.
         So, we need call use_absl_handler in the new process.
         '''
         from absl import logging
@@ -73,4 +74,3 @@ class Cache:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
         self._manager.__exit__(exc_type, exc_value, traceback)
-

--- a/tb_plugin/torch_tb_profiler/io/file.py
+++ b/tb_plugin/torch_tb_profiler/io/file.py
@@ -80,6 +80,16 @@ def get_filesystem(filename):
         raise ValueError("No recognized filesystem for prefix %s" % prefix)
     return fs
 
+# When subprocesses are started without state, they won't retain
+# the filesystem dictionary from the main process. Therefore,
+# we define these helpers functions to restore the mapping.
+def get_all_filesystems():
+    return _REGISTERED_FILESYSTEMS
+
+def restore_filesystems(fs_dictionary):
+    global _REGISTERED_FILESYSTEMS
+    _REGISTERED_FILESYSTEMS = fs_dictionary
+
 
 class LocalFileSystem(LocalPath, BaseFileSystem):
     def __init__(self):

--- a/tb_plugin/torch_tb_profiler/plugin.py
+++ b/tb_plugin/torch_tb_profiler/plugin.py
@@ -4,7 +4,6 @@
 import atexit
 import gzip
 import json
-import multiprocessing as mp
 import os
 import sys
 import tempfile
@@ -44,9 +43,7 @@ class TorchProfilerPlugin(base_plugin.TBPlugin):
           context: A base_plugin.TBContext instance.
         """
         super(TorchProfilerPlugin, self).__init__(context)
-        start_method = os.getenv('TORCH_PROFILER_START_METHOD')
-        if start_method:
-            mp.set_start_method(start_method, force=True)
+
         self.logdir = io.abspath(context.logdir.rstrip('/'))
 
         self._load_lock = threading.Lock()

--- a/tb_plugin/torch_tb_profiler/profiler/multiprocessing.py
+++ b/tb_plugin/torch_tb_profiler/profiler/multiprocessing.py
@@ -1,0 +1,16 @@
+# When some filesystems launch, they need to be in a process
+# launched by a certain start method. Here, we provide utility
+# functions to set a start method for only this plugin's
+# subprocesses, without disrupting the start method used in
+# other plugins.
+
+import os
+import multiprocessing as mp
+
+def KinetoContext():
+    # Default to the operating system's start method,
+    # and keep the method as a static attribute
+    method = mp.get_start_method(False)
+    if os.getenv('TORCH_PROFILER_START_METHOD'):
+        method = os.getenv('TORCH_PROFILER_START_METHOD')
+    return mp.get_context(method)


### PR DESCRIPTION
Differential Revision: D29458946

Currently, the TB Plugin runs several operations using the Python multiprocessing module. When that module starts new processes, it uses the `TORCH_PROFILER_START_METHOD` flag to see which method it should use. However, it uses that flag to **globally** set the start method, which messes up other plugins who rely on using the OS default. 

This commit fixes this, by running concurrent operations inside of contexts. This way, the start method for profiler operations can be set *without affecting other plugins*.