### PR TITLE
Fix profiling via sigusr2

### DIFF
--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -176,6 +176,7 @@ Config::Config()
       multiplexPeriod_(kDefaultMultiplexPeriodMsecs),
       activityProfilerEnabled_(true),
       activitiesLogFile_(defaultTraceFileName()),
+      activitiesLogUrl_(fmt::format("file://{}", activitiesLogFile_)),
       activitiesMaxGpuBufferSize_(kDefaultActivitiesMaxGpuBufferSize),
       activitiesWarmupDuration_(kDefaultActivitiesWarmupDurationSecs),
       activitiesOnDemandDuration_(kDefaultActivitiesProfileDurationMSecs),
@@ -187,7 +188,7 @@ Config::Config()
       activitiesOnDemandTimestamp_(milliseconds(0)),
       profileStartTime_(milliseconds(0)),
       requestTimestamp_(milliseconds(0)),
-      enableSigUsr2_(true),
+      enableSigUsr2_(false),
       enableIpcFabric_(false) {
   auto factories = configFactories();
   if (factories) {
@@ -342,7 +343,8 @@ void Config::setClientDefaults() {
   activitiesLogToMemory_ = true;
 }
 
-void Config::validate(const std::chrono::time_point<std::chrono::system_clock>& fallbackProfileStartTime) {
+void Config::validate(
+    const time_point<system_clock>& fallbackProfileStartTime) {
   if (samplePeriod_.count() == 0) {
     LOG(WARNING) << "Sample period must be greater than 0, setting to 1ms";
     samplePeriod_ = milliseconds(1);

--- a/libkineto/src/Config.h
+++ b/libkineto/src/Config.h
@@ -284,7 +284,8 @@ class Config : public AbstractConfig {
 
   void printActivityProfilerConfig(std::ostream& s) const override;
 
-  void validate(const std::chrono::time_point<std::chrono::system_clock>& fallbackProfileStartTime) override;
+  void validate(
+      const std::chrono::time_point<std::chrono::system_clock>& fallbackProfileStartTime) override;
 
   static void addConfigFactory(
       std::string name,

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -13,6 +13,7 @@
 
 #include <stdlib.h>
 #include <chrono>
+#include <fmt/format.h>
 #include <fstream>
 
 #include "DaemonConfigLoader.h"
@@ -224,8 +225,9 @@ void ConfigLoader::configureFromSignal(
     Config& config) {
   LOG(INFO) << "Received on-demand profiling signal, "
             << "reading config from " << kOnDemandConfigFile;
-  const std::string config_str =
-      readConfigFromConfigFile(kOnDemandConfigFile);
+  // Reset start time to 0 in order to compute new default start time
+  const std::string config_str = "PROFILE_START_TIME=0\n"
+      + readConfigFromConfigFile(kOnDemandConfigFile);
   config.parse(config_str);
   config.setSignalDefaults();
   notifyHandlers(config);


### PR DESCRIPTION
Summary:
Triggering profiling via sigusr2 caused a couple of configuration errors.
Also disable sigusr2 setup by default.

Reviewed By: lw

Differential Revision: D30574351

