### PR TITLE
Add Callback API centralized handler

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -217,7 +217,9 @@ void CuptiActivityApi::clearActivities() {
   }
   // Can't hold mutex_ during this call, since bufferCompleted
   // will be called by libcupti and mutex_ is acquired there.
+#ifdef HAS_CUPTI
   CUPTI_CALL(cuptiActivityFlushAll(0));
+#endif
   // FIXME: We might want to make sure we reuse
   // the same memory during warmup and tracing.
   // Also, try to use the amount of memory required

--- a/libkineto/src/CuptiCallbackAPI.cpp
+++ b/libkineto/src/CuptiCallbackAPI.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CuptiCallbackAPI.h"
+
+#include <assert.h>
+#include <chrono>
+#include <algorithm>
+#include <mutex>
+#include <shared_mutex>
+
+#include "cupti_call.h"
+#include "Logger.h"
+
+
+namespace KINETO_NAMESPACE {
+
+// limit on number of handles per callback type
+constexpr size_t MAX_CB_FNS_PER_CB = 8;
+
+// Reader Writer lock types
+using ReaderWriterLock = std::shared_mutex;
+using ReaderLockGuard = std::shared_lock<ReaderWriterLock>;
+using WriteLockGuard = std::unique_lock<ReaderWriterLock>;
+
+static ReaderWriterLock callbackLock_;
+
+/* Callback Table :
+ *  Overall goal of the design is to optimize the lookup of function
+ *  pointers. The table is structured at two levels and the leaf
+ *  elements in the table are std::list to enable fast access/inserts/deletes
+ *
+ *   <callback domain0> |
+ *                     -> cb id 0 -> std::list of callbacks
+ *                     ...
+ *                     -> cb id n -> std::list of callbacks
+ *   <callback domain1> |
+ *                    ...
+ *  CallbackTable is the finaly table type above
+ *  See type declrartions in header file.
+ */
+
+
+/* callback_switchboard : is the global callback handler we register
+ *  with CUPTI. The goal is to make it as efficient as possible
+ *  to re-direct to the registered callback(s).
+ *
+ *  Few things to care about :
+ *   a) use if/then switches rather than map/hash structures
+ *   b) avoid dynamic memory allocations
+ *   c) be aware of locking overheads
+ */
+#ifdef HAS_CUPTI
+static void CUPTIAPI callback_switchboard(
+#else
+static void callback_switchboard(
+#endif
+   void* /* unused */,
+   CUpti_CallbackDomain domain,
+   CUpti_CallbackId cbid,
+   const CUpti_CallbackData* cbInfo) {
+
+  // below statement is likey going to call a mutex
+  // on the singleton access
+  CuptiCallbackAPI::singleton().__callback_switchboard(
+      domain, cbid, cbInfo);
+}
+
+
+void CuptiCallbackAPI::__callback_switchboard(
+   CUpti_CallbackDomain domain,
+   CUpti_CallbackId cbid,
+   const CUpti_CallbackData* cbInfo) {
+  VLOG(0) << "Callback: domain = " << domain << ", cbid = " << cbid;
+  CallbackList *cblist = nullptr;
+
+  switch (domain) {
+
+    // add the fastest path for kernel launch callbacks
+    // as these are the most frequent ones
+    case CUPTI_CB_DOMAIN_RUNTIME_API:
+      switch (cbid) {
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000:
+          cblist = &callbacks_.runtime[
+            CUDA_LAUNCH_KERNEL - __RUNTIME_CB_DOMAIN_START];
+          break;
+      }
+      break;
+
+    case CUPTI_CB_DOMAIN_RESOURCE:
+      switch (cbid) {
+        case CUPTI_CBID_RESOURCE_CONTEXT_CREATED:
+          cblist = &callbacks_.resource[
+            RESOURCE_CONTEXT_CREATED - __RESOURCE_CB_DOMAIN_START];
+          break;
+        case CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING:
+          cblist = &callbacks_.resource[
+            RESOURCE_CONTEXT_DESTROYED - __RESOURCE_CB_DOMAIN_START];
+          break;
+      }
+      break;
+
+    default:
+      return;
+  }
+
+  // ignore callbacks that are not handled
+  if (cblist == nullptr) {
+    return;
+  }
+
+  // make a copy of the callback list so we avoid holding lock
+  // in common case this should be just one func pointer copy
+  std::array<CuptiCallbackFn, MAX_CB_FNS_PER_CB> callbacks;
+  int num_cbs = 0;
+  {
+    ReaderLockGuard rl(callbackLock_);
+    int i = 0;
+    for (auto it = cblist->begin();
+        it != cblist->end() && i < MAX_CB_FNS_PER_CB;
+        it++, i++) {
+      callbacks[i] = *it;
+    }
+    num_cbs = i;
+  }
+
+  for (int i = 0; i < num_cbs; i++) {
+    auto fn = callbacks[i];
+    fn(domain, cbid, cbInfo);
+  }
+}
+
+CuptiCallbackAPI& CuptiCallbackAPI::singleton() {
+  static CuptiCallbackAPI instance;
+  return instance;
+}
+
+CuptiCallbackAPI::CuptiCallbackAPI() {
+#ifdef HAS_CUPTI
+  lastCuptiStatus_ = CUPTI_ERROR_UNKNOWN;
+  lastCuptiStatus_ = CUPTI_CALL_NOWARN(
+    cuptiSubscribe(&subscriber_,
+      (CUpti_CallbackFunc)callback_switchboard,
+      nullptr));
+
+  initSuccess_ = (lastCuptiStatus_ == CUPTI_SUCCESS);
+#endif
+}
+
+CuptiCallbackAPI::CallbackList* CuptiCallbackAPI::CallbackTable::lookup(
+    CUpti_CallbackDomain domain, CuptiCallBackID cbid) {
+  size_t idx;
+
+  switch (domain) {
+
+    case CUPTI_CB_DOMAIN_RESOURCE:
+      assert(cbid >= __RESOURCE_CB_DOMAIN_START);
+      assert(cbid < __RESOURCE_CB_DOMAIN_END);
+      idx = cbid - __RESOURCE_CB_DOMAIN_START;
+      return &resource.at(idx);
+
+    case CUPTI_CB_DOMAIN_RUNTIME_API:
+      assert(cbid >= __RUNTIME_CB_DOMAIN_START);
+      assert(cbid < __RUNTIME_CB_DOMAIN_END);
+      idx = cbid - __RUNTIME_CB_DOMAIN_START;
+      return &runtime.at(idx);
+
+    default:
+      LOG(WARNING) << " Unsupported callback domain : " << domain;
+      return nullptr;
+  }
+}
+
+bool CuptiCallbackAPI::registerCallback(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid,
+    CuptiCallbackFn cbfn) {
+  CallbackList* cblist = callbacks_.lookup(domain, cbid);
+
+  if (!cblist) {
+    LOG(WARNING) << "Could not register callback -- domain = " << domain
+                 << " callback id = " << cbid;
+    return false;
+  }
+
+  // avoid duplicates
+  auto it = std::find(cblist->begin(), cblist->end(), cbfn);
+  if (it != cblist->end()) {
+    LOG(WARNING) << "Adding duplicate callback -- domain = " << domain
+                 << " callback id = " << cbid;
+    return true;
+  }
+
+  if (cblist->size() == MAX_CB_FNS_PER_CB) {
+    LOG(WARNING) << "Already registered max callback -- domain = " << domain
+                 << " callback id = " << cbid;
+  }
+
+  WriteLockGuard wl(callbackLock_);
+  cblist->push_back(cbfn);
+  return true;
+}
+
+bool CuptiCallbackAPI::deleteCallback(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid,
+    CuptiCallbackFn cbfn) {
+  CallbackList* cblist = callbacks_.lookup(domain, cbid);
+  if (!cblist) {
+    LOG(WARNING) << "Attempting to remove unsupported callback -- domain = " << domain
+                 << " callback id = " << cbid;
+    return false;
+  }
+
+  // Locks are not required here as
+  //  https://en.cppreference.com/w/cpp/container/list/erase
+  //  "References and iterators to the erased elements are invalidated.
+  //   Other references and iterators are not affected."
+  auto it = std::find(cblist->begin(), cblist->end(), cbfn);
+  if (it == cblist->end()) {
+    LOG(WARNING) << "Could not find callback to remove -- domain = " << domain
+                 << " callback id = " << cbid;
+    return false;
+  }
+
+  WriteLockGuard wl(callbackLock_);
+  cblist->erase(it);
+  return true;
+}
+
+bool CuptiCallbackAPI::enableCallback(
+    CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
+#ifdef HAS_CUPTI
+  if (initSuccess_) {
+    lastCuptiStatus_ = CUPTI_CALL_NOWARN(
+        cuptiEnableCallback(1, subscriber_, domain, cbid));
+    return (lastCuptiStatus_ == CUPTI_SUCCESS);
+  }
+#endif
+  return false;
+}
+
+bool CuptiCallbackAPI::disableCallback(
+    CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
+#ifdef HAS_CUPTI
+  if (initSuccess_) {
+    lastCuptiStatus_ = CUPTI_CALL_NOWARN(
+        cuptiEnableCallback(0, subscriber_, domain, cbid));
+    return (lastCuptiStatus_ == CUPTI_SUCCESS);
+  }
+#endif
+  return false;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiCallbackAPI.h
+++ b/libkineto/src/CuptiCallbackAPI.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#ifdef HAS_CUPTI
+#include <cupti.h>
+#endif
+#include <array>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <set>
+
+namespace KINETO_NAMESPACE {
+
+using namespace libkineto;
+
+
+/* CuptiCallbackAPI : Provides an abstraction over CUPTI callback
+ *  interface. This enables various callback functions to be registered
+ *  with this class. The class registers a global callback handler that
+ *  redirects to the respective callbacks.
+ *
+ *  Note: one design choice we made is to only support simple function pointers
+ *  in order to speed up the implementation for fast path.
+ */
+
+#ifndef HAS_CUPTI
+enum CUpti_CallbackDomain {
+  CUPTI_CB_DOMAIN_RESOURCE,
+  CUPTI_CB_DOMAIN_RUNTIME_API,
+};
+enum CUpti_CallbackData {
+  CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+  CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
+  CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
+};
+
+using CUpti_CallbackId = size_t;
+#endif
+
+using CuptiCallbackFn = void(*)(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo);
+
+
+class CuptiCallbackAPI {
+
+ public:
+
+  /* Global list of supported callback ids
+   *  use the class namespace to avoid confusing with CUPTI enums*/
+  enum CuptiCallBackID {
+    CUDA_LAUNCH_KERNEL =  0,
+    // can possibly support more callback ids per domain
+    //
+    __RUNTIME_CB_DOMAIN_START = CUDA_LAUNCH_KERNEL,
+
+    // Callbacks under Resource CB domain
+    RESOURCE_CONTEXT_CREATED,
+    RESOURCE_CONTEXT_DESTROYED,
+
+    __RUNTIME_CB_DOMAIN_END = RESOURCE_CONTEXT_CREATED,
+    __RESOURCE_CB_DOMAIN_START = RESOURCE_CONTEXT_CREATED,
+
+    __RESOURCE_CB_DOMAIN_END = RESOURCE_CONTEXT_DESTROYED + 1,
+  };
+
+
+  CuptiCallbackAPI(const CuptiCallbackAPI&) = delete;
+  CuptiCallbackAPI& operator=(const CuptiCallbackAPI&) = delete;
+
+  static CuptiCallbackAPI& singleton();
+
+  bool initSuccess() const {
+    return initSuccess_;
+  }
+
+#ifdef HAS_CUPTI
+  CUptiResult getCuptiStatus() const {
+    return lastCuptiStatus_;
+  }
+#endif
+
+  bool registerCallback(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid,
+    CuptiCallbackFn cbfn);
+
+  // returns false if callback was not found
+  bool deleteCallback(
+    CUpti_CallbackDomain domain,
+    CuptiCallBackID cbid,
+    CuptiCallbackFn cbfn);
+
+  bool enableCallback(CUpti_CallbackDomain domain, CUpti_CallbackId cbid);
+  bool disableCallback(CUpti_CallbackDomain domain, CUpti_CallbackId cbid);
+
+
+  // Please do not use this method. This has to be exposed as public
+  // so it is accessible from the callback handler
+  void __callback_switchboard(
+      CUpti_CallbackDomain domain,
+      CUpti_CallbackId cbid,
+      const CUpti_CallbackData* cbInfo);
+
+ private:
+
+  explicit CuptiCallbackAPI();
+
+  // For callback table design overview see the .cpp file
+  using CallbackList = std::list<CuptiCallbackFn>;
+
+  // level 2 tables sizes are known at compile time
+  constexpr static size_t RUNTIME_CB_DOMAIN_SIZE
+    = (__RUNTIME_CB_DOMAIN_END - __RUNTIME_CB_DOMAIN_START);
+
+  constexpr static size_t RESOURCE_CB_DOMAIN_SIZE
+    = (__RESOURCE_CB_DOMAIN_END - __RESOURCE_CB_DOMAIN_START);
+
+  // level 1 table is a struct
+  struct CallbackTable {
+    std::array<CallbackList, RUNTIME_CB_DOMAIN_SIZE> runtime;
+    std::array<CallbackList, RESOURCE_CB_DOMAIN_SIZE> resource;
+
+    CallbackList* lookup(CUpti_CallbackDomain domain, CuptiCallBackID cbid);
+  };
+
+  CallbackTable callbacks_;
+  bool initSuccess_ = false;
+
+#ifdef HAS_CUPTI
+  CUptiResult lastCuptiStatus_;
+  CUpti_SubscriberHandle subscriber_;
+#endif
+};
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/cupti_call.h
+++ b/libkineto/src/cupti_call.h
@@ -32,7 +32,7 @@
 
 #else
 
-#define CUPTI_CALL(call)
-#define CUPTI_CALL_NOWARN(call)
+#define CUPTI_CALL(call) call
+#define CUPTI_CALL_NOWARN(call) call
 
 #endif // HAS_CUPTI

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -31,6 +31,7 @@
 #include "ActivityProfilerProxy.h"
 #include "Config.h"
 #ifdef HAS_CUPTI
+#include "CuptiCallbackAPI.h"
 #include "EventProfilerController.h"
 #endif
 #include "cupti_call.h"
@@ -44,8 +45,16 @@ namespace KINETO_NAMESPACE {
 static bool initialized = false;
 static std::mutex initMutex;
 
-static void initProfilers(CUcontext ctx) {
+static void initProfilers(
+    CUpti_CallbackDomain /*domain*/,
+    CUpti_CallbackId /*cbid*/,
+    const CUpti_CallbackData* cbInfo) {
+  CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
+  CUcontext ctx = d->context;
+
+  VLOG(0) << "CUDA Context created";
   std::lock_guard<std::mutex> lock(initMutex);
+
   if (!initialized) {
     libkineto::api().initProfilerIfRegistered();
     initialized = true;
@@ -60,7 +69,14 @@ static void initProfilers(CUcontext ctx) {
   }
 }
 
-static void stopProfiler(CUcontext ctx) {
+static void stopProfiler(
+    CUpti_CallbackDomain /*domain*/,
+    CUpti_CallbackId /*cbid*/,
+    const CUpti_CallbackData* cbInfo) {
+  CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
+  CUcontext ctx = d->context;
+
+  LOG(INFO) << "CUDA Context destroyed";
   std::lock_guard<std::mutex> lock(initMutex);
   EventProfilerController::stop(ctx);
 }
@@ -72,61 +88,37 @@ static void stopProfiler(CUcontext ctx) {
 using namespace KINETO_NAMESPACE;
 extern "C" {
 
-#ifdef HAS_CUPTI
-static void CUPTIAPI callback(
-    void* /* unused */,
-    CUpti_CallbackDomain domain,
-    CUpti_CallbackId cbid,
-    const CUpti_CallbackData* cbInfo) {
-  VLOG(0) << "Callback: domain = " << domain << ", cbid = " << cbid;
-
-  if (domain == CUPTI_CB_DOMAIN_RESOURCE) {
-    CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
-    if (cbid == CUPTI_CBID_RESOURCE_CONTEXT_CREATED) {
-      VLOG(0) << "CUDA Context created";
-      initProfilers(d->context);
-    } else if (cbid == CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING) {
-      VLOG(0) << "CUDA Context destroyed";
-      stopProfiler(d->context);
-    }
-  }
-}
-#endif // HAS_CUPTI
-
 // Return true if no CUPTI errors occurred during init
 bool libkineto_init(bool cpuOnly, bool logOnError) {
   bool success = true;
 #ifdef HAS_CUPTI
   if (!cpuOnly) {
-    CUpti_SubscriberHandle subscriber;
-    CUptiResult status = CUPTI_ERROR_UNKNOWN;
     // libcupti will be lazily loaded on this call.
     // If it is not available (e.g. CUDA is not installed),
     // then this call will return an error and we just abort init.
-    status = CUPTI_CALL_NOWARN(
-        cuptiSubscribe(&subscriber, (CUpti_CallbackFunc)callback, nullptr));
-    if (status == CUPTI_SUCCESS) {
-      status = CUPTI_CALL_NOWARN(
-          cuptiEnableCallback(
-              1,
-              subscriber,
-              CUPTI_CB_DOMAIN_RESOURCE,
-              CUPTI_CBID_RESOURCE_CONTEXT_CREATED));
+    auto& cbapi = CuptiCallbackAPI::singleton();
+    bool status = false;
 
-      if (status == CUPTI_SUCCESS) {
-        status = CUPTI_CALL_NOWARN(
-            cuptiEnableCallback(
-                1,
-                subscriber,
-                CUPTI_CB_DOMAIN_RESOURCE,
-                CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING));
+    if (cbapi.initSuccess()){
+      const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RESOURCE;
+      status = cbapi.registerCallback(
+          domain, CuptiCallbackAPI::RESOURCE_CONTEXT_CREATED, initProfilers);
+      status = status && cbapi.registerCallback(
+          domain, CuptiCallbackAPI::RESOURCE_CONTEXT_DESTROYED, stopProfiler);
+
+      if (status) {
+        status = cbapi.enableCallback(
+            domain, CuptiCallbackAPI::RESOURCE_CONTEXT_CREATED);
+        status = status && cbapi.enableCallback(
+            domain, CuptiCallbackAPI::RESOURCE_CONTEXT_DESTROYED);
         }
     }
-    if (status != CUPTI_SUCCESS) {
+
+    if (!cbapi.initSuccess() || !status) {
       success = false;
       cpuOnly = true;
       if (logOnError) {
-        CUPTI_CALL(status);
+        CUPTI_CALL(cbapi.getCuptiStatus());
         LOG(WARNING) << "CUPTI initialization failed - "
                      << "CUDA profiler activities will be missing";
         LOG(INFO) << "If you see CUPTI_ERROR_INSUFFICIENT_PRIVILEGES, refer to "

--- a/libkineto/test/CuptiCallbackAPITest.cpp
+++ b/libkineto/test/CuptiCallbackAPITest.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "src/Logger.h"
+#include "src/CuptiCallbackAPI.h"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono;
+using namespace KINETO_NAMESPACE;
+using namespace libkineto;
+
+const size_t some_data = 42;
+
+std::atomic<int> simple_cb_calls = 0;
+
+void simple_cb(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo) {
+
+  // simple arg check
+  EXPECT_EQ(domain, CUPTI_CB_DOMAIN_RUNTIME_API);
+  EXPECT_EQ(cbid, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000);
+  EXPECT_EQ(*reinterpret_cast<const size_t*>(cbInfo), some_data);
+
+  simple_cb_calls++;
+}
+
+void atomic_cb(
+    CUpti_CallbackDomain /*domain*/,
+    CUpti_CallbackId /*cbid*/,
+    const CUpti_CallbackData* /*cbInfo)*/) {
+  // do some atomics in a loop
+  for (int i = 0; i < 1000; i++) {
+    // would have used release consistency but this is fine
+    simple_cb_calls++;
+  }
+}
+
+void empty_cb(
+    CUpti_CallbackDomain /*domain*/,
+    CUpti_CallbackId /*cbid*/,
+    const CUpti_CallbackData* /*cbInfo*/) {
+}
+
+TEST(CuptiCallbackAPITest, SimpleTest) {
+  auto& api = CuptiCallbackAPI::singleton();
+
+  auto addSimpleCallback = [&]() -> bool {
+    bool ret = api.registerCallback(
+        CUPTI_CB_DOMAIN_RUNTIME_API,
+        CuptiCallbackAPI::CUDA_LAUNCH_KERNEL,
+        &simple_cb
+    );
+    return ret;
+  };
+  EXPECT_TRUE(addSimpleCallback()) << "Failed to add callback";
+
+  // duplicate add should be okay
+  EXPECT_TRUE(addSimpleCallback()) << "Failed to re-add callback";
+
+  simple_cb_calls = 0;
+
+  // simulate callback
+  api.__callback_switchboard(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+      reinterpret_cast<const CUpti_CallbackData*>(&some_data));
+
+  EXPECT_EQ(simple_cb_calls, 1);
+
+  bool ret = api.deleteCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CuptiCallbackAPI::CUDA_LAUNCH_KERNEL,
+      &simple_cb
+  );
+
+  EXPECT_TRUE(ret) << "Failed to remove callback";
+
+  ret = api.deleteCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CuptiCallbackAPI::CUDA_LAUNCH_KERNEL,
+      &atomic_cb
+  );
+
+  EXPECT_FALSE(ret) << "oops! deleted a callback that was never added";
+}
+
+TEST(CuptiCallbackAPITest, AllCallbacks) {
+  auto& api = CuptiCallbackAPI::singleton();
+
+  auto testCallback = [&](
+      CUpti_CallbackDomain domain,
+      CUpti_CallbackId cbid,
+      CuptiCallbackAPI::CuptiCallBackID kineto_cbid) -> bool {
+
+    bool ret = api.registerCallback(domain, kineto_cbid, atomic_cb);
+    EXPECT_TRUE(ret) << "Failed to add callback";
+
+    if (!ret) {
+      return false;
+    }
+
+    simple_cb_calls = 0;
+    api.__callback_switchboard(domain, cbid, nullptr);
+    EXPECT_EQ(simple_cb_calls, 1000);
+    ret = simple_cb_calls == 1000;
+
+    EXPECT_TRUE(api.deleteCallback(domain, kineto_cbid, atomic_cb));
+
+    return ret;
+  };
+
+  EXPECT_TRUE(
+      testCallback(
+        CUPTI_CB_DOMAIN_RESOURCE,
+        CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
+        CuptiCallbackAPI::RESOURCE_CONTEXT_CREATED))
+    << "Failed to run callback for RESOURCE_CONTEXT_CREATED";
+
+  EXPECT_TRUE(
+      testCallback(
+        CUPTI_CB_DOMAIN_RESOURCE,
+        CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
+        CuptiCallbackAPI::RESOURCE_CONTEXT_DESTROYED))
+    << "Failed to run callback for RESOURCE_CONTEXT_DESTROYED";
+
+  EXPECT_TRUE(
+      testCallback(
+        CUPTI_CB_DOMAIN_RUNTIME_API,
+        CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+        CuptiCallbackAPI::CUDA_LAUNCH_KERNEL))
+    << "Failed to run callback for CUDA_LAUNCH_KERNEL";
+
+}
+
+TEST(CuptiCallbackAPITest, ContentionTest) {
+  auto& api = CuptiCallbackAPI::singleton();
+  const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RUNTIME_API;
+  const CUpti_CallbackId cbid = CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000;
+  const CuptiCallbackAPI::CuptiCallBackID kineto_cbid =
+    CuptiCallbackAPI::CUDA_LAUNCH_KERNEL;
+
+  bool ret = api.registerCallback(domain, kineto_cbid, empty_cb);
+  EXPECT_TRUE(ret) << "Failed to add callback";
+
+  const int iters = 10000;
+  const int num_readers = 8;
+
+  simple_cb_calls = 0;
+
+  // simulate callbacks being executed on multiple threads in parallel
+  //  during this interval add a new atomic_callback.
+  //  this test ensured mutual exclusion is working fine
+  auto read_fn = [&](int tid){
+    auto start_ts = high_resolution_clock::now();
+    for (int i = 0; i < iters; i++) {
+      api.__callback_switchboard(domain, cbid, nullptr);
+    }
+    auto runtime_ms = duration_cast<milliseconds>(
+      high_resolution_clock::now() - start_ts);
+    LOG(INFO) << "th " << tid << " done in " << runtime_ms.count() << " ms";
+  };
+
+
+  std::vector<std::thread> read_ths;
+  for (int i = 0; i< num_readers; i++) {
+    read_ths.emplace_back(read_fn, i);
+  }
+
+  ret = api.registerCallback(domain, kineto_cbid, atomic_cb);
+  EXPECT_TRUE(ret) << "Failed to add callback";
+
+  for (auto& t : read_ths) {
+    t.join();
+  }
+
+  //EXPECT_GT(simple_cb_calls, 0)
+  //  << "Atomic callback should have been called at least once.";
+
+  api.deleteCallback(domain, kineto_cbid, empty_cb);
+  api.deleteCallback(domain, kineto_cbid, atomic_cb);
+}
+
+TEST(CuptiCallbackAPITest, Bechmark) {
+
+  constexpr int iters = 1000;
+  // atomic bench a number of times to get a baseline
+
+  const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RUNTIME_API;
+  const CUpti_CallbackId cbid = CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000;
+  const CuptiCallbackAPI::CuptiCallBackID kineto_cbid =
+    CuptiCallbackAPI::CUDA_LAUNCH_KERNEL;
+
+  LOG(INFO) << "Iteration count = " << iters;
+
+  const bool use_empty = true;
+  auto cbfn = use_empty ? &empty_cb : &atomic_cb;
+
+  // warmup
+  for (int i = 0; i < 50; i++) {
+    (*cbfn)(domain, cbid, nullptr);
+  }
+
+  auto start_ts = high_resolution_clock::now();
+  for (int i = 0; i < iters; i++) {
+    (*cbfn)(domain, cbid, nullptr);
+  }
+  auto delta_baseline_ns = duration_cast<nanoseconds>(
+      high_resolution_clock::now() - start_ts);
+  LOG(INFO) << "Baseline runtime  = " << delta_baseline_ns.count() << " ns";
+
+
+  auto& api = CuptiCallbackAPI::singleton();
+  bool ret = api.registerCallback(domain, kineto_cbid, cbfn);
+  EXPECT_TRUE(ret) << "Failed to add callback";
+
+  // warmup
+  for (int i = 0; i < 50; i++) {
+    api.__callback_switchboard(domain, cbid, nullptr);
+  }
+
+  start_ts = high_resolution_clock::now();
+  for (int i = 0; i < iters; i++) {
+    api.__callback_switchboard(domain, cbid, nullptr);
+  }
+
+  auto delta_callback_ns = duration_cast<nanoseconds>(
+      high_resolution_clock::now() - start_ts);
+  LOG(INFO) << "Callback runtime  = " << delta_callback_ns.count() << " ns";
+
+  LOG(INFO) << "Callback runtime per iteration = " <<
+    (delta_callback_ns.count() - delta_baseline_ns.count()) / (double) iters
+    << " ns";
+
+}


### PR DESCRIPTION
Summary:
# Summary
CUPTI only permits one function to be registered to handle callbacks. In this change we add a level or indirection for callbacks
thus enabling any profilers in Kineto to access cupti callback interface.

## Use cases
1. Tracking CUDA context create/destroy for initializing the EventProfiler. Migrated this to use the new CallbackAPI module.
2. For Cupti Range profiler we can use callbacks for logging kernel names.

In the future we can also envision a Callback profiler to track copies/kernel arguments etc.

## Design decisions
1. One design choice we made is to only support simple function pointers in order to speed up the implementation for fast path.
2. __cupti_callback_exchange() function does the indirection. To keep it really lightweight it uses jump tables kind of structure making it a bit verbose but performant.

Differential Revision: D31704969

