### PR TITLE
Ensure GPU timelines appear after CPU timelines

### DIFF
--- a/libkineto/src/ActivityProfiler.cpp
+++ b/libkineto/src/ActivityProfiler.cpp
@@ -700,13 +700,14 @@ void ActivityProfiler::finalizeTrace(const Config& config, ActivityLogger& logge
   if (!process_name.empty()) {
     int32_t pid = processId();
     logger.handleProcessInfo(
-        {pid, process_name, "CPU"}, captureWindowStartTime_);
+        {pid, process_name, "CPU"}, pid, captureWindowStartTime_);
     if (!cpuOnly_) {
       // GPU events use device id as pid (0-7).
       constexpr int kMaxGpuCount = 8;
       for (int gpu = 0; gpu < kMaxGpuCount; gpu++) {
         logger.handleProcessInfo(
             {gpu, process_name, fmt::format("GPU {}", gpu)},
+            0x40000000 + gpu, // appear after CPU processes
             captureWindowStartTime_);
       }
     }

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -38,6 +38,7 @@ class ActivityLogger {
 
   virtual void handleProcessInfo(
       const ProcessInfo& processInfo,
+      int32_t sort_index,
       uint64_t time) = 0;
 
   virtual void handleThreadInfo(const ThreadInfo& threadInfo, int64_t time) = 0;

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -85,6 +85,7 @@ static int64_t us(int64_t timestamp) {
 
 void ChromeTraceLogger::handleProcessInfo(
     const ProcessInfo& processInfo,
+    int32_t sort_index,
     uint64_t time) {
   if (!traceOf_) {
     return;
@@ -105,11 +106,19 @@ void ChromeTraceLogger::handleProcessInfo(
     "args": {{
       "labels": "{}"
     }}
+  }},
+  {{
+    "name": "process_sort_index", "ph": "M", "ts": {}, "pid": {}, "tid": 0,
+    "args": {{
+      "sort_index": {}
+    }}
   }},)JSON",
       time, processInfo.pid,
       processInfo.name,
       time, processInfo.pid,
-      processInfo.label);
+      processInfo.label,
+      time, processInfo.pid,
+      sort_index);
   // clang-format on
 }
 
@@ -129,9 +138,17 @@ void ChromeTraceLogger::handleThreadInfo(
     "args": {{
       "name": "thread {} ({})"
     }}
+  }},
+  {{
+    "name": "thread_sort_index", "ph": "M", "ts": {}, "pid": {}, "tid": "{}",
+    "args": {{
+      "sort_index": {}
+    }}
   }},)JSON",
       time, processId(), threadInfo.tid,
-      threadInfo.tid, threadInfo.name);
+      threadInfo.tid, threadInfo.name,
+      time, processId(), threadInfo.tid,
+      threadInfo.tid);
   // clang-format on
 }
 

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -36,6 +36,7 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   // i.e., we these functions are not thread-safe
   void handleProcessInfo(
       const ProcessInfo& processInfo,
+      int32_t sort_index,
       uint64_t time) override;
 
   void handleThreadInfo(const ThreadInfo& threadInfo, int64_t time) override;


### PR DESCRIPTION
Summary:
Allow better control of timeline sort order by taking a sort_order arg to handleProcessInfo.
This way we can ensure GPU timelines appear after CPU timelines by specifying very high indices.

Differential Revision: D30236066

