### PR TITLE
Add more starting buffer for default timestamp

### DIFF
--- a/libkineto/src/ActivityProfiler.cpp
+++ b/libkineto/src/ActivityProfiler.cpp
@@ -522,12 +522,11 @@ void ActivityProfiler::configure(
 #endif // HAS_CUPTI
 
   profileStartTime_ = config_->requestTimestamp();
-  if ((profileStartTime_ - now) < config_->activitiesWarmupDuration()) {
-    if (profileStartTime_ < now) {
-      LOG(ERROR) << "Not starting tracing - start timestamp is in the past. Time difference (ms): " << duration_cast<milliseconds>(now - profileStartTime_).count();
-    } else {
-      LOG(ERROR) << "Not starting tracing - insufficient time for warmup. Time to warmup (ms): " << duration_cast<milliseconds>(profileStartTime_ - now).count() ;
-    }
+
+  if (profileStartTime_ < now) {
+    LOG(ERROR) << "Not starting tracing - start timestamp is in the past. Time difference (ms): " << duration_cast<milliseconds>(now - profileStartTime_).count();
+  } else if ((profileStartTime_ - now) < config_->activitiesWarmupDuration()) {
+    LOG(ERROR) << "Not starting tracing - insufficient time for warmup. Time to warmup (ms): " << duration_cast<milliseconds>(profileStartTime_ - now).count() ;
   } else {
     if (profilers_.size() > 0) {
       configureChildProfilers();

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -101,7 +101,7 @@ void ActivityProfilerController::profilerLoop() {
       std::lock_guard<std::mutex> lock(asyncConfigLock_);
       if (asyncRequestConfig_) {
         // Note on now + kProfilerIntervalMsecs
-        // Profiler interval does not align perfectly upto starTime - warmup. Waiting until next the next tick
+        // Profiler interval does not align perfectly upto startTime - warmup. Waiting until the next tick
         // won't allow sufficient time for the profiler to warm up. So check if we are very close to the warmup time and trigger warmup
         if (now + kProfilerIntervalMsecs 
             >= (asyncRequestConfig_->requestTimestamp() - asyncRequestConfig_->activitiesWarmupDuration())) {

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -38,7 +38,7 @@ constexpr int kDefaultActivitiesExternalAPINetSizeThreshold(0);
 constexpr int kDefaultActivitiesExternalAPIGpuOpCountThreshold(0);
 constexpr int kDefaultActivitiesMaxGpuBufferSize(128 * 1024 * 1024);
 constexpr seconds kDefaultActivitiesWarmupDurationSecs(5);
-constexpr seconds kDefaultBufferUntilWarmup(1);
+constexpr seconds kDefaultBufferUntilWarmup(10);
 constexpr seconds kDefaultReportPeriodSecs(1);
 constexpr int kDefaultSamplesPerReport(1);
 constexpr int kDefaultMaxEventProfilersPerGpu(1);


### PR DESCRIPTION
Summary: `kDefaultBufferUntilWarmup` clearly was not enough where the overhead of handling dyno's thrift request would often go slightly over 1 second about half of the time. Without extra buffer to account for this "pre-warmup" phase, the default timestamp is set couple seconds into the actual warm up phase i.e. 1-2 seconds in, causing ActivityProfiler to reject the profiling.

Reviewed By: leitian

Differential Revision: D30007594

