### PR TITLE
Fix cupti timestamp issue on windows

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -20,6 +20,7 @@ def get_libkineto_srcs(with_api = True):
         "src/ConfigLoader.cpp",
         "src/CudaDeviceProperties.cpp",
         "src/CuptiActivityInterface.cpp",
+        "src/CuptiActivityPlatform.cpp",
         "src/CuptiEventInterface.cpp",
         "src/CuptiMetricInterface.cpp",
         "src/Demangle.cpp",

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -33,7 +33,7 @@ struct CuptiActivity : public TraceActivity {
   explicit CuptiActivity(const T* activity, const TraceActivity& linked)
       : activity_(*activity), linked_(linked) {}
   int64_t timestamp() const override {
-    return nsToUs(cuptiPlatformAgnosticTs(activity_.start));
+    return nsToUs(unixEpochTimestamp(activity_.start));
   }
   int64_t duration() const override {
     return nsToUs(activity_.end - activity_.start);

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -10,6 +10,7 @@
 #include <cupti.h>
 
 #include "TraceActivity.h"
+#include "CuptiActivityPlatform.h"
 #include "ThreadUtil.h"
 #include "cupti_strings.h"
 
@@ -32,7 +33,7 @@ struct CuptiActivity : public TraceActivity {
   explicit CuptiActivity(const T* activity, const TraceActivity& linked)
       : activity_(*activity), linked_(linked) {}
   int64_t timestamp() const override {
-    return nsToUs(activity_.start);
+    return nsToUs(cuptiPlatformAgnosticTs(activity_.start));
   }
   int64_t duration() const override {
     return nsToUs(activity_.end - activity_.start);

--- a/libkineto/src/CuptiActivityPlatform.cpp
+++ b/libkineto/src/CuptiActivityPlatform.cpp
@@ -1,0 +1,31 @@
+#include <chrono>
+
+namespace chrono = std::chrono;
+
+namespace KINETO_NAMESPACE {
+
+#ifdef _WIN32
+uint64_t epochs_diff() {
+  // On Windows, steady_clock wraps the QueryPerformanceCounter function.
+  // https://docs.microsoft.com/en-us/cpp/standard-library/steady-clock-struct?view=msvc-160
+  auto steady =
+      chrono::time_point_cast<chrono::nanoseconds>(chrono::steady_clock::now());
+  auto system =
+      chrono::time_point_cast<chrono::nanoseconds>(chrono::system_clock::now());
+
+  auto time_since_unix = system.time_since_epoch().count();
+  auto time_since_boot = steady.time_since_epoch().count();
+  return time_since_unix - time_since_boot;
+}
+
+uint64_t cuptiPlatformAgnosticTs(uint64_t ts) {
+  static uint64_t diff = epochs_diff();
+  return ts + diff;
+}
+#else
+uint64_t cuptiPlatformAgnosticTs(uint64_t ts) {
+  return ts;
+}
+#endif // _WIN32
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiActivityPlatform.cpp
+++ b/libkineto/src/CuptiActivityPlatform.cpp
@@ -18,12 +18,12 @@ uint64_t epochs_diff() {
   return time_since_unix - time_since_boot;
 }
 
-uint64_t cuptiPlatformAgnosticTs(uint64_t ts) {
+uint64_t unixEpochTimestamp(uint64_t ts) {
   static uint64_t diff = epochs_diff();
   return ts + diff;
 }
 #else
-uint64_t cuptiPlatformAgnosticTs(uint64_t ts) {
+uint64_t unixEpochTimestamp(uint64_t ts) {
   return ts;
 }
 #endif // _WIN32

--- a/libkineto/src/CuptiActivityPlatform.h
+++ b/libkineto/src/CuptiActivityPlatform.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+namespace KINETO_NAMESPACE {
+
+// cupti's timestamps are platform specific. This function convert the raw
+// cupti timestamp to time since unix epoch. So that on different platform,
+// correction can work correctly.
+uint64_t cuptiPlatformAgnosticTs(uint64_t ts);
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiActivityPlatform.h
+++ b/libkineto/src/CuptiActivityPlatform.h
@@ -7,6 +7,6 @@ namespace KINETO_NAMESPACE {
 // cupti's timestamps are platform specific. This function convert the raw
 // cupti timestamp to time since unix epoch. So that on different platform,
 // correction can work correctly.
-uint64_t cuptiPlatformAgnosticTs(uint64_t ts);
+uint64_t unixEpochTimestamp(uint64_t ts);
 
 } // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Fixes #384 

On windows, cupti's timestamps are time since boot causing it return.
Results in kernel activity being filtered out and correction issue.