### PR TITLE
Add CUPTI Range Profiler Interface

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -17,6 +17,7 @@ def get_libkineto_cupti_srcs(with_api = True):
         "src/CuptiCallbackApi.cpp",
         "src/CuptiEventApi.cpp",
         "src/CuptiMetricApi.cpp",
+        "src/CuptiRangeProfilerApi.cpp",
         "src/Demangle.cpp",
         "src/EventProfiler.cpp",
         "src/EventProfilerController.cpp",

--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -14,6 +14,7 @@ def get_libkineto_cupti_srcs(with_api = True):
         "src/CudaDeviceProperties.cpp",
         "src/CuptiActivityApi.cpp",
         "src/CuptiActivityPlatform.cpp",
+        "src/CuptiCallbackApi.cpp",
         "src/CuptiEventApi.cpp",
         "src/CuptiMetricApi.cpp",
         "src/Demangle.cpp",

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -217,7 +217,9 @@ void CuptiActivityApi::clearActivities() {
   }
   // Can't hold mutex_ during this call, since bufferCompleted
   // will be called by libcupti and mutex_ is acquired there.
+#ifdef HAS_CUPTI
   CUPTI_CALL(cuptiActivityFlushAll(0));
+#endif
   // FIXME: We might want to make sure we reuse
   // the same memory during warmup and tracing.
   // Also, try to use the amount of memory required

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CuptiCallbackApi.h"
+
+#include <assert.h>
+#include <chrono>
+#include <algorithm>
+#include <mutex>
+#include <shared_mutex>
+
+#include "cupti_call.h"
+#include "Logger.h"
+
+
+namespace KINETO_NAMESPACE {
+
+// limit on number of handles per callback type
+constexpr size_t MAX_CB_FNS_PER_CB = 8;
+
+// Reader Writer lock types
+using ReaderWriterLock = std::shared_mutex;
+using ReaderLockGuard = std::shared_lock<ReaderWriterLock>;
+using WriteLockGuard = std::unique_lock<ReaderWriterLock>;
+
+static ReaderWriterLock callbackLock_;
+
+/* Callback Table :
+ *  Overall goal of the design is to optimize the lookup of function
+ *  pointers. The table is structured at two levels and the leaf
+ *  elements in the table are std::list to enable fast access/inserts/deletes
+ *
+ *   <callback domain0> |
+ *                     -> cb id 0 -> std::list of callbacks
+ *                     ...
+ *                     -> cb id n -> std::list of callbacks
+ *   <callback domain1> |
+ *                    ...
+ *  CallbackTable is the finaly table type above
+ *  See type declrartions in header file.
+ */
+
+
+/* callback_switchboard : is the global callback handler we register
+ *  with CUPTI. The goal is to make it as efficient as possible
+ *  to re-direct to the registered callback(s).
+ *
+ *  Few things to care about :
+ *   a) use if/then switches rather than map/hash structures
+ *   b) avoid dynamic memory allocations
+ *   c) be aware of locking overheads
+ */
+#ifdef HAS_CUPTI
+static void CUPTIAPI callback_switchboard(
+#else
+static void callback_switchboard(
+#endif
+   void* /* unused */,
+   CUpti_CallbackDomain domain,
+   CUpti_CallbackId cbid,
+   const CUpti_CallbackData* cbInfo) {
+
+  // below statement is likey going to call a mutex
+  // on the singleton access
+  CuptiCallbackApi::singleton().__callback_switchboard(
+      domain, cbid, cbInfo);
+}
+
+
+void CuptiCallbackApi::__callback_switchboard(
+   CUpti_CallbackDomain domain,
+   CUpti_CallbackId cbid,
+   const CUpti_CallbackData* cbInfo) {
+  VLOG(0) << "Callback: domain = " << domain << ", cbid = " << cbid;
+  CallbackList *cblist = nullptr;
+
+  switch (domain) {
+
+    // add the fastest path for kernel launch callbacks
+    // as these are the most frequent ones
+    case CUPTI_CB_DOMAIN_RUNTIME_API:
+      switch (cbid) {
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000:
+          cblist = &callbacks_.runtime[
+            CUDA_LAUNCH_KERNEL - __RUNTIME_CB_DOMAIN_START];
+          break;
+      }
+      break;
+
+    case CUPTI_CB_DOMAIN_RESOURCE:
+      switch (cbid) {
+        case CUPTI_CBID_RESOURCE_CONTEXT_CREATED:
+          cblist = &callbacks_.resource[
+            RESOURCE_CONTEXT_CREATED - __RESOURCE_CB_DOMAIN_START];
+          break;
+        case CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING:
+          cblist = &callbacks_.resource[
+            RESOURCE_CONTEXT_DESTROYED - __RESOURCE_CB_DOMAIN_START];
+          break;
+      }
+      break;
+
+    default:
+      return;
+  }
+
+  // ignore callbacks that are not handled
+  if (cblist == nullptr) {
+    return;
+  }
+
+  // make a copy of the callback list so we avoid holding lock
+  // in common case this should be just one func pointer copy
+  std::array<CuptiCallbackFn, MAX_CB_FNS_PER_CB> callbacks;
+  int num_cbs = 0;
+  {
+    ReaderLockGuard rl(callbackLock_);
+    int i = 0;
+    for (auto it = cblist->begin();
+        it != cblist->end() && i < MAX_CB_FNS_PER_CB;
+        it++, i++) {
+      callbacks[i] = *it;
+    }
+    num_cbs = i;
+  }
+
+  for (int i = 0; i < num_cbs; i++) {
+    auto fn = callbacks[i];
+    fn(domain, cbid, cbInfo);
+  }
+}
+
+CuptiCallbackApi& CuptiCallbackApi::singleton() {
+  static CuptiCallbackApi instance;
+  return instance;
+}
+
+CuptiCallbackApi::CuptiCallbackApi() {
+#ifdef HAS_CUPTI
+  lastCuptiStatus_ = CUPTI_ERROR_UNKNOWN;
+  lastCuptiStatus_ = CUPTI_CALL_NOWARN(
+    cuptiSubscribe(&subscriber_,
+      (CUpti_CallbackFunc)callback_switchboard,
+      nullptr));
+
+  initSuccess_ = (lastCuptiStatus_ == CUPTI_SUCCESS);
+#endif
+}
+
+CuptiCallbackApi::CallbackList* CuptiCallbackApi::CallbackTable::lookup(
+    CUpti_CallbackDomain domain, CuptiCallBackID cbid) {
+  size_t idx;
+
+  switch (domain) {
+
+    case CUPTI_CB_DOMAIN_RESOURCE:
+      assert(cbid >= __RESOURCE_CB_DOMAIN_START);
+      assert(cbid < __RESOURCE_CB_DOMAIN_END);
+      idx = cbid - __RESOURCE_CB_DOMAIN_START;
+      return &resource.at(idx);
+
+    case CUPTI_CB_DOMAIN_RUNTIME_API:
+      assert(cbid >= __RUNTIME_CB_DOMAIN_START);
+      assert(cbid < __RUNTIME_CB_DOMAIN_END);
+      idx = cbid - __RUNTIME_CB_DOMAIN_START;
+      return &runtime.at(idx);
+
+    default:
+      LOG(WARNING) << " Unsupported callback domain : " << domain;
+      return nullptr;
+  }
+}
+
+bool CuptiCallbackApi::registerCallback(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid,
+    CuptiCallbackFn cbfn) {
+  CallbackList* cblist = callbacks_.lookup(domain, cbid);
+
+  if (!cblist) {
+    LOG(WARNING) << "Could not register callback -- domain = " << domain
+                 << " callback id = " << cbid;
+    return false;
+  }
+
+  // avoid duplicates
+  auto it = std::find(cblist->begin(), cblist->end(), cbfn);
+  if (it != cblist->end()) {
+    LOG(WARNING) << "Adding duplicate callback -- domain = " << domain
+                 << " callback id = " << cbid;
+    return true;
+  }
+
+  if (cblist->size() == MAX_CB_FNS_PER_CB) {
+    LOG(WARNING) << "Already registered max callback -- domain = " << domain
+                 << " callback id = " << cbid;
+  }
+
+  WriteLockGuard wl(callbackLock_);
+  cblist->push_back(cbfn);
+  return true;
+}
+
+bool CuptiCallbackApi::deleteCallback(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid,
+    CuptiCallbackFn cbfn) {
+  CallbackList* cblist = callbacks_.lookup(domain, cbid);
+  if (!cblist) {
+    LOG(WARNING) << "Attempting to remove unsupported callback -- domain = " << domain
+                 << " callback id = " << cbid;
+    return false;
+  }
+
+  // Locks are not required here as
+  //  https://en.cppreference.com/w/cpp/container/list/erase
+  //  "References and iterators to the erased elements are invalidated.
+  //   Other references and iterators are not affected."
+  auto it = std::find(cblist->begin(), cblist->end(), cbfn);
+  if (it == cblist->end()) {
+    LOG(WARNING) << "Could not find callback to remove -- domain = " << domain
+                 << " callback id = " << cbid;
+    return false;
+  }
+
+  WriteLockGuard wl(callbackLock_);
+  cblist->erase(it);
+  return true;
+}
+
+bool CuptiCallbackApi::enableCallback(
+    CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
+#ifdef HAS_CUPTI
+  if (initSuccess_) {
+    lastCuptiStatus_ = CUPTI_CALL_NOWARN(
+        cuptiEnableCallback(1, subscriber_, domain, cbid));
+    return (lastCuptiStatus_ == CUPTI_SUCCESS);
+  }
+#endif
+  return false;
+}
+
+bool CuptiCallbackApi::disableCallback(
+    CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
+#ifdef HAS_CUPTI
+  if (initSuccess_) {
+    lastCuptiStatus_ = CUPTI_CALL_NOWARN(
+        cuptiEnableCallback(0, subscriber_, domain, cbid));
+    return (lastCuptiStatus_ == CUPTI_SUCCESS);
+  }
+#endif
+  return false;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#ifdef HAS_CUPTI
+#include <cupti.h>
+#endif
+#include <array>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <set>
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+
+
+/* CuptiCallbackApi : Provides an abstraction over CUPTI callback
+ *  interface. This enables various callback functions to be registered
+ *  with this class. The class registers a global callback handler that
+ *  redirects to the respective callbacks.
+ *
+ *  Note: one design choice we made is to only support simple function pointers
+ *  in order to speed up the implementation for fast path.
+ */
+
+#ifndef HAS_CUPTI
+enum CUpti_CallbackDomain {
+  CUPTI_CB_DOMAIN_RESOURCE,
+  CUPTI_CB_DOMAIN_RUNTIME_API,
+};
+enum CUpti_CallbackData {
+  CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+  CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
+  CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
+};
+
+using CUpti_CallbackId = size_t;
+#endif
+
+using CuptiCallbackFn = void(*)(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo);
+
+
+class CuptiCallbackApi {
+
+ public:
+
+  /* Global list of supported callback ids
+   *  use the class namespace to avoid confusing with CUPTI enums*/
+  enum CuptiCallBackID {
+    CUDA_LAUNCH_KERNEL =  0,
+    // can possibly support more callback ids per domain
+    //
+    __RUNTIME_CB_DOMAIN_START = CUDA_LAUNCH_KERNEL,
+
+    // Callbacks under Resource CB domain
+    RESOURCE_CONTEXT_CREATED,
+    RESOURCE_CONTEXT_DESTROYED,
+
+    __RUNTIME_CB_DOMAIN_END = RESOURCE_CONTEXT_CREATED,
+    __RESOURCE_CB_DOMAIN_START = RESOURCE_CONTEXT_CREATED,
+
+    __RESOURCE_CB_DOMAIN_END = RESOURCE_CONTEXT_DESTROYED + 1,
+  };
+
+
+  CuptiCallbackApi(const CuptiCallbackApi&) = delete;
+  CuptiCallbackApi& operator=(const CuptiCallbackApi&) = delete;
+
+  static CuptiCallbackApi& singleton();
+
+  bool initSuccess() const {
+    return initSuccess_;
+  }
+
+#ifdef HAS_CUPTI
+  CUptiResult getCuptiStatus() const {
+    return lastCuptiStatus_;
+  }
+#endif
+
+  bool registerCallback(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid,
+    CuptiCallbackFn cbfn);
+
+  // returns false if callback was not found
+  bool deleteCallback(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid,
+    CuptiCallbackFn cbfn);
+
+  bool enableCallback(CUpti_CallbackDomain domain, CUpti_CallbackId cbid);
+  bool disableCallback(CUpti_CallbackDomain domain, CUpti_CallbackId cbid);
+
+
+  // Please do not use this method. This has to be exposed as public
+  // so it is accessible from the callback handler
+  void __callback_switchboard(
+      CUpti_CallbackDomain domain,
+      CUpti_CallbackId cbid,
+      const CUpti_CallbackData* cbInfo);
+
+ private:
+
+  explicit CuptiCallbackApi();
+
+  // For callback table design overview see the .cpp file
+  using CallbackList = std::list<CuptiCallbackFn>;
+
+  // level 2 tables sizes are known at compile time
+  constexpr static size_t RUNTIME_CB_DOMAIN_SIZE
+    = (__RUNTIME_CB_DOMAIN_END - __RUNTIME_CB_DOMAIN_START);
+
+  constexpr static size_t RESOURCE_CB_DOMAIN_SIZE
+    = (__RESOURCE_CB_DOMAIN_END - __RESOURCE_CB_DOMAIN_START);
+
+  // level 1 table is a struct
+  struct CallbackTable {
+    std::array<CallbackList, RUNTIME_CB_DOMAIN_SIZE> runtime;
+    std::array<CallbackList, RESOURCE_CB_DOMAIN_SIZE> resource;
+
+    CallbackList* lookup(CUpti_CallbackDomain domain, CuptiCallBackID cbid);
+  };
+
+  CallbackTable callbacks_;
+  bool initSuccess_ = false;
+
+#ifdef HAS_CUPTI
+  CUptiResult lastCuptiStatus_;
+  CUpti_SubscriberHandle subscriber_;
+#endif
+};
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiNvPerfMetric.cpp
+++ b/libkineto/src/CuptiNvPerfMetric.cpp
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <nvperf_cuda_host.h>
+#include <nvperf_host.h>
+#include <nvperf_target.h>
+
+#include "ScopeExit.h"
+#include "CuptiNvPerfMetric.h"
+#include "Logger.h"
+
+namespace KINETO_NAMESPACE {
+
+// Add a namespace to isolate these utility functions that are only
+// giong to be used by the CuptiRangeProfiler. These included calls
+// to NVIDIA PerfWorks APIs.
+namespace nvperf {
+
+
+// Largely based on NVIDIA sample code provided with CUDA release
+//  files Metric.cpp and Eval.cpp
+
+// -------------------------------------------------
+// Metric and Counter Data Configuration
+// -------------------------------------------------
+
+
+// Note: Be carful before modifying the code below. There is a specific
+// sequence one needs to follow to program the metrics else things may
+// stop working. We tried to keep the flow consistent with the example
+// code from NVIDIA. Since most of the programmability comes from
+// the CUPTI profiler metric names this should be okay.
+
+bool getRawMetricRequests(
+    NVPA_MetricsContext* metricsContext,
+    std::vector<std::string> metricNames,
+    std::vector<std::string>& rawMetricsDeps,
+    std::vector<NVPA_RawMetricRequest>& rawMetricRequests) {
+  bool isolated = true;
+  /* Bug in collection with collection of metrics without instances, keep it
+   * to true*/
+  bool keepInstances = true;
+
+  for (const auto& metricName : metricNames) {
+
+    NVPW_MetricsContext_GetMetricProperties_Begin_Params
+        getMetricPropertiesBeginParams = {
+            NVPW_MetricsContext_GetMetricProperties_Begin_Params_STRUCT_SIZE, nullptr};
+    getMetricPropertiesBeginParams.pMetricsContext = metricsContext;
+    getMetricPropertiesBeginParams.pMetricName = metricName.c_str();
+
+    if (!NVPW_CALL(
+        NVPW_MetricsContext_GetMetricProperties_Begin(
+            &getMetricPropertiesBeginParams))) {
+      return false;
+    }
+
+    for (const char** metricDepsIt =
+             getMetricPropertiesBeginParams.ppRawMetricDependencies;
+         *metricDepsIt;
+         ++metricDepsIt) {
+      rawMetricsDeps.push_back(*metricDepsIt);
+    }
+
+    NVPW_MetricsContext_GetMetricProperties_End_Params
+        getMetricPropertiesEndParams = {
+            NVPW_MetricsContext_GetMetricProperties_End_Params_STRUCT_SIZE, nullptr};
+    getMetricPropertiesEndParams.pMetricsContext = metricsContext;
+
+    if (!NVPW_CALL(NVPW_MetricsContext_GetMetricProperties_End(
+            &getMetricPropertiesEndParams))) {
+      return false;
+    }
+  }
+
+  for (const auto& rawMetricName : rawMetricsDeps) {
+    NVPA_RawMetricRequest metricRequest = {NVPA_RAW_METRIC_REQUEST_STRUCT_SIZE, nullptr};
+    metricRequest.pMetricName = rawMetricName.c_str();
+    metricRequest.isolated = isolated;
+    metricRequest.keepInstances = keepInstances;
+    rawMetricRequests.push_back(metricRequest);
+    VLOG(1) << "Adding raw metric struct  : raw metric = " << rawMetricName
+        << " isolated = " << isolated << " keepinst = " << keepInstances;
+  }
+
+  if (rawMetricRequests.size() == 0) {
+    LOG(WARNING) << "CUPTI Profiler was unable to configure any metrics";
+    return false;
+  }
+  return true;
+}
+
+// Setup CUPTI Profiler Config Image
+bool getProfilerConfigImage(
+    const std::string& chipName,
+    const std::vector<std::string>& metricNames,
+    std::vector<uint8_t>& configImage,
+    const uint8_t* counterAvailabilityImage) {
+
+  NVPW_CUDA_MetricsContext_Create_Params metricsContextCreateParams = {
+      NVPW_CUDA_MetricsContext_Create_Params_STRUCT_SIZE, nullptr};
+  metricsContextCreateParams.pChipName = chipName.c_str();
+
+  if (!NVPW_CALL(
+        NVPW_CUDA_MetricsContext_Create(&metricsContextCreateParams))) {
+    return false;
+  }
+
+  NVPW_MetricsContext_Destroy_Params metricsContextDestroyParams = {
+      NVPW_MetricsContext_Destroy_Params_STRUCT_SIZE, nullptr};
+  metricsContextDestroyParams.pMetricsContext =
+      metricsContextCreateParams.pMetricsContext;
+
+  SCOPE_EXIT([&]() {
+    NVPW_MetricsContext_Destroy(
+        (NVPW_MetricsContext_Destroy_Params*)&metricsContextDestroyParams);
+  });
+
+  // Get all raw metrics required for given metricNames list
+  std::vector<NVPA_RawMetricRequest> rawMetricRequests;
+
+  // note: we need a variable at this functions scope to hold the string
+  // pointers for underlying C char arrays.
+  std::vector<std::string> rawMetricDeps;
+
+  if (!getRawMetricRequests(
+      metricsContextCreateParams.pMetricsContext,
+      metricNames,
+      rawMetricDeps,
+      rawMetricRequests)) {
+    return false;
+  }
+
+  NVPA_RawMetricsConfigOptions metricsConfigOptions = {
+      NVPA_RAW_METRICS_CONFIG_OPTIONS_STRUCT_SIZE, nullptr};
+  metricsConfigOptions.activityKind = NVPA_ACTIVITY_KIND_PROFILER;
+  metricsConfigOptions.pChipName = chipName.c_str();
+  NVPA_RawMetricsConfig* rawMetricsConfig;
+  if (!NVPW_CALL(
+        NVPA_RawMetricsConfig_Create(
+          &metricsConfigOptions, &rawMetricsConfig))) {
+    return false;
+  }
+
+  // TODO check if this is required
+  if (counterAvailabilityImage) {
+    NVPW_RawMetricsConfig_SetCounterAvailability_Params
+        setCounterAvailabilityParams = {
+            NVPW_RawMetricsConfig_SetCounterAvailability_Params_STRUCT_SIZE, nullptr};
+    setCounterAvailabilityParams.pRawMetricsConfig = rawMetricsConfig;
+    setCounterAvailabilityParams.pCounterAvailabilityImage =
+        counterAvailabilityImage;
+    if (!NVPW_CALL(
+          NVPW_RawMetricsConfig_SetCounterAvailability(
+            &setCounterAvailabilityParams))) {
+      return false;
+    }
+  }
+
+  NVPW_RawMetricsConfig_Destroy_Params rawMetricsConfigDestroyParams = {
+      NVPW_RawMetricsConfig_Destroy_Params_STRUCT_SIZE, nullptr};
+  rawMetricsConfigDestroyParams.pRawMetricsConfig = rawMetricsConfig;
+  SCOPE_EXIT([&]() {
+    NVPW_RawMetricsConfig_Destroy(
+        (NVPW_RawMetricsConfig_Destroy_Params*)&rawMetricsConfigDestroyParams);
+  });
+
+  // Start a Raw Metric Pass group
+  NVPW_RawMetricsConfig_BeginPassGroup_Params beginPassGroupParams = {
+      NVPW_RawMetricsConfig_BeginPassGroup_Params_STRUCT_SIZE, nullptr};
+  beginPassGroupParams.pRawMetricsConfig = rawMetricsConfig;
+  if (!NVPW_CALL(
+        NVPW_RawMetricsConfig_BeginPassGroup(&beginPassGroupParams))) {
+    return false;
+  }
+
+  // Add all raw metrics
+  NVPW_RawMetricsConfig_AddMetrics_Params addMetricsParams = {
+      NVPW_RawMetricsConfig_AddMetrics_Params_STRUCT_SIZE, nullptr};
+  addMetricsParams.pRawMetricsConfig = rawMetricsConfig;
+  addMetricsParams.pRawMetricRequests = rawMetricRequests.data();
+  addMetricsParams.numMetricRequests = rawMetricRequests.size();
+  if (!NVPW_CALL(
+        NVPW_RawMetricsConfig_AddMetrics(&addMetricsParams))) {
+    return false;
+  }
+
+  // End pass group
+  NVPW_RawMetricsConfig_EndPassGroup_Params endPassGroupParams = {
+      NVPW_RawMetricsConfig_EndPassGroup_Params_STRUCT_SIZE, nullptr};
+  endPassGroupParams.pRawMetricsConfig = rawMetricsConfig;
+  if (!NVPW_CALL(
+        NVPW_RawMetricsConfig_EndPassGroup(&endPassGroupParams))) {
+    return false;
+  }
+
+  // Setup Config Image generation
+  NVPW_RawMetricsConfig_GenerateConfigImage_Params generateConfigImageParams = {
+      NVPW_RawMetricsConfig_GenerateConfigImage_Params_STRUCT_SIZE, nullptr};
+  generateConfigImageParams.pRawMetricsConfig = rawMetricsConfig;
+  if (!NVPW_CALL(
+        NVPW_RawMetricsConfig_GenerateConfigImage(&generateConfigImageParams))) {
+    return false;
+  }
+
+  // Get the Config Image size... nearly there
+  NVPW_RawMetricsConfig_GetConfigImage_Params getConfigImageParams = {
+      NVPW_RawMetricsConfig_GetConfigImage_Params_STRUCT_SIZE, nullptr};
+  getConfigImageParams.pRawMetricsConfig = rawMetricsConfig;
+  getConfigImageParams.bytesAllocated = 0;
+  getConfigImageParams.pBuffer = nullptr;
+  if (!NVPW_CALL(
+        NVPW_RawMetricsConfig_GetConfigImage(&getConfigImageParams))) {
+    return false;
+  }
+
+  configImage.resize(getConfigImageParams.bytesCopied);
+
+  // Write the Config image binary
+  getConfigImageParams.bytesAllocated = configImage.size();
+  getConfigImageParams.pBuffer = configImage.data();
+  if (!NVPW_CALL(
+        NVPW_RawMetricsConfig_GetConfigImage(&getConfigImageParams))) {
+    return false;
+  }
+
+  return true;
+}
+
+bool getCounterDataPrefixImage(
+    const std::string& chipName,
+    const std::vector<std::string>& metricNames,
+    std::vector<uint8_t>& counterDataImagePrefix) {
+
+  NVPW_CUDA_MetricsContext_Create_Params metricsContextCreateParams = {
+      NVPW_CUDA_MetricsContext_Create_Params_STRUCT_SIZE, nullptr};
+  metricsContextCreateParams.pChipName = chipName.c_str();
+
+  if (!NVPW_CALL(
+        NVPW_CUDA_MetricsContext_Create(&metricsContextCreateParams))) {
+    return false;
+  }
+
+  NVPW_MetricsContext_Destroy_Params metricsContextDestroyParams = {
+      NVPW_MetricsContext_Destroy_Params_STRUCT_SIZE, nullptr};
+  metricsContextDestroyParams.pMetricsContext =
+      metricsContextCreateParams.pMetricsContext;
+
+
+  SCOPE_EXIT([&]() {
+    NVPW_MetricsContext_Destroy(
+        (NVPW_MetricsContext_Destroy_Params*)&metricsContextDestroyParams);
+  });
+
+  // Get all raw metrics required for given metricNames list
+  std::vector<NVPA_RawMetricRequest> rawMetricRequests;
+
+  // note: we need a variable at this functions scope to hold the string
+  // pointers for underlying C char arrays.
+  std::vector<std::string> rawMetricDeps;
+
+  if (!getRawMetricRequests(
+      metricsContextCreateParams.pMetricsContext,
+      metricNames,
+      rawMetricDeps,
+      rawMetricRequests)) {
+    return false;
+  }
+
+  // Setup Counter Data builder
+  NVPW_CounterDataBuilder_Create_Params counterDataBuilderCreateParams = {
+      NVPW_CounterDataBuilder_Create_Params_STRUCT_SIZE, nullptr};
+  counterDataBuilderCreateParams.pChipName = chipName.c_str();
+  if (!NVPW_CALL(
+        NVPW_CounterDataBuilder_Create(&counterDataBuilderCreateParams))) {
+    return false;
+  }
+
+  NVPW_CounterDataBuilder_Destroy_Params counterDataBuilderDestroyParams = {
+      NVPW_CounterDataBuilder_Destroy_Params_STRUCT_SIZE, nullptr};
+  counterDataBuilderDestroyParams.pCounterDataBuilder =
+      counterDataBuilderCreateParams.pCounterDataBuilder;
+  SCOPE_EXIT([&]() {
+    NVPW_CounterDataBuilder_Destroy((
+        NVPW_CounterDataBuilder_Destroy_Params*)&counterDataBuilderDestroyParams);
+  });
+
+  // Add metrics to counter data image prefix
+  NVPW_CounterDataBuilder_AddMetrics_Params addMetricsParams = {
+      NVPW_CounterDataBuilder_AddMetrics_Params_STRUCT_SIZE, nullptr};
+  addMetricsParams.pCounterDataBuilder =
+      counterDataBuilderCreateParams.pCounterDataBuilder;
+  addMetricsParams.pRawMetricRequests = rawMetricRequests.data();
+  addMetricsParams.numMetricRequests = rawMetricRequests.size();
+  if (!NVPW_CALL(
+        NVPW_CounterDataBuilder_AddMetrics(&addMetricsParams))) {
+    return false;
+  }
+
+  // Get image prefix size
+  NVPW_CounterDataBuilder_GetCounterDataPrefix_Params
+      getCounterDataPrefixParams = {
+          NVPW_CounterDataBuilder_GetCounterDataPrefix_Params_STRUCT_SIZE, nullptr};
+  getCounterDataPrefixParams.pCounterDataBuilder =
+      counterDataBuilderCreateParams.pCounterDataBuilder;
+  getCounterDataPrefixParams.bytesAllocated = 0;
+  getCounterDataPrefixParams.pBuffer = nullptr;
+  if (!NVPW_CALL(
+        NVPW_CounterDataBuilder_GetCounterDataPrefix(
+          &getCounterDataPrefixParams))) {
+    return false;
+  }
+
+  counterDataImagePrefix.resize(getCounterDataPrefixParams.bytesCopied);
+
+  // Now write counter data image prefix
+  getCounterDataPrefixParams.bytesAllocated = counterDataImagePrefix.size();
+  getCounterDataPrefixParams.pBuffer = counterDataImagePrefix.data();
+  if (!NVPW_CALL(
+        NVPW_CounterDataBuilder_GetCounterDataPrefix(
+          &getCounterDataPrefixParams))) {
+    return false;
+  }
+
+  return true;
+}
+
+// -------------------------------------------------
+// Metric and Counter Evaluation Utilities
+// -------------------------------------------------
+
+std::string getRangeDescription(
+    const std::vector<uint8_t>& counterDataImage,
+    int rangeIndex) {
+  std::vector<const char*> descriptionPtrs;
+
+  NVPW_Profiler_CounterData_GetRangeDescriptions_Params getRangeDescParams = {
+      NVPW_Profiler_CounterData_GetRangeDescriptions_Params_STRUCT_SIZE, nullptr};
+  getRangeDescParams.pCounterDataImage = counterDataImage.data();
+  getRangeDescParams.rangeIndex = rangeIndex;
+
+  if (!NVPW_CALL(
+      NVPW_Profiler_CounterData_GetRangeDescriptions(&getRangeDescParams))) {
+    return "";
+  }
+
+  descriptionPtrs.resize(getRangeDescParams.numDescriptions);
+  getRangeDescParams.ppDescriptions = descriptionPtrs.data();
+
+  if (!NVPW_CALL(
+      NVPW_Profiler_CounterData_GetRangeDescriptions(&getRangeDescParams))) {
+    return "";
+  }
+
+  std::string rangeName;
+
+  for (size_t i = 0; i < getRangeDescParams.numDescriptions; i++) {
+    if (i > 0) {
+      rangeName.append("/");
+    }
+    rangeName.append(descriptionPtrs[i]);
+  }
+  return rangeName;
+}
+
+CuptiProfilerResult evalMetricValues(
+    const std::string& chipName,
+    const std::vector<uint8_t>& counterDataImage,
+    const std::vector<std::string>& metricNames,
+    bool verbose) {
+
+  if (!counterDataImage.size()) {
+    LOG(ERROR) << "Counter Data Image is empty!";
+    return {};
+  }
+
+  NVPW_CUDA_MetricsContext_Create_Params metricsContextCreateParams = {
+      NVPW_CUDA_MetricsContext_Create_Params_STRUCT_SIZE, nullptr};
+  metricsContextCreateParams.pChipName = chipName.c_str();
+  if (!NVPW_CALL(
+        NVPW_CUDA_MetricsContext_Create(&metricsContextCreateParams))) {
+    return {};
+  }
+
+  NVPW_MetricsContext_Destroy_Params metricsContextDestroyParams = {
+      NVPW_MetricsContext_Destroy_Params_STRUCT_SIZE, nullptr};
+  metricsContextDestroyParams.pMetricsContext =
+      metricsContextCreateParams.pMetricsContext;
+  SCOPE_EXIT([&]() {
+    NVPW_MetricsContext_Destroy(
+        (NVPW_MetricsContext_Destroy_Params*)&metricsContextDestroyParams);
+  });
+
+  NVPW_CounterData_GetNumRanges_Params getNumRangesParams = {
+      NVPW_CounterData_GetNumRanges_Params_STRUCT_SIZE, nullptr};
+  getNumRangesParams.pCounterDataImage = counterDataImage.data();
+  if (!NVPW_CALL(
+      NVPW_CounterData_GetNumRanges(&getNumRangesParams))) {
+    return {};
+  }
+
+  // TBD in the future support special chars in metric name
+  // for now these are default
+  const bool isolated = true;
+
+  // API takes a 2D array of chars
+  std::vector<const char*> metricNamePtrs;
+
+  for (const auto& metric : metricNames) {
+    metricNamePtrs.push_back(metric.c_str());
+  }
+
+  CuptiProfilerResult result{
+    .metricNames = metricNames};
+
+  for (size_t rangeIndex = 0; rangeIndex < getNumRangesParams.numRanges;
+       ++rangeIndex) {
+
+    CuptiRangeMeasurement rangeData {
+    .rangeName = getRangeDescription(counterDataImage, rangeIndex)};
+    rangeData.values.resize(metricNames.size());
+
+    // First set Counter data image with current range
+    NVPW_MetricsContext_SetCounterData_Params setCounterDataParams = {
+        NVPW_MetricsContext_SetCounterData_Params_STRUCT_SIZE, nullptr};
+
+    setCounterDataParams.pMetricsContext =
+        metricsContextCreateParams.pMetricsContext;
+    setCounterDataParams.pCounterDataImage = counterDataImage.data();
+    setCounterDataParams.isolated = isolated;
+    setCounterDataParams.rangeIndex = rangeIndex;
+
+    NVPW_CALL(NVPW_MetricsContext_SetCounterData(&setCounterDataParams));
+
+
+    // Now we can evaluate GPU metrics
+    NVPW_MetricsContext_EvaluateToGpuValues_Params evalToGpuParams = {
+        NVPW_MetricsContext_EvaluateToGpuValues_Params_STRUCT_SIZE, nullptr};
+    evalToGpuParams.pMetricsContext =
+        metricsContextCreateParams.pMetricsContext;
+    evalToGpuParams.numMetrics = metricNamePtrs.size();
+    evalToGpuParams.ppMetricNames = metricNamePtrs.data();
+    evalToGpuParams.pMetricValues = rangeData.values.data();
+
+    if (!NVPW_CALL(NVPW_MetricsContext_EvaluateToGpuValues(&evalToGpuParams))) {
+      LOG(WARNING) << "Failed to evaluate metris for range : "
+                   << rangeData.rangeName;
+      continue;
+    }
+
+    if (verbose) {
+      for (size_t i = 0; i < metricNames.size(); i++) {
+        LOG(INFO) << "rangeName: " << rangeData.rangeName
+                  << "\tmetricName: " << metricNames[i]
+                  << "\tgpuValue: " << rangeData.values[i];
+      }
+    }
+
+    result.rangeVals.emplace_back(std::move(rangeData));
+  }
+
+  return result;
+}
+
+
+} // namespace nvperf
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiNvPerfMetric.h
+++ b/libkineto/src/CuptiNvPerfMetric.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <fmt/format.h>
+
+#include "Logger.h"
+
+namespace KINETO_NAMESPACE {
+
+struct CuptiRangeMeasurement {
+  std::string rangeName;
+  std::vector<double> values;
+};
+
+struct CuptiProfilerResult {
+  std::vector<std::string> metricNames;
+  // rangeName, list<double> values
+  std::vector<CuptiRangeMeasurement> rangeVals;
+};
+
+/* Utilities for CUPTI and NVIDIA PerfWorks Metric API
+ */
+
+#define NVPW_CALL(call)                            \
+  [&]() -> bool {                                  \
+    NVPA_Status _status_ = call;                   \
+    if (_status_ != NVPA_STATUS_SUCCESS) {         \
+      LOG(WARNING) << fmt::format(                 \
+          "function {} failed with error ({})",    \
+          #call,                                   \
+          (int)_status_);                          \
+      return false;                                \
+    }                                              \
+    return true;                                   \
+  }()
+
+// fixme - add a results string
+// nvpperfGetResultString(_status_, &_errstr_);
+
+namespace nvperf {
+
+// Setup CUPTI profiler configuration blob and counter data image prefix
+bool getProfilerConfigImage(
+    const std::string& chipName,
+    const std::vector<std::string>& metricNames,
+    std::vector<uint8_t>& configImage,
+    const uint8_t* counterAvailabilityImage = nullptr);
+
+// Setup CUPTI profiler configuration blob and counter data image prefix
+bool getCounterDataPrefixImage(
+    const std::string& chipName,
+    const std::vector<std::string>& metricNames,
+    std::vector<uint8_t>& counterDataImagePrefix);
+
+/* NV Perf Metric Evaluation helpers
+ *   - utilities to read binary data and obtain metrics for ranges
+ */
+CuptiProfilerResult evalMetricValues(
+    const std::string& chipName,
+    const std::vector<uint8_t>& counterDataImage,
+    const std::vector<std::string>& metricNames,
+    bool verbose = false);
+
+
+} // namespace nvperf
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiRangeProfilerApi.cpp
+++ b/libkineto/src/CuptiRangeProfilerApi.cpp
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cupti.h>
+#include <nvperf_host.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "cupti_call.h"
+#include "Logger.h"
+#include "Demangle.h"
+
+#include "CuptiRangeProfilerApi.h"
+
+
+namespace KINETO_NAMESPACE {
+
+#ifdef HAS_CUPTI
+
+/// Helper functions
+
+// Available raw counters
+std::vector<uint8_t> getCounterAvailiability(CUcontext cuContext) {
+  std::vector<uint8_t> counterAvailabilityImage;
+
+  CUpti_Profiler_GetCounterAvailability_Params getCounterAvailabilityParams = {
+      CUpti_Profiler_GetCounterAvailability_Params_STRUCT_SIZE, nullptr};
+  getCounterAvailabilityParams.ctx = cuContext;
+  CUPTI_CALL(
+      cuptiProfilerGetCounterAvailability(&getCounterAvailabilityParams));
+
+  counterAvailabilityImage.clear();
+  counterAvailabilityImage.resize(
+      getCounterAvailabilityParams.counterAvailabilityImageSize);
+
+  getCounterAvailabilityParams.pCounterAvailabilityImage =
+      counterAvailabilityImage.data();
+  CUPTI_CALL(
+      cuptiProfilerGetCounterAvailability(&getCounterAvailabilityParams));
+
+  return counterAvailabilityImage;
+}
+
+std::string getChipName(int deviceId) {
+  // Get chip name for the cuda device
+  CUpti_Device_GetChipName_Params getChipNameParams = {
+      CUpti_Device_GetChipName_Params_STRUCT_SIZE, nullptr};
+
+  getChipNameParams.deviceIndex = deviceId;
+  CUPTI_CALL(cuptiDeviceGetChipName(&getChipNameParams));
+
+  return getChipNameParams.pChipName;
+}
+
+
+// static
+void CuptiRBProfilerSession::initCupti() {
+  CUpti_Profiler_Initialize_Params profilerInitializeParams = {
+      CUpti_Profiler_Initialize_Params_STRUCT_SIZE, nullptr};
+  CUPTI_CALL(cuptiProfilerInitialize(&profilerInitializeParams));
+}
+
+// static
+void CuptiRBProfilerSession::deInitCupti() {
+  CUpti_Profiler_DeInitialize_Params profilerDeInitializeParams = {
+      CUpti_Profiler_DeInitialize_Params_STRUCT_SIZE, nullptr};
+  CUPTI_CALL(cuptiProfilerDeInitialize(&profilerDeInitializeParams));
+}
+
+// static
+void CuptiRBProfilerSession::staticInit() {
+  CuptiRBProfilerSession::initCupti();
+}
+
+// static
+std::vector<uint8_t>& CuptiRBProfilerSession::counterAvailabilityImage() {
+  static std::vector<uint8_t> counterAvailabilityImage_;
+  return counterAvailabilityImage_;
+}
+
+
+// Setup the profiler sessions
+CuptiRBProfilerSession::CuptiRBProfilerSession(
+    const std::vector<std::string>& metricNames,
+    int deviceId,
+    int maxRanges,
+    int numNestingLevels,
+    CUcontext cuContext)
+    : metricNames_(metricNames),
+      chipName_(getChipName(deviceId)),
+      deviceId_(deviceId),
+      maxRanges_(maxRanges),
+      numNestingLevels_(numNestingLevels),
+      cuContext_(cuContext) {
+  CuptiRBProfilerSession::initCupti();
+
+  LOG(INFO) << "Initializing CUPTI profiler session : device = " << deviceId
+            << " chip = " << chipName_;
+  /* Generate configuration for metrics, this can also be done offline*/
+  NVPW_InitializeHost_Params initializeHostParams = {
+      NVPW_InitializeHost_Params_STRUCT_SIZE, nullptr};
+  NVPW_CALL(NVPW_InitializeHost(&initializeHostParams));
+
+  if (metricNames.size()) {
+    if (!nvperf::getProfilerConfigImage(
+            chipName_,
+            metricNames,
+            configImage,
+            CuptiRBProfilerSession::counterAvailabilityImage().data())) {
+      LOG(ERROR) << "Failed to create configImage or counterDataImagePrefix";
+      return;
+    }
+    if (!nvperf::getCounterDataPrefixImage(
+            chipName_,
+            metricNames,
+            counterDataImagePrefix)) {
+      LOG(ERROR) << "Failed to create counterDataImagePrefix";
+      return;
+    }
+  } else {
+    LOG(ERROR) << "No metrics provided to profile";
+    return;
+  }
+
+  if (!createCounterDataImage()) {
+    LOG(ERROR) << "Failed to create counterDataImage";
+    return;
+  }
+
+  LOG(INFO) << "Size of structs\n"
+            << " config image size = " << configImage.size()  << " B"
+            << " counter data image prefix = "
+            << counterDataImagePrefix.size()  << " B"
+            << " counter data image size = " << counterDataImage.size() / 1024
+            << " KB"
+            << " counter sb image size = "
+            << counterDataScratchBuffer.size()  << " B";
+
+  beginPassParams_ = {CUpti_Profiler_BeginPass_Params_STRUCT_SIZE, nullptr};
+  endPassParams_ = {CUpti_Profiler_EndPass_Params_STRUCT_SIZE, nullptr};
+
+  initSuccess_ = true;
+
+  // TODO profiler_map[deviceId] = this;
+}
+
+void CuptiRBProfilerSession::startInternal(
+    CUpti_ProfilerRange profilerRange,
+    CUpti_ProfilerReplayMode profilerReplayMode) {
+  LOG(INFO) << "Starting profiler session: profiler range = "
+            << ((profilerRange == CUPTI_AutoRange) ? "autorange" : "userrange")
+            << " replay mode = "
+            << ((profilerReplayMode == CUPTI_KernelReplay) ? "kernel" : "user");
+  if (!initSuccess_) {
+    LOG(WARNING) << __func__ << "() bailing out since initialization failed";
+    return;
+  }
+
+  profilerStartTs_ = std::chrono::high_resolution_clock::now();
+  curRange_ = profilerRange;
+  curReplay_ = profilerReplayMode;
+
+  CUpti_Profiler_BeginSession_Params beginSessionParams = {
+      CUpti_Profiler_BeginSession_Params_STRUCT_SIZE, nullptr};
+
+  beginSessionParams.ctx = cuContext_;
+  beginSessionParams.counterDataImageSize = counterDataImage.size();
+  beginSessionParams.pCounterDataImage = counterDataImage.data();
+  beginSessionParams.counterDataScratchBufferSize =
+      counterDataScratchBuffer.size();
+  beginSessionParams.pCounterDataScratchBuffer = counterDataScratchBuffer.data();
+  beginSessionParams.range = profilerRange;
+  beginSessionParams.replayMode = profilerReplayMode;
+  beginSessionParams.maxRangesPerPass = maxRanges_;
+  beginSessionParams.maxLaunchesPerPass = maxRanges_;
+
+  auto status = CUPTI_CALL(cuptiProfilerBeginSession(&beginSessionParams));
+  if (status != CUPTI_SUCCESS) {
+    LOG(WARNING) << "Failed to start CUPTI profiler";
+    initSuccess_ = false;
+    return;
+  }
+
+  // Set counter configuration
+  CUpti_Profiler_SetConfig_Params setConfigParams = {
+      CUpti_Profiler_SetConfig_Params_STRUCT_SIZE, nullptr};
+
+  setConfigParams.ctx = cuContext_;
+  setConfigParams.pConfig = configImage.data();
+  setConfigParams.configSize = configImage.size();
+  setConfigParams.passIndex = 0;
+  setConfigParams.minNestingLevel = 1;
+  setConfigParams.numNestingLevels = numNestingLevels_;
+  status = CUPTI_CALL(cuptiProfilerSetConfig(&setConfigParams));
+
+  if (status != CUPTI_SUCCESS) {
+    LOG(WARNING) << "Failed to configure CUPTI profiler";
+    initSuccess_ = false;
+    return;
+  }
+  profilerInitDoneTs_ = std::chrono::high_resolution_clock::now();
+}
+
+void CuptiRBProfilerSession::stop() {
+  if (!initSuccess_) {
+    LOG(WARNING) << __func__ << "() bailing out since initialization failed";
+    return;
+  }
+  LOG(INFO) << "Stop profiler session on device = " << deviceId_;
+
+  CUpti_Profiler_UnsetConfig_Params unsetConfigParams = {
+      CUpti_Profiler_UnsetConfig_Params_STRUCT_SIZE, nullptr};
+  CUPTI_CALL(cuptiProfilerUnsetConfig(&unsetConfigParams));
+
+  CUpti_Profiler_EndSession_Params endSessionParams = {
+      CUpti_Profiler_EndSession_Params_STRUCT_SIZE, nullptr};
+  CUPTI_CALL(cuptiProfilerEndSession(&endSessionParams));
+
+  profilerStopTs_ = std::chrono::high_resolution_clock::now();
+}
+
+void CuptiRBProfilerSession::beginPass() {
+  if (!initSuccess_) {
+    LOG(WARNING) << __func__ << "() bailing out since initialization failed";
+    return;
+  }
+  CUPTI_CALL(cuptiProfilerBeginPass(&beginPassParams_));
+}
+
+bool CuptiRBProfilerSession::endPass() {
+  if (!initSuccess_) {
+    LOG(WARNING) << __func__ << "() bailing out since initialization failed";
+    return true;
+  }
+  CUPTI_CALL(cuptiProfilerEndPass(&endPassParams_));
+  return endPassParams_.allPassesSubmitted;
+}
+
+void CuptiRBProfilerSession::flushCounterData() {
+  LOG(INFO) << "Flushing counter data on device = " << deviceId_;
+  CUpti_Profiler_FlushCounterData_Params flushCounterDataParams = {
+      CUpti_Profiler_FlushCounterData_Params_STRUCT_SIZE, nullptr};
+  CUPTI_CALL(cuptiProfilerFlushCounterData(&flushCounterDataParams));
+}
+
+/// Enable and disable the profiler
+void CuptiRBProfilerSession::enable() {
+  if (!initSuccess_) {
+    LOG(WARNING) << __func__ << "() bailing out since initialization failed";
+    return;
+  }
+  CUpti_Profiler_EnableProfiling_Params enableProfilingParams = {
+      CUpti_Profiler_EnableProfiling_Params_STRUCT_SIZE, nullptr};
+  CUPTI_CALL(cuptiProfilerEnableProfiling(&enableProfilingParams));
+}
+
+void CuptiRBProfilerSession::disable() {
+  if (!initSuccess_) {
+    LOG(WARNING) << __func__ << "() bailing out since initialization failed";
+    return;
+  }
+  CUpti_Profiler_DisableProfiling_Params disableProfilingParams = {
+      CUpti_Profiler_DisableProfiling_Params_STRUCT_SIZE, nullptr};
+  CUPTI_CALL(cuptiProfilerDisableProfiling(&disableProfilingParams));
+}
+
+void CuptiRBProfilerSession::asyncStartAndEnable(
+    CUpti_ProfilerRange /*profilerRange*/,
+    CUpti_ProfilerReplayMode /*profilerReplayMode*/) {
+  /* TBD */
+}
+
+void CuptiRBProfilerSession::asyncDisableAndStop() {
+  /* TBD */
+}
+
+/// User range based profiling
+void CuptiRBProfilerSession::pushRange(const std::string& rangeName) {
+  LOG(INFO) << "Push User range = " << rangeName;
+  CUpti_Profiler_PushRange_Params pushRangeParams = {
+      CUpti_Profiler_PushRange_Params_STRUCT_SIZE, nullptr};
+  pushRangeParams.pRangeName = rangeName.c_str();
+  CUPTI_CALL(cuptiProfilerPushRange(&pushRangeParams));
+}
+
+void CuptiRBProfilerSession::popRange() {
+  LOG(INFO) << "Pop User range";
+  CUpti_Profiler_PopRange_Params popRangeParams = {
+      CUpti_Profiler_PopRange_Params_STRUCT_SIZE, nullptr};
+  CUPTI_CALL(cuptiProfilerPopRange(&popRangeParams));
+}
+
+CuptiProfilerResult CuptiRBProfilerSession::evalualteMetrics(
+    bool verbose) {
+  if (!initSuccess_) {
+    LOG(WARNING) << "Profiling failed, no results to return";
+    return {};
+  }
+
+  LOG(INFO) << "Total kernels logged = " << kernelNames_.size();
+  if (verbose) {
+    for (const auto& kernel : kernelNames_) {
+      std::cout << demangle(kernel) << std::endl;
+    }
+    LOG(INFO) << "Profiler Range data : ";
+  }
+
+  auto results = nvperf::evalMetricValues(
+      chipName_, counterDataImage, metricNames_, verbose /*verbose*/);
+
+  // profiler end-end duration
+  auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      profilerStopTs_ - profilerStartTs_);
+
+  auto init_dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      profilerInitDoneTs_ - profilerStartTs_);
+  LOG(INFO) << "Total profiler time = " << duration_ms.count() << " ms";
+  LOG(INFO) << "Total profiler init time = " << init_dur_ms.count() << " ms";
+
+  return results;
+}
+
+void CuptiRBProfilerSession::saveCounterData(
+    const std::string& /*CounterDataFileName*/,
+    const std::string& /*CounterDataSBFileName*/) {
+  /* TBD write binary files for counter data and counter scratch buffer */
+}
+
+/// Setup counter data
+bool CuptiRBProfilerSession::createCounterDataImage() {
+  CUpti_Profiler_CounterDataImageOptions counterDataImageOptions;
+  counterDataImageOptions.pCounterDataPrefix = counterDataImagePrefix.data();
+  counterDataImageOptions.counterDataPrefixSize = counterDataImagePrefix.size();
+  counterDataImageOptions.maxNumRanges = maxRanges_;
+  counterDataImageOptions.maxNumRangeTreeNodes = maxRanges_;
+  counterDataImageOptions.maxRangeNameLength = 64;
+
+  // Calculate size of counter data image
+  CUpti_Profiler_CounterDataImage_CalculateSize_Params calculateSizeParams = {
+      CUpti_Profiler_CounterDataImage_CalculateSize_Params_STRUCT_SIZE, nullptr};
+  calculateSizeParams.pOptions = &counterDataImageOptions;
+  calculateSizeParams.sizeofCounterDataImageOptions =
+      CUpti_Profiler_CounterDataImageOptions_STRUCT_SIZE;
+
+  CUPTI_CALL(
+      cuptiProfilerCounterDataImageCalculateSize(&calculateSizeParams));
+  counterDataImage.resize(calculateSizeParams.counterDataImageSize);
+
+  // Initialize counter data image
+  CUpti_Profiler_CounterDataImage_Initialize_Params initializeParams = {
+    CUpti_Profiler_CounterDataImage_Initialize_Params_STRUCT_SIZE, nullptr};
+  initializeParams.sizeofCounterDataImageOptions =
+    CUpti_Profiler_CounterDataImageOptions_STRUCT_SIZE;
+  initializeParams.pOptions = &counterDataImageOptions;
+  initializeParams.counterDataImageSize =
+    calculateSizeParams.counterDataImageSize;
+  initializeParams.pCounterDataImage = counterDataImage.data();
+  CUPTI_CALL(cuptiProfilerCounterDataImageInitialize(&initializeParams));
+
+  // Calculate counter Scratch Buffer size
+  CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params
+    scratchBufferSizeParams = {
+          CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params_STRUCT_SIZE, nullptr};
+
+  scratchBufferSizeParams.counterDataImageSize =
+    calculateSizeParams.counterDataImageSize;
+  scratchBufferSizeParams.pCounterDataImage =
+    initializeParams.pCounterDataImage;
+  CUPTI_CALL(cuptiProfilerCounterDataImageCalculateScratchBufferSize(
+    &scratchBufferSizeParams));
+
+  counterDataScratchBuffer.resize(
+      scratchBufferSizeParams.counterDataScratchBufferSize);
+
+  // Initialize scratch buffer
+  CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params
+    initScratchBufferParams = {
+      CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params_STRUCT_SIZE, nullptr};
+
+  initScratchBufferParams.counterDataImageSize =
+    calculateSizeParams.counterDataImageSize;
+
+  initScratchBufferParams.pCounterDataImage =
+    initializeParams.pCounterDataImage;
+  initScratchBufferParams.counterDataScratchBufferSize =
+    scratchBufferSizeParams.counterDataScratchBufferSize;
+  initScratchBufferParams.pCounterDataScratchBuffer =
+    counterDataScratchBuffer.data();
+
+  CUPTI_CALL(cuptiProfilerCounterDataImageInitializeScratchBuffer(
+      &initScratchBufferParams));
+
+  return true;
+}
+#endif // HAS_CUPTI
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiRangeProfilerApi.h
+++ b/libkineto/src/CuptiRangeProfilerApi.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cuda.h>
+#include <cupti_profiler_target.h>
+#include <cupti_target.h>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "CuptiNvPerfMetric.h"
+
+/* Cupti Range based profiler session
+ * See : https://docs.nvidia.com/cupti/Cupti/r_main.html#r_profiler
+ */
+
+namespace KINETO_NAMESPACE {
+
+#ifdef HAS_CUPTI
+class CuptiRBProfilerSession {
+ public:
+  // Initialize and configure CUPTI Profiler counters.
+  // - Metric names must be provided as string vector.
+  // - Supported values by CUPTI can be found at -
+  //   https://docs.nvidia.com/cupti/Cupti/r_main.html#r_host_metrics_api
+  explicit CuptiRBProfilerSession(
+      const std::vector<std::string>& metricNames,
+      int deviceId,
+      int maxRanges,
+      int numNestingLevels = 1,
+      CUcontext cuContext = nullptr);
+
+
+  // Start profiling session
+  // This function has to be called from the CPU thread running
+  // the CUDA context. If this is not the case asyncStartAndEnable()
+  // can be used
+  void start(
+      CUpti_ProfilerRange profilerRange = CUPTI_AutoRange,
+      CUpti_ProfilerReplayMode profilerReplayMode = CUPTI_KernelReplay) {
+    startInternal(profilerRange, profilerReplayMode);
+  }
+
+  // Stop profiling session
+  void stop();
+
+  void enable();
+  void disable();
+
+  // Profiler passes
+  //  GPU hardware has limited performance monitoring resources
+  //  the CUPTI profiler may need to run multiple passes to collect
+  //  data for a given range
+  //  If we use kernel replay model the kernels are automatically replayed
+  //  else, you can use the beginPass() and endPass() functions below
+  //  for user to manage the replays
+
+  // starts a profiler pass with given kernels in between
+  void beginPass();
+
+  // end a profiler pass with given kernels in between
+  // returns true if no more passes are required
+  bool endPass();
+
+  // flushes the counter data - required if you use user replay
+  void flushCounterData();
+
+  // Each pass can contain multiple of ranges
+  //  metrics configured in a pass are collected per each range-stack.
+  void pushRange(const std::string& rangeName);
+  void popRange();
+
+  // Async APIs : these will can be called from another thread
+  // outside the CUDA context being profiled
+  void asyncStartAndEnable(
+      CUpti_ProfilerRange profilerRange = CUPTI_AutoRange,
+      CUpti_ProfilerReplayMode profilerReplayMode = CUPTI_KernelReplay);
+  void asyncDisableAndStop();
+
+  void printMetrics() {
+    evalualteMetrics(true);
+  }
+
+  CuptiProfilerResult evalualteMetrics(bool verbose = false);
+
+  void saveCounterData(
+      const std::string& CounterDataFileName,
+      const std::string& CounterDataSBFileName);
+
+  static void initCupti();
+
+  static void deInitCupti();
+
+  static void staticInit();
+
+  static void setCounterAvailabilityImage(std::vector<uint8_t> img) {
+    counterAvailabilityImage() = img;
+  }
+
+ private:
+
+  bool createCounterDataImage();
+
+  void startInternal(
+      CUpti_ProfilerRange profilerRange,
+      CUpti_ProfilerReplayMode profilerReplayMode);
+
+  // log kernel name that used with callbacks
+  void logKernelName(const char* kernel) {
+    std::lock_guard<std::mutex> lg(kernelNamesMutex_);
+    kernelNames_.emplace_back(kernel);
+  }
+
+
+  std::vector<std::string> metricNames_;
+  std::string chipName_;
+
+  uint32_t deviceId_;
+  int maxRanges_;
+  int numNestingLevels_;
+  CUcontext cuContext_;
+
+  CUpti_ProfilerRange curRange_ = CUPTI_AutoRange;
+  CUpti_ProfilerReplayMode curReplay_ = CUPTI_KernelReplay;
+
+  // data buffers for configuration and counter data collection
+  std::vector<uint8_t> counterDataImagePrefix;
+  std::vector<uint8_t> configImage;
+  std::vector<uint8_t> counterDataImage;
+  std::vector<uint8_t> counterDataScratchBuffer;
+
+  std::chrono::time_point<std::chrono::high_resolution_clock> profilerStartTs_;
+  std::chrono::time_point<std::chrono::high_resolution_clock>
+      profilerInitDoneTs_;
+  std::chrono::time_point<std::chrono::high_resolution_clock> profilerStopTs_;
+
+  std::mutex kernelNamesMutex_;
+  // raw kernel names (not demangled)
+  std::vector<std::string> kernelNames_;
+
+  static std::vector<uint8_t>& counterAvailabilityImage();
+
+  CUpti_Profiler_BeginPass_Params beginPassParams_;
+  CUpti_Profiler_EndPass_Params endPassParams_;
+
+  bool initSuccess_ = false;
+};
+#endif // HAS_CUPTI
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/Demangle.cpp
+++ b/libkineto/src/Demangle.cpp
@@ -47,4 +47,8 @@ std::string demangle(const char* name) {
 #endif
 }
 
+std::string demangle(const std::string& name) {
+  return demangle(name.c_str());
+}
+
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/Demangle.h
+++ b/libkineto/src/Demangle.h
@@ -12,5 +12,6 @@
 namespace KINETO_NAMESPACE {
 
 std::string demangle(const char* name);
+std::string demangle(const std::string& name);
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/ScopeExit.h
+++ b/libkineto/src/ScopeExit.h
@@ -1,0 +1,29 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+#pragma once
+
+// Implement a simple scope handler allowing a function to release
+// resources when an error or exception occurs
+
+template <typename T>
+class ScopeExit {
+ public:
+  explicit ScopeExit(T t) : t(t) {}
+  ~ScopeExit() {
+    t();
+  }
+  T t;
+};
+
+template <typename T>
+ScopeExit<T> makeScopeExit(T t) {
+  return ScopeExit<T>(t);
+};
+
+// Add a level of indirection so __LINE__ is expanded
+#define __kINETO_CONCAT(name, line) name##line
+#define ANON_VAR(name, line) __kINETO_CONCAT(name, line)
+
+#define SCOPE_EXIT(func)                                      \
+  const auto ANON_VAR(SCOPE_BLOCK, __LINE__) =                \
+      makeScopeExit([=]() { func; })

--- a/libkineto/src/cupti_call.h
+++ b/libkineto/src/cupti_call.h
@@ -32,7 +32,7 @@
 
 #else
 
-#define CUPTI_CALL(call)
-#define CUPTI_CALL_NOWARN(call)
+#define CUPTI_CALL(call) call
+#define CUPTI_CALL_NOWARN(call) call
 
 #endif // HAS_CUPTI

--- a/libkineto/test/CuptiCallbackApiTest.cpp
+++ b/libkineto/test/CuptiCallbackApiTest.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "src/Logger.h"
+#include "src/CuptiCallbackApi.h"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono;
+using namespace KINETO_NAMESPACE;
+using namespace libkineto;
+
+const size_t some_data = 42;
+
+std::atomic<int> simple_cb_calls = 0;
+
+void simple_cb(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo) {
+
+  // simple arg check
+  EXPECT_EQ(domain, CUPTI_CB_DOMAIN_RUNTIME_API);
+  EXPECT_EQ(cbid, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000);
+  EXPECT_EQ(*reinterpret_cast<const size_t*>(cbInfo), some_data);
+
+  simple_cb_calls++;
+}
+
+void atomic_cb(
+    CUpti_CallbackDomain /*domain*/,
+    CUpti_CallbackId /*cbid*/,
+    const CUpti_CallbackData* /*cbInfo)*/) {
+  // do some atomics in a loop
+  for (int i = 0; i < 1000; i++) {
+    // would have used release consistency but this is fine
+    simple_cb_calls++;
+  }
+}
+
+void empty_cb(
+    CUpti_CallbackDomain /*domain*/,
+    CUpti_CallbackId /*cbid*/,
+    const CUpti_CallbackData* /*cbInfo*/) {
+}
+
+TEST(CuptiCallbackApiTest, SimpleTest) {
+  auto& api = CuptiCallbackApi::singleton();
+
+  auto addSimpleCallback = [&]() -> bool {
+    bool ret = api.registerCallback(
+        CUPTI_CB_DOMAIN_RUNTIME_API,
+        CuptiCallbackApi::CUDA_LAUNCH_KERNEL,
+        &simple_cb
+    );
+    return ret;
+  };
+  EXPECT_TRUE(addSimpleCallback()) << "Failed to add callback";
+
+  // duplicate add should be okay
+  EXPECT_TRUE(addSimpleCallback()) << "Failed to re-add callback";
+
+  simple_cb_calls = 0;
+
+  // simulate callback
+  api.__callback_switchboard(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+      reinterpret_cast<const CUpti_CallbackData*>(&some_data));
+
+  EXPECT_EQ(simple_cb_calls, 1);
+
+  bool ret = api.deleteCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CuptiCallbackApi::CUDA_LAUNCH_KERNEL,
+      &simple_cb
+  );
+
+  EXPECT_TRUE(ret) << "Failed to remove callback";
+
+  ret = api.deleteCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CuptiCallbackApi::CUDA_LAUNCH_KERNEL,
+      &atomic_cb
+  );
+
+  EXPECT_FALSE(ret) << "oops! deleted a callback that was never added";
+}
+
+TEST(CuptiCallbackApiTest, AllCallbacks) {
+  auto& api = CuptiCallbackApi::singleton();
+
+  auto testCallback = [&](
+      CUpti_CallbackDomain domain,
+      CUpti_CallbackId cbid,
+      CuptiCallbackApi::CuptiCallBackID kineto_cbid) -> bool {
+
+    bool ret = api.registerCallback(domain, kineto_cbid, atomic_cb);
+    EXPECT_TRUE(ret) << "Failed to add callback";
+
+    if (!ret) {
+      return false;
+    }
+
+    simple_cb_calls = 0;
+    api.__callback_switchboard(domain, cbid, nullptr);
+    EXPECT_EQ(simple_cb_calls, 1000);
+    ret = simple_cb_calls == 1000;
+
+    EXPECT_TRUE(api.deleteCallback(domain, kineto_cbid, atomic_cb));
+
+    return ret;
+  };
+
+  EXPECT_TRUE(
+      testCallback(
+        CUPTI_CB_DOMAIN_RESOURCE,
+        CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
+        CuptiCallbackApi::RESOURCE_CONTEXT_CREATED))
+    << "Failed to run callback for RESOURCE_CONTEXT_CREATED";
+
+  EXPECT_TRUE(
+      testCallback(
+        CUPTI_CB_DOMAIN_RESOURCE,
+        CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
+        CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED))
+    << "Failed to run callback for RESOURCE_CONTEXT_DESTROYED";
+
+  EXPECT_TRUE(
+      testCallback(
+        CUPTI_CB_DOMAIN_RUNTIME_API,
+        CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+        CuptiCallbackApi::CUDA_LAUNCH_KERNEL))
+    << "Failed to run callback for CUDA_LAUNCH_KERNEL";
+
+}
+
+TEST(CuptiCallbackApiTest, ContentionTest) {
+  auto& api = CuptiCallbackApi::singleton();
+  const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RUNTIME_API;
+  const CUpti_CallbackId cbid = CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000;
+  const CuptiCallbackApi::CuptiCallBackID kineto_cbid =
+    CuptiCallbackApi::CUDA_LAUNCH_KERNEL;
+
+  bool ret = api.registerCallback(domain, kineto_cbid, empty_cb);
+  EXPECT_TRUE(ret) << "Failed to add callback";
+
+  const int iters = 10000;
+  const int num_readers = 8;
+
+  simple_cb_calls = 0;
+
+  // simulate callbacks being executed on multiple threads in parallel
+  //  during this interval add a new atomic_callback.
+  //  this test ensured mutual exclusion is working fine
+  auto read_fn = [&](int tid){
+    auto start_ts = high_resolution_clock::now();
+    for (int i = 0; i < iters; i++) {
+      api.__callback_switchboard(domain, cbid, nullptr);
+    }
+    auto runtime_ms = duration_cast<milliseconds>(
+      high_resolution_clock::now() - start_ts);
+    LOG(INFO) << "th " << tid << " done in " << runtime_ms.count() << " ms";
+  };
+
+
+  std::vector<std::thread> read_ths;
+  for (int i = 0; i< num_readers; i++) {
+    read_ths.emplace_back(read_fn, i);
+  }
+
+  ret = api.registerCallback(domain, kineto_cbid, atomic_cb);
+  EXPECT_TRUE(ret) << "Failed to add callback";
+
+  for (auto& t : read_ths) {
+    t.join();
+  }
+
+  //EXPECT_GT(simple_cb_calls, 0)
+  //  << "Atomic callback should have been called at least once.";
+
+  api.deleteCallback(domain, kineto_cbid, empty_cb);
+  api.deleteCallback(domain, kineto_cbid, atomic_cb);
+}
+
+TEST(CuptiCallbackApiTest, Bechmark) {
+
+  constexpr int iters = 1000;
+  // atomic bench a number of times to get a baseline
+
+  const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RUNTIME_API;
+  const CUpti_CallbackId cbid = CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000;
+  const CuptiCallbackApi::CuptiCallBackID kineto_cbid =
+    CuptiCallbackApi::CUDA_LAUNCH_KERNEL;
+
+  LOG(INFO) << "Iteration count = " << iters;
+
+  const bool use_empty = true;
+  auto cbfn = use_empty ? &empty_cb : &atomic_cb;
+
+  // warmup
+  for (int i = 0; i < 50; i++) {
+    (*cbfn)(domain, cbid, nullptr);
+  }
+
+  auto start_ts = high_resolution_clock::now();
+  for (int i = 0; i < iters; i++) {
+    (*cbfn)(domain, cbid, nullptr);
+  }
+  auto delta_baseline_ns = duration_cast<nanoseconds>(
+      high_resolution_clock::now() - start_ts);
+  LOG(INFO) << "Baseline runtime  = " << delta_baseline_ns.count() << " ns";
+
+
+  auto& api = CuptiCallbackApi::singleton();
+  bool ret = api.registerCallback(domain, kineto_cbid, cbfn);
+  EXPECT_TRUE(ret) << "Failed to add callback";
+
+  // warmup
+  for (int i = 0; i < 50; i++) {
+    api.__callback_switchboard(domain, cbid, nullptr);
+  }
+
+  start_ts = high_resolution_clock::now();
+  for (int i = 0; i < iters; i++) {
+    api.__callback_switchboard(domain, cbid, nullptr);
+  }
+
+  auto delta_callback_ns = duration_cast<nanoseconds>(
+      high_resolution_clock::now() - start_ts);
+  LOG(INFO) << "Callback runtime  = " << delta_callback_ns.count() << " ns";
+
+  LOG(INFO) << "Callback runtime per iteration = " <<
+    (delta_callback_ns.count() - delta_baseline_ns.count()) / (double) iters
+    << " ns";
+
+}

--- a/libkineto/test/CuptiProfilerApiTest.cu
+++ b/libkineto/test/CuptiProfilerApiTest.cu
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <string>
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <cuda.h>
+
+#include "src/Logger.h"
+#include "src/CuptiRangeProfilerApi.h"
+
+#define DRIVER_API_CALL(apiFuncCall)                           \
+  do {                                                         \
+    CUresult _status = apiFuncCall;                            \
+    if (_status != CUDA_SUCCESS) {                             \
+      LOG(ERROR) << "Failed invoking CUDA driver function "    \
+                 << #apiFuncCall << " status = "               \
+                 << _status;                                   \
+      exit(-1);                                                \
+    }                                                          \
+  } while (0)
+
+#define EXPECT(expr)\
+  if (!(expr)) {\
+  };
+
+using namespace KINETO_NAMESPACE;
+
+static int numRanges = 1;
+
+using Type = double;
+
+// Device code
+__global__ void VecAdd(const Type* A, const Type* B, Type* C, int N) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < N) {
+    C[i] = A[i] + B[i];
+  }
+}
+
+// Device code
+__global__ void VecSub(const Type* A, const Type* B, Type* C, int N) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < N) {
+    C[i] = A[i] - B[i];
+  }
+}
+
+static void initVec(Type* vec, int n) {
+  for (int i = 0; i < n; i++) {
+    vec[i] = i;
+  }
+}
+
+static void cleanUp(
+    Type* h_A,
+    Type* h_B,
+    Type* h_C,
+    Type* h_D,
+    Type* d_A,
+    Type* d_B,
+    Type* d_C,
+    Type* d_D) {
+  if (d_A)
+    cudaFree(d_A);
+  if (d_B)
+    cudaFree(d_B);
+  if (d_C)
+    cudaFree(d_C);
+  if (d_D)
+    cudaFree(d_D);
+
+  // Free host memory
+  if (h_A)
+    free(h_A);
+  if (h_B)
+    free(h_B);
+  if (h_C)
+    free(h_C);
+  if (h_D)
+    free(h_D);
+}
+
+/* Benchmark application used to test profiler measurements
+ * This simply runs two kernels vector Add and Vector Subtract
+ */
+
+void VectorAddSubtract() {
+  int N = 50000;
+  size_t size = N * sizeof(Type);
+  int threadsPerBlock = 0;
+  int blocksPerGrid = 0;
+  Type *h_A, *h_B, *h_C, *h_D;
+  Type *d_A, *d_B, *d_C, *d_D;
+  int i;
+  Type sum, diff;
+
+  // Allocate input vectors h_A and h_B in host memory
+  h_A = (Type*)malloc(size);
+  h_B = (Type*)malloc(size);
+  h_C = (Type*)malloc(size);
+  h_D = (Type*)malloc(size);
+
+  // Initialize input vectors
+  initVec(h_A, N);
+  initVec(h_B, N);
+  memset(h_C, 0, size);
+  memset(h_D, 0, size);
+
+  // Allocate vectors in device memory
+  cudaMalloc((void**)&d_A, size);
+  cudaMalloc((void**)&d_B, size);
+  cudaMalloc((void**)&d_C, size);
+  cudaMalloc((void**)&d_D, size);
+
+  // Copy vectors from host memory to device memory
+  cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice);
+  cudaMemcpy(d_B, h_B, size, cudaMemcpyHostToDevice);
+
+  // Invoke kernel
+  threadsPerBlock = 256;
+  blocksPerGrid = (N + threadsPerBlock - 1) / threadsPerBlock;
+  LOG(INFO) << fmt::format(
+      "Launching kernel: blocks {}, thread/block {}",
+      blocksPerGrid,
+      threadsPerBlock);
+
+  VecAdd<<<blocksPerGrid, threadsPerBlock>>>(d_A, d_B, d_C, N);
+
+  VecSub<<<blocksPerGrid, threadsPerBlock>>>(d_A, d_B, d_D, N);
+
+  // Copy result from device memory to host memory
+  // h_C contains the result in host memory
+  cudaMemcpy(h_C, d_C, size, cudaMemcpyDeviceToHost);
+  cudaMemcpy(h_D, d_D, size, cudaMemcpyDeviceToHost);
+
+  // Verify result
+  for (i = 0; i < N; ++i) {
+    sum = h_A[i] + h_B[i];
+    diff = h_A[i] - h_B[i];
+    if (h_C[i] != sum || h_D[i] != diff) {
+      LOG(ERROR) << "Result verification failed";
+    }
+  }
+
+  cleanUp(h_A, h_B, h_C, h_D, d_A, d_B, d_C, d_D);
+}
+
+bool runTestWithAutoRange(
+    int deviceNum,
+    const std::vector<std::string>& metricNames,
+    CUcontext cuContext) {
+
+  // create a CUPTI range based profiling profiler
+  //  this configures the counter data as well
+  CuptiRBProfilerSession profiler(
+      metricNames, deviceNum, 2, 1, cuContext);
+
+  CUpti_ProfilerRange profilerRange = CUPTI_AutoRange;
+  CUpti_ProfilerReplayMode profilerReplayMode = CUPTI_KernelReplay;
+
+  profiler.start(profilerRange, profilerReplayMode);
+
+  profiler.enable();
+  VectorAddSubtract();
+  profiler.disable();
+
+  // stop profiler
+  profiler.stop();
+
+  auto result = profiler.evalualteMetrics(true);
+
+  // check results
+  EXPECT_EQ(result.metricNames.size(), 3);
+  EXPECT_EQ(result.rangeVals.size(), 2);
+
+  for (const auto& measurement : result.rangeVals) {
+    EXPECT_EQ(measurement.values.size(), 3);
+
+    if (measurement.values.size() == 3) {
+      // smsp__warps_launched.avg
+      EXPECT_NE(measurement.values[0], 0);
+      // smsp__sass_thread_inst_executed_op_dadd_pred_on.sum
+      // each kernel has 50000 dadd ops
+      EXPECT_EQ(measurement.values[1], 50000);
+      // sm__inst_executed_pipe_tensor.sum
+      //EXPECT_EQ(measurement.values[2], 0);
+    }
+  }
+  return true;
+}
+
+bool runTestWithUserRange(
+    int deviceNum,
+    const std::vector<std::string>& metricNames,
+    CUcontext cuContext) {
+
+  // create a CUPTI range based profiling profiler
+  //  this configures the counter data as well
+  CuptiRBProfilerSession profiler(
+      metricNames, deviceNum, numRanges, 1, cuContext);
+
+  CUpti_ProfilerRange profilerRange = CUPTI_UserRange;
+  CUpti_ProfilerReplayMode profilerReplayMode = CUPTI_UserReplay;
+
+  profiler.start(profilerRange, profilerReplayMode);
+
+  /* User takes the resposiblity of replaying the kernel launches */
+  bool replay = true;
+  do {
+    profiler.beginPass();
+    {
+      profiler.enable();
+      std::string rangeName = "vecAddSub";
+      profiler.pushRange(rangeName);
+      { VectorAddSubtract(); }
+      profiler.popRange();
+      profiler.disable();
+    }
+    LOG(INFO) << "Replay starting.";
+    replay = profiler.endPass();
+  } while (!replay);
+  // stop profiler
+  profiler.stop();
+
+  auto result = profiler.evalualteMetrics(true);
+
+  // check results
+  EXPECT_EQ(result.metricNames.size(), 3);
+  EXPECT_EQ(result.rangeVals.size(), 1);
+
+  if (result.rangeVals.size() > 0) {
+    const auto& measurement = result.rangeVals[0];
+    EXPECT_EQ(measurement.values.size(), 3);
+
+    if (measurement.values.size() == 3) {
+      // smsp__warps_launched.avg
+      EXPECT_NE(measurement.values[0], 0);
+      // smsp__sass_thread_inst_executed_op_dadd_pred_on.sum
+      EXPECT_EQ(measurement.values[1], 100000);
+      // sm__inst_executed_pipe_tensor.sum
+      //EXPECT_EQ(measurement.values[2], 0);
+    }
+  }
+  return true;
+}
+
+int main(int argc, char* argv[]) {
+
+  CUdevice cuDevice;
+
+  int deviceCount, deviceNum;
+  int computeCapabilityMajor = 0, computeCapabilityMinor = 0;
+
+  printf("Usage: %s [device_num]\n", argv[0]);
+
+  DRIVER_API_CALL(cuInit(0));
+  DRIVER_API_CALL(cuDeviceGetCount(&deviceCount));
+
+  if (deviceCount == 0) {
+    LOG(ERROR) << "There is no device supporting CUDA.";
+    return -2;
+  }
+
+  if (argc > 1)
+    deviceNum = atoi(argv[1]);
+  else
+    deviceNum = 0;
+  LOG(INFO) << "CUDA Device Number: " << deviceNum;
+
+  DRIVER_API_CALL(cuDeviceGet(&cuDevice, deviceNum));
+  DRIVER_API_CALL(cuDeviceGetAttribute(
+      &computeCapabilityMajor,
+      CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+      cuDevice));
+  DRIVER_API_CALL(cuDeviceGetAttribute(
+      &computeCapabilityMinor,
+      CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+      cuDevice));
+
+  LOG(INFO) << "Compute Cabapbility = "
+            << fmt::format("{},{}",computeCapabilityMajor, computeCapabilityMinor);
+
+  if (computeCapabilityMajor < 7) {
+    LOG(ERROR) << "CUPTI Profiler is not supported  with compute capability < 7.0";
+    return -2;
+  }
+
+  // metrics to profile
+  std::vector<std::string> metricNames = {
+    "smsp__warps_launched.avg",
+    "smsp__sass_thread_inst_executed_op_dadd_pred_on.sum",
+    "sm__inst_executed_pipe_tensor.sum",
+  };
+
+  CUcontext cuContext;
+  DRIVER_API_CALL(cuCtxCreate(&cuContext, 0, cuDevice));
+
+  VectorAddSubtract();
+
+  CuptiRBProfilerSession::staticInit();
+
+  if (!runTestWithUserRange(deviceNum, metricNames, cuContext)) {
+    LOG(ERROR) << "Failed to profiler test benchmark in user range";
+  } else if (!runTestWithAutoRange(deviceNum, metricNames, cuContext)) {
+    LOG(ERROR) << "Failed to profiler test benchmark in auto range";
+  }
+  CuptiRBProfilerSession::deInitCupti();
+  DRIVER_API_CALL(cuCtxDestroy(cuContext));
+
+
+  return 0;
+}


### PR DESCRIPTION
Summary:
# CUPTI Range Profiler API Support
Adds new core logic to leverage CUPTI Range Profiler API.
Note that this adds a dependency on nvperf_host.so library that was introduced in later CUDA versions
The range based profiler allows us to calculate any number of profiler metrics for a region of the code. This region is known as a range.

## User vs Auto Range
The profiler can be enabled in an auto-range mode where each kernel automatically becomes a range and configured metrics are collected for it. The kernel executions in auto range mode are serialized.
In user range mode we can push/pop user range names and the metric is collected between each range stack. User range mode supports kernel concurrency.

User range example
```
profiler.pushRange("iter0");
....
profiler.popRange();
```

Reference : https://docs.nvidia.com/cupti/Cupti/r_main.html#r_profiler

# Implementation Details
1. CuptiProfilerAPI.h :
      CuptiRBSerssion -> this object contains all of the state and configuration data for CUPTI profiler. It performs counter configuration and returns results in the CuptiProfilerResults datastructure.
2. CuptiNvPerf.cpp : Adds helper code using NV PerfWorks APIs to configure and evaluate metrics from the range profiler.

Differential Revision: D31437227

