### PR TITLE
Add env var for disabling event profiler

### DIFF
--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -51,9 +51,13 @@ static void initProfilers(CUcontext ctx) {
     initialized = true;
     VLOG(0) << "libkineto profilers activated";
   }
-  ConfigLoader& config_loader = libkineto::api().configLoader();
-  config_loader.initBaseConfig();
-  EventProfilerController::start(ctx, config_loader);
+  if (getenv("KINETO_DISABLE_EVENT_PROFILER") != nullptr) {
+    VLOG(0) << "Event profiler disabled via env var";
+  } else {
+    ConfigLoader& config_loader = libkineto::api().configLoader();
+    config_loader.initBaseConfig();
+    EventProfilerController::start(ctx, config_loader);
+  }
 }
 
 static void stopProfiler(CUcontext ctx) {


### PR DESCRIPTION
Summary: Allow explicitly disabling event profiler via an environment variable.

Differential Revision: D30818225

