### PR TITLE
add PYTHON_FUNCTION activity type

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -23,6 +23,7 @@ enum class ActivityType {
     CUDA_RUNTIME, // host side cuda runtime events
     GLOW_RUNTIME, // host side glow runtime events
     CPU_INSTANT_EVENT, // host side point-like events
+    PYTHON_FUNCTION,
     ENUM_COUNT
 };
 

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -27,6 +27,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
     {"cuda_runtime", ActivityType::CUDA_RUNTIME},
     {"glow_runtime", ActivityType::GLOW_RUNTIME},
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
+    {"python_function", ActivityType::PYTHON_FUNCTION},
     {"ENUM_COUNT", ActivityType::ENUM_COUNT}
 }};
 

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -86,6 +86,7 @@ TEST(ParseTest, ActivityTypes) {
   EXPECT_EQ(cfg.selectedActivityTypes(),
     std::set<ActivityType>({ActivityType::CPU_OP,
                             ActivityType::CPU_INSTANT_EVENT,
+                            ActivityType::PYTHON_FUNCTION,
                             ActivityType::USER_ANNOTATION,
                             ActivityType::GPU_USER_ANNOTATION,
                             ActivityType::GPU_MEMCPY,


### PR DESCRIPTION
Add new event type for https://github.com/pytorch/pytorch/pull/67407

I patched this change into the `third_party/kineto` folder of my pytorch checkout and events still show up on the chrome trace. (With just a couple tweaks.) So we can land this and then I'll update the submodule ref in pytorch to pick it up before we land the tracer.