### PR TITLE
Refactor for extensibility 1/n: Rename ActivityProfiler

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -12,7 +12,7 @@ def get_libkineto_api_srcs():
 def get_libkineto_srcs(with_api = True):
     return [
         "src/AbstractConfig.cpp",
-        "src/ActivityProfiler.cpp",
+        "src/CuptiActivityProfiler.cpp",
         "src/ActivityProfilerController.cpp",
         "src/ActivityProfilerProxy.cpp",
         "src/ActivityType.cpp",
@@ -38,7 +38,7 @@ def get_libkineto_srcs(with_api = True):
 def get_libkineto_cpu_only_srcs(with_api = True):
     return [
         "src/AbstractConfig.cpp",
-        "src/ActivityProfiler.cpp",
+        "src/CuptiActivityProfiler.cpp",
         "src/ActivityProfilerController.cpp",
         "src/ActivityProfilerProxy.cpp",
         "src/ActivityType.cpp",

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -28,7 +28,7 @@ constexpr milliseconds kProfilerIntervalMsecs(1000);
 ActivityProfilerController::ActivityProfilerController(
     ConfigLoader& configLoader, bool cpuOnly)
     : configLoader_(configLoader) {
-  profiler_ = std::make_unique<ActivityProfiler>(
+  profiler_ = std::make_unique<CuptiActivityProfiler>(
       CuptiActivityInterface::singleton(), cpuOnly);
   configLoader_.addHandler(ConfigLoader::ConfigKind::ActivityProfiler, this);
 }

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -13,7 +13,7 @@
 #include <thread>
 
 #include "ActivityLoggerFactory.h"
-#include "ActivityProfiler.h"
+#include "CuptiActivityProfiler.h"
 #include "ActivityProfilerInterface.h"
 #include "ActivityTraceInterface.h"
 #include "ConfigLoader.h"
@@ -78,7 +78,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
 
   std::unique_ptr<Config> asyncRequestConfig_;
   std::mutex asyncConfigLock_;
-  std::unique_ptr<ActivityProfiler> profiler_;
+  std::unique_ptr<CuptiActivityProfiler> profiler_;
   std::unique_ptr<ActivityLogger> logger_;
   std::thread* profilerThread_{nullptr};
   std::atomic_bool stopRunloop_{false};

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -33,11 +33,11 @@ namespace KINETO_NAMESPACE {
 class Config;
 class CuptiActivityInterface;
 
-class ActivityProfiler {
+class CuptiActivityProfiler {
  public:
-  ActivityProfiler(CuptiActivityInterface& cupti, bool cpuOnly);
-  ActivityProfiler(const ActivityProfiler&) = delete;
-  ActivityProfiler& operator=(const ActivityProfiler&) = delete;
+  CuptiActivityProfiler(CuptiActivityInterface& cupti, bool cpuOnly);
+  CuptiActivityProfiler(const CuptiActivityProfiler&) = delete;
+  CuptiActivityProfiler& operator=(const CuptiActivityProfiler&) = delete;
 
   bool isActive() const {
     return currentRunloopState_ != RunloopState::WaitForRequest;

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -19,7 +19,7 @@
 #endif
 
 #include "include/libkineto.h"
-#include "src/ActivityProfiler.h"
+#include "src/CuptiActivityProfiler.h"
 #include "src/ActivityTrace.h"
 #include "src/Config.h"
 #include "src/CuptiActivityInterface.h"
@@ -163,10 +163,10 @@ class MockCuptiActivities : public CuptiActivityInterface {
 
 
 // Common setup / teardown and helper functions
-class ActivityProfilerTest : public ::testing::Test {
+class CuptiActivityProfilerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    profiler_ = std::make_unique<ActivityProfiler>(
+    profiler_ = std::make_unique<CuptiActivityProfiler>(
         cuptiActivities_, /*cpu only*/ false);
     cfg_ = std::make_unique<Config>();
     cfg_->validate(std::chrono::system_clock::now());
@@ -177,18 +177,18 @@ class ActivityProfilerTest : public ::testing::Test {
 
   std::unique_ptr<Config> cfg_;
   MockCuptiActivities cuptiActivities_;
-  std::unique_ptr<ActivityProfiler> profiler_;
+  std::unique_ptr<CuptiActivityProfiler> profiler_;
   ActivityLoggerFactory loggerFactory;
 };
 
 
-TEST(ActivityProfiler, AsyncTrace) {
+TEST(CuptiActivityProfiler, AsyncTrace) {
   std::vector<std::string> log_modules(
-      {"ActivityProfiler.cpp", "output_json.cpp"});
+      {"CuptiActivityProfiler.cpp", "output_json.cpp"});
   SET_LOG_VERBOSITY_LEVEL(1, log_modules);
 
   MockCuptiActivities activities;
-  ActivityProfiler profiler(activities, /*cpu only*/ true);
+  CuptiActivityProfiler profiler(activities, /*cpu only*/ true);
 
   char filename[] = "/tmp/libkineto_testXXXXXX.json";
   mkstemps(filename, 5);
@@ -259,17 +259,17 @@ TEST(ActivityProfiler, AsyncTrace) {
 }
 
 
-TEST_F(ActivityProfilerTest, SyncTrace) {
+TEST_F(CuptiActivityProfilerTest, SyncTrace) {
   using ::testing::Return;
   using ::testing::ByMove;
 
   // Verbose logging is useful for debugging
   std::vector<std::string> log_modules(
-      {"ActivityProfiler.cpp"});
+      {"CuptiActivityProfiler.cpp"});
   SET_LOG_VERBOSITY_LEVEL(2, log_modules);
 
   // Start and stop profiling
-  ActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
   int64_t start_time_us = 100;
   int64_t duration_us = 300;
   auto start_time = time_point<system_clock>(microseconds(start_time_us));
@@ -348,14 +348,14 @@ TEST_F(ActivityProfilerTest, SyncTrace) {
 #endif
 }
 
-TEST_F(ActivityProfilerTest, CorrelatedTimestampTest) {
+TEST_F(CuptiActivityProfilerTest, CorrelatedTimestampTest) {
   // Verbose logging is useful for debugging
   std::vector<std::string> log_modules(
-      {"ActivityProfiler.cpp"});
+      {"CuptiActivityProfiler.cpp"});
   SET_LOG_VERBOSITY_LEVEL(2, log_modules);
 
   // Start and stop profiling
-  ActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
   int64_t start_time_us = 100;
   int64_t duration_us = 300;
   auto start_time = time_point<system_clock>(microseconds(start_time_us));
@@ -396,13 +396,13 @@ TEST_F(ActivityProfilerTest, CorrelatedTimestampTest) {
   EXPECT_EQ(counts["launchKernel"], 1);
 }
 
-TEST_F(ActivityProfilerTest, SubActivityProfilers) {
+TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
   using ::testing::Return;
   using ::testing::ByMove;
 
   // Verbose logging is useful for debugging
   std::vector<std::string> log_modules(
-      {"ActivityProfiler.cpp"});
+      {"CuptiActivityProfiler.cpp"});
   SET_LOG_VERBOSITY_LEVEL(2, log_modules);
 
   // Setup example events to test
@@ -429,7 +429,7 @@ TEST_F(ActivityProfilerTest, SubActivityProfilers) {
     std::make_unique<MockActivityProfiler>(test_activities);
 
   MockCuptiActivities activities;
-  ActivityProfiler profiler(activities, /*cpu only*/ true);
+  CuptiActivityProfiler profiler(activities, /*cpu only*/ true);
   profiler.addChildActivityProfiler(
       std::move(mock_activity_profiler));
 
@@ -469,8 +469,8 @@ TEST_F(ActivityProfilerTest, SubActivityProfilers) {
   EXPECT_GT(buf.st_size, 100);
 }
 
-TEST_F(ActivityProfilerTest, BufferSizeLimitTestWarmup) {
-  ActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+TEST_F(CuptiActivityProfilerTest, BufferSizeLimitTestWarmup) {
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
 
   auto now = system_clock::now();
   auto startTime = now + seconds(10);


### PR DESCRIPTION
Summary:
This is the first step towards refactoring for extensibility across 1) More device types and 2) More types of profilers.

The patch simply renames ActivityProfiler* to CuptiActivityProfiler*, as the current ActivityProfiler is specific to Cupti.

Differential Revision: D31234167

