### PR TITLE
Kineto: Add Logger Listeners to support saving logs to traces

### DIFF
--- a/libkineto/include/ILoggerObserver.h
+++ b/libkineto/include/ILoggerObserver.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if !USE_GOOGLE_LOG
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace KINETO_NAMESPACE {
+
+enum LoggerOutputType {
+  VERBOSE = 0,
+  INFO = 1,
+  WARNING = 2,
+  ERROR = 3,
+  ENUM_COUNT = 4
+};
+
+const char* toString(LoggerOutputType t);
+LoggerOutputType toLoggerOutputType(const std::string& str);
+
+constexpr int LoggerTypeCount = (int) LoggerOutputType::ENUM_COUNT;
+
+class ILoggerObserver {
+ public:
+  virtual ~ILoggerObserver() = default;
+  virtual void write(const std::string& message, LoggerOutputType ot) = 0;
+  virtual const std::map<LoggerOutputType, std::vector<std::string>> extractCollectorMetadata() {
+    return std::map<LoggerOutputType, std::vector<std::string>>();
+  }
+
+};
+
+} // namespace KINETO_NAMESPACE
+
+#endif // !USE_GOOGLE_LOG

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -21,12 +21,15 @@
 #include <unordered_set>
 #include <vector>
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "ThreadUtil.h"
 #include "TraceSpan.h"
 #include "libkineto.h"
 #include "output_base.h"
 #include "GenericTraceActivity.h"
 #include "IActivityProfiler.h"
