### PR TITLE
refactor loader&data to make sure the cache only used in loader

### DIFF
--- a/tb_plugin/test/test_profiler.py
+++ b/tb_plugin/test/test_profiler.py
@@ -1,8 +1,7 @@
-import json
 import gzip
+import json
 import unittest
 
-import torch_tb_profiler.profiler.trace as trace
 from torch_tb_profiler.profiler.data import RunProfileData
 from torch_tb_profiler.profiler.overall_parser import ProfileRole
 from torch_tb_profiler.run import RunProfile
@@ -14,14 +13,7 @@ WORKER_NAME = "worker0"
 def parse_json_trace(json_content):
     trace_json = json.loads(json_content)
     trace_json = {"schemaVersion": 1, "traceEvents": trace_json}
-    profile = RunProfileData(WORKER_NAME)
-    profile.trace_json = trace_json
-    profile.events = []
-    for data in trace_json["traceEvents"]:
-        event = trace.create_event(data)
-        if event is not None:
-            profile.events.append(event)
-    return profile
+    return RunProfileData.from_json(WORKER_NAME, 0, trace_json)
 
 
 '''
@@ -1593,6 +1585,7 @@ class TestProfiler(unittest.TestCase):
         ]
         """
         import logging
+
         from torch_tb_profiler.utils import get_logger
         logger = get_logger()
         logger.addHandler(logging.StreamHandler())

--- a/tb_plugin/torch_tb_profiler/profiler/loader.py
+++ b/tb_plugin/torch_tb_profiler/profiler/loader.py
@@ -88,10 +88,11 @@ class RunLoader(object):
         absl.logging.use_absl_handler()
 
         try:
-            logger.debug("starting process_data")
-            data = RunProfileData.parse(self.run_dir, worker, span, path, self.caches)
-            data.process()
-            data.analyze()
+            logger.debug("Parse trace, run_dir=%s, worker=%s", self.run_dir, path)
+            local_file = self.caches.get_remote_cache(io.join(self.run_dir, path))
+            data, trace_path = RunProfileData.parse(worker, span, local_file)
+            if trace_path != local_file:
+                self.caches.add_file(local_file, trace_path)
 
             generator = RunGenerator(worker, span, data)
             profile = generator.generate_run_profile()


### PR DESCRIPTION
Make sure the cache instance only used in loader instead of in both loader and data. In this way, the caches operation only happens in loader including looking up and update.