+#include "LoggerCollector.h"
 
 namespace KINETO_NAMESPACE {
 
@@ -355,6 +358,9 @@ class CuptiActivityProfiler {
 
   // a vector of active profiler plugin sessions
   std::vector<std::unique_ptr<IActivityProfilerSession>> sessions_;
+
+  // LoggerObserver to collect all LOGs during the trace
+  std::unique_ptr<LoggerCollector> loggerCollectorMetadata_;
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/ILoggerObserver.cpp
+++ b/libkineto/src/ILoggerObserver.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ILoggerObserver.h"
+
+#if !USE_GOOGLE_LOG
+
+#include <array>
+#include <fmt/format.h>
+
+namespace KINETO_NAMESPACE {
+
+struct LoggerTypeName {
+  constexpr LoggerTypeName(const char* n, LoggerOutputType t) : name(n), type(t) {};
+  const char* name;
+  LoggerOutputType type;
+};
+
+static constexpr std::array<LoggerTypeName, LoggerTypeCount + 1> LoggerMap{{
+    {"VERBOSE", LoggerOutputType::VERBOSE},
+    {"INFO", LoggerOutputType::INFO},
+    {"WARNING", LoggerOutputType::WARNING},
+    {"ERROR", LoggerOutputType::ERROR},
+    {"???", LoggerOutputType::ENUM_COUNT}
+}};
+
+static constexpr bool matchingOrder(int idx = 0) {
+  return LoggerMap[idx].type == LoggerOutputType::ENUM_COUNT ||
+    ((idx == (int) LoggerMap[idx].type) && matchingOrder(idx + 1));
+}
+static_assert(matchingOrder(), "LoggerTypeName map is out of order");
+
+const char* toString(LoggerOutputType t) {
+  if(t < VERBOSE || t >= ENUM_COUNT) {
+    return LoggerMap[ENUM_COUNT].name;
+  }
+  return LoggerMap[(int)t].name;
+}
+
+LoggerOutputType toLoggerOutputType(const std::string& str) {
+  for (int i = 0; i < LoggerTypeCount; i++) {
+    if (str == LoggerMap[i].name) {
+      return LoggerMap[i].type;
+    }
+  }
+  throw std::invalid_argument(fmt::format("Invalid activity type: {}", str));
+}
+
+} // namespace KINETO_NAMESPACE
+
+
+#endif // !USE_GOOGLE_LOG

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -5,7 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "Logger.h"
+#include "ILoggerObserver.h"
 
 #ifndef USE_GOOGLE_LOG
 
@@ -13,6 +16,8 @@
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <list>
+#include <mutex>
 #include <time.h>
 
 #include <fmt/chrono.h>
@@ -20,31 +25,23 @@
 
 #include "ThreadUtil.h"
 
-namespace libkineto {
+namespace KINETO_NAMESPACE {
 
 std::atomic_int Logger::severityLevel_{VERBOSE};
 std::atomic_int Logger::verboseLogLevel_{-1};
 std::atomic<uint64_t> Logger::verboseLogModules_{~0ull};
+static std::list<ILoggerObserver*>& LoggerObservers() {
+  static std::list<ILoggerObserver*> observers;
+  return observers;
+}
+static std::mutex& mutex() {
+  static std::mutex mutex_;
+  return mutex_;
+}
 
 Logger::Logger(int severity, int line, const char* filePath, int errnum)
-    : buf_(), out_(LIBKINETO_DBG_STREAM), errnum_(errnum) {
-  switch (severity) {
-    case VERBOSE:
-      buf_ << "V:";
-      break;
-    case INFO:
-      buf_ << "INFO:";
-      break;
-    case WARNING:
-      buf_ << "WARNING:";
-      break;
-    case ERROR:
-      buf_ << "ERROR:";
-      break;
-    default:
-      buf_ << "???:";
-      break;
-  }
+    : buf_(), out_(LIBKINETO_DBG_STREAM), errnum_(errnum), messageSeverity_(severity) {
+  buf_ << toString((LoggerOutputType) severity) << ":";
 
   const auto tt =
       std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
@@ -61,8 +58,15 @@ Logger::~Logger() {
     buf_ << " : " << strerror_r(errnum_, buf, sizeof(buf));
   }
 #endif
-  buf_ << std::endl;
-  out_ << buf_.str();
+
+  // Output to observers. Current Severity helps keep track of which bucket the output goes.
+  for (auto& observer : LoggerObservers()) {
+    std::lock_guard<std::mutex> guard(mutex());
+    observer->write(buf_.str(), (LoggerOutputType) messageSeverity_);
+  }
+
+  // Finally, print to terminal or console.
+  out_ << buf_.str() << std::endl;
 }
 
 void Logger::setVerboseLogModules(const std::vector<std::string>& modules) {
@@ -77,6 +81,20 @@ void Logger::setVerboseLogModules(const std::vector<std::string>& modules) {
   verboseLogModules_ = mask;
 }
 
-} // namespace libkineto
+void Logger::addLoggerObserver(ILoggerObserver* observer) {
+  std::lock_guard<std::mutex> guard(mutex());
+  LoggerObservers().push_back(observer);
+}
+
+void Logger::removeLoggerObserver(ILoggerObserver* observer) {
+  std::lock_guard<std::mutex> guard(mutex());
+  auto& LoggerObservers_ = LoggerObservers();
+  auto it = std::find(LoggerObservers_.begin(), LoggerObservers_.end(), observer);
+  if (it != LoggerObservers_.end()) {
+    LoggerObservers_.erase(it);
+  }
+}
+
+} // namespace KINETO_NAMESPACE
 
 #endif // USE_GOOGLE_LOG

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -30,22 +30,22 @@
 #else // !USE_GOOGLE_LOG
 #include <stdio.h>
 #include <atomic>
+#include <map>
 #include <ostream>
 #include <string>
 #include <sstream>
 #include <vector>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ILoggerObserver.h"
 
 #ifdef _MSC_VER
 // unset a predefined ERROR (windows)
 #undef ERROR
 #endif // _MSC_VER
 
-namespace libkineto {
-
-constexpr int VERBOSE = 0;
-constexpr int INFO = 1;
-constexpr int WARNING = 2;
-constexpr int ERROR = 3;
+namespace KINETO_NAMESPACE {
 
 class Logger {
  public:
@@ -101,10 +101,15 @@ class Logger {
     return verboseLogModules_;
   }
 
+  static void addLoggerObserver(ILoggerObserver* observer);
+
+  static void removeLoggerObserver(ILoggerObserver* observer);
+
  private:
   std::stringstream buf_;
   std::ostream& out_;
   int errnum_;
+  int messageSeverity_;
   static std::atomic_int severityLevel_;
   static std::atomic_int verboseLogLevel_;
   static std::atomic<uint64_t> verboseLogModules_;
@@ -116,7 +121,7 @@ class VoidLogger {
   void operator&(std::ostream&) {}
 };
 
-} // namespace libkineto
+} // namespace KINETO_NAMESPACE
 
 #ifdef LOG // Undefine in case these are already defined (quite likely)
 #undef LOG

--- a/libkineto/src/LoggerCollector.h
+++ b/libkineto/src/LoggerCollector.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if !USE_GOOGLE_LOG
+
+#include <map>
+#include <vector>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ILoggerObserver.h"
+
+namespace KINETO_NAMESPACE {
+
+class LoggerCollector : public ILoggerObserver {
+ public:
+  LoggerCollector() : buckets_() {}
+
+  void write(const std::string& message, LoggerOutputType ot = ERROR) override {
+    buckets_[ot].push_back(message);
+  }
+
+  const std::map<LoggerOutputType, std::vector<std::string>> extractCollectorMetadata() override {
+    return buckets_;
+  }
+
+ protected:
+  std::map<LoggerOutputType, std::vector<std::string>> buckets_;
+
+};
+
+} // namespace KINETO_NAMESPACE
+
+#endif // !USE_GOOGLE_LOG

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -87,7 +87,8 @@ class ActivityLogger {
   virtual void finalizeTrace(
       const KINETO_NAMESPACE::Config& config,
       std::unique_ptr<ActivityBuffers> buffers,
-      int64_t endTime) = 0;
+      int64_t endTime,
+      std::unordered_map<std::string, std::vector<std::string>>& metadata) = 0;
 
  protected:
   ActivityLogger() = default;

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -19,7 +19,7 @@
 #include "GenericTraceActivity.h"
 #include "output_base.h"
 
-namespace libkineto {
+namespace KINETO_NAMESPACE {
   // Previous declaration of TraceSpan is struct. Must match the same here.
   struct TraceSpan;
 }
@@ -60,7 +60,8 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   void finalizeTrace(
       const Config& config,
       std::unique_ptr<ActivityBuffers> buffers,
-      int64_t endTime) override;
+      int64_t endTime,
+      std::unordered_map<std::string, std::vector<std::string>>& metadata) override;
 
   std::string traceFileName() const {
     return fileName_;
@@ -83,6 +84,8 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   void handleGenericInstantEvent(const ITraceActivity& op);
 
   void handleGenericLink(const ITraceActivity& activity);
+
+  void metadataToJSON(const std::unordered_map<std::string, std::string>& metadata);
 
   std::string fileName_;
   std::ofstream traceOf_;

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -90,7 +90,8 @@ class MemoryTraceLogger : public ActivityLogger {
   void finalizeTrace(
       const Config& config,
       std::unique_ptr<ActivityBuffers> buffers,
-      int64_t endTime) override {
+      int64_t endTime,
+      std::unordered_map<std::string, std::vector<std::string>>& metadata) override {
     buffers_ = std::move(buffers);
     endTime_ = endTime;
   }
@@ -114,7 +115,7 @@ class MemoryTraceLogger : public ActivityLogger {
       logger.handleTraceSpan(cpu_trace_buffer->span);
     }
     // Hold on to the buffers
-    logger.finalizeTrace(*config_, nullptr, endTime_);
+    logger.finalizeTrace(*config_, nullptr, endTime_, loggerMetadata_);
   }
 
  private:
@@ -127,6 +128,7 @@ class MemoryTraceLogger : public ActivityLogger {
   std::vector<std::pair<ResourceInfo, int64_t>> resourceInfoList_;
   std::unique_ptr<ActivityBuffers> buffers_;
   std::unordered_map<std::string, std::string> metadata_;
+  std::unordered_map<std::string, std::vector<std::string>> loggerMetadata_;
   int64_t endTime_{0};
 };
 


### PR DESCRIPTION
Summary: Add the architecture for the LoggerListenerBase, which will be extended to saving logs to the Console and Trace metadata. This will be extended in the future to saving logs to Scuba to enable health monitoring via UST.

Differential Revision: D32039329

