### PR TITLE
Refactor 2/n: Rename CuptiInterface to CuptiApi

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -12,9 +12,11 @@ def get_libkineto_api_srcs():
 def get_libkineto_cupti_srcs(with_api = True):
     return [
         "src/CudaDeviceProperties.cpp",
+        "src/CuptiActivityApi.cpp",
         "src/CuptiActivityPlatform.cpp",
-        "src/CuptiEventInterface.cpp",
-        "src/CuptiMetricInterface.cpp",
+        "src/CuptiEventApi.cpp",
+        "src/CuptiMetricApi.cpp",
+        "src/Demangle.cpp",
         "src/EventProfiler.cpp",
         "src/EventProfilerController.cpp",
         "src/WeakSymbols.cpp",
@@ -23,7 +25,7 @@ def get_libkineto_cupti_srcs(with_api = True):
 
 def get_libkineto_roctracer_srcs(with_api = True):
     return [
-        "src/RoctracerActivityInterface.cpp",
+        "src/RoctracerActivityApi.cpp",
     ] + (get_libkineto_cpu_only_srcs(with_api))
 
 def get_libkineto_cpu_only_srcs(with_api = True):
@@ -35,7 +37,7 @@ def get_libkineto_cpu_only_srcs(with_api = True):
         "src/ActivityType.cpp",
         "src/Config.cpp",
         "src/ConfigLoader.cpp",
-        "src/CuptiActivityInterface.cpp",
+        "src/CuptiActivityApi.cpp",
         "src/Demangle.cpp",
         "src/GenericTraceActivity.cpp",
         "src/Logger.cpp",

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -12,9 +12,9 @@
 
 #include "ActivityLoggerFactory.h"
 #include "ActivityTrace.h"
-#include "CuptiActivityInterface.h"
+#include "CuptiActivityApi.h"
 #ifdef HAS_ROCTRACER
-#include "RoctracerActivityInterface.h"
+#include "RoctracerActivityApi.h"
 #endif
 #include "ThreadUtil.h"
 #include "output_json.h"
@@ -33,10 +33,10 @@ ActivityProfilerController::ActivityProfilerController(
     : configLoader_(configLoader) {
 #ifdef HAS_ROCTRACER
   profiler_ = std::make_unique<CuptiActivityProfiler>(
-      RoctracerActivityInterface::singleton(), cpuOnly);
+      RoctracerActivityApi::singleton(), cpuOnly);
 #else
   profiler_ = std::make_unique<CuptiActivityProfiler>(
-      CuptiActivityInterface::singleton(), cpuOnly);
+      CuptiActivityApi::singleton(), cpuOnly);
 #endif
   configLoader_.addHandler(ConfigLoader::ConfigKind::ActivityProfiler, this);
 }

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -17,7 +17,7 @@
 #include "ActivityProfilerInterface.h"
 #include "ActivityTraceInterface.h"
 #include "ConfigLoader.h"
-#include "CuptiActivityInterface.h"
+#include "CuptiActivityApi.h"
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -9,7 +9,7 @@
 
 #include "ActivityProfilerController.h"
 #include "Config.h"
-#include "CuptiActivityInterface.h"
+#include "CuptiActivityApi.h"
 #include <chrono>
 
 namespace KINETO_NAMESPACE {
@@ -62,23 +62,23 @@ bool ActivityProfilerProxy::isActive() {
 }
 
 void ActivityProfilerProxy::pushCorrelationId(uint64_t id) {
-  CuptiActivityInterface::pushCorrelationID(id,
-    CuptiActivityInterface::CorrelationFlowType::Default);
+  CuptiActivityApi::pushCorrelationID(id,
+    CuptiActivityApi::CorrelationFlowType::Default);
 }
 
 void ActivityProfilerProxy::popCorrelationId() {
-  CuptiActivityInterface::popCorrelationID(
-    CuptiActivityInterface::CorrelationFlowType::Default);
+  CuptiActivityApi::popCorrelationID(
+    CuptiActivityApi::CorrelationFlowType::Default);
 }
 
 void ActivityProfilerProxy::pushUserCorrelationId(uint64_t id) {
-  CuptiActivityInterface::pushCorrelationID(id,
-    CuptiActivityInterface::CorrelationFlowType::User);
+  CuptiActivityApi::pushCorrelationID(id,
+    CuptiActivityApi::CorrelationFlowType::User);
 }
 
 void ActivityProfilerProxy::popUserCorrelationId() {
-  CuptiActivityInterface::popCorrelationID(
-    CuptiActivityInterface::CorrelationFlowType::User);
+  CuptiActivityApi::popCorrelationID(
+    CuptiActivityApi::CorrelationFlowType::User);
 }
 
 void ActivityProfilerProxy::transferCpuTrace(

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "CuptiActivityInterface.h"
+#include "CuptiActivityApi.h"
 
 #include <assert.h>
 #include <chrono>
@@ -23,12 +23,12 @@ namespace KINETO_NAMESPACE {
 // Consider putting this on huge pages?
 constexpr size_t kBufSize(2 * 1024 * 1024);
 
-CuptiActivityInterface& CuptiActivityInterface::singleton() {
-  static CuptiActivityInterface instance;
+CuptiActivityApi& CuptiActivityApi::singleton() {
+  static CuptiActivityApi instance;
   return instance;
 }
 
-void CuptiActivityInterface::pushCorrelationID(int id, CorrelationFlowType type) {
+void CuptiActivityApi::pushCorrelationID(int id, CorrelationFlowType type) {
 #ifdef HAS_CUPTI
   if (!singleton().externalCorrelationEnabled_) {
     return;
@@ -46,7 +46,7 @@ void CuptiActivityInterface::pushCorrelationID(int id, CorrelationFlowType type)
 #endif
 }
 
-void CuptiActivityInterface::popCorrelationID(CorrelationFlowType type) {
+void CuptiActivityApi::popCorrelationID(CorrelationFlowType type) {
 #ifdef HAS_CUPTI
   if (!singleton().externalCorrelationEnabled_) {
     return;
@@ -93,7 +93,7 @@ static int getSMCount() {
   return -1;
 }
 
-int CuptiActivityInterface::smCount() {
+int CuptiActivityApi::smCount() {
   static int sm_count = getSMCount();
   return sm_count;
 }
@@ -115,19 +115,19 @@ static bool nextActivityRecord(
   return record != nullptr;
 }
 
-void CuptiActivityInterface::setMaxBufferSize(int size) {
+void CuptiActivityApi::setMaxBufferSize(int size) {
   maxGpuBufferCount_ = 1 + size / kBufSize;
 }
 
 #ifdef HAS_CUPTI
-void CUPTIAPI CuptiActivityInterface::bufferRequestedTrampoline(
+void CUPTIAPI CuptiActivityApi::bufferRequestedTrampoline(
     uint8_t** buffer,
     size_t* size,
     size_t* maxNumRecords) {
   singleton().bufferRequested(buffer, size, maxNumRecords);
 }
 
-void CuptiActivityInterface::bufferRequested(
+void CuptiActivityApi::bufferRequested(
     uint8_t** buffer, size_t* size, size_t* maxNumRecords) {
   std::lock_guard<std::mutex> guard(mutex_);
   if (allocatedGpuTraceBuffers_.size() >= maxGpuBufferCount_) {
@@ -149,7 +149,7 @@ void CuptiActivityInterface::bufferRequested(
 #endif
 
 std::unique_ptr<CuptiActivityBufferMap>
-CuptiActivityInterface::activityBuffers() {
+CuptiActivityApi::activityBuffers() {
   {
     std::lock_guard<std::mutex> guard(mutex_);
     if (allocatedGpuTraceBuffers_.empty()) {
@@ -177,7 +177,7 @@ CuptiActivityInterface::activityBuffers() {
 }
 
 #ifdef HAS_CUPTI
-int CuptiActivityInterface::processActivitiesForBuffer(
+int CuptiActivityApi::processActivitiesForBuffer(
     uint8_t* buf,
     size_t validSize,
     std::function<void(const CUpti_Activity*)> handler) {
@@ -193,7 +193,7 @@ int CuptiActivityInterface::processActivitiesForBuffer(
 }
 #endif
 
-const std::pair<int, int> CuptiActivityInterface::processActivities(
+const std::pair<int, int> CuptiActivityApi::processActivities(
     CuptiActivityBufferMap& buffers,
     std::function<void(const CUpti_Activity*)> handler) {
   std::pair<int, int> res{0, 0};
@@ -208,7 +208,7 @@ const std::pair<int, int> CuptiActivityInterface::processActivities(
   return res;
 }
 
-void CuptiActivityInterface::clearActivities() {
+void CuptiActivityApi::clearActivities() {
   {
     std::lock_guard<std::mutex> guard(mutex_);
     if (allocatedGpuTraceBuffers_.empty()) {
@@ -228,7 +228,7 @@ void CuptiActivityInterface::clearActivities() {
 }
 
 #ifdef HAS_CUPTI
-void CUPTIAPI CuptiActivityInterface::bufferCompletedTrampoline(
+void CUPTIAPI CuptiActivityApi::bufferCompletedTrampoline(
     CUcontext ctx,
     uint32_t streamId,
     uint8_t* buffer,
@@ -237,7 +237,7 @@ void CUPTIAPI CuptiActivityInterface::bufferCompletedTrampoline(
   singleton().bufferCompleted(ctx, streamId, buffer, 0, validSize);
 }
 
-void CuptiActivityInterface::bufferCompleted(
+void CuptiActivityApi::bufferCompleted(
     CUcontext ctx,
     uint32_t streamId,
     uint8_t* buffer,
@@ -273,7 +273,7 @@ void CuptiActivityInterface::bufferCompleted(
 }
 #endif
 
-void CuptiActivityInterface::enableCuptiActivities(
+void CuptiActivityApi::enableCuptiActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_CUPTI
   static bool registered = false;
@@ -307,7 +307,7 @@ void CuptiActivityInterface::enableCuptiActivities(
   stopCollection = false;
 }
 
-void CuptiActivityInterface::disableCuptiActivities(
+void CuptiActivityApi::disableCuptiActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_CUPTI
   for (const auto& activity : selected_activities) {

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -30,20 +30,20 @@ using namespace libkineto;
 using CUpti_Activity = void;
 #endif
 
-class CuptiActivityInterface {
+class CuptiActivityApi {
  public:
   enum CorrelationFlowType {
     Default,
     User
   };
 
-  CuptiActivityInterface() = default;
-  CuptiActivityInterface(const CuptiActivityInterface&) = delete;
-  CuptiActivityInterface& operator=(const CuptiActivityInterface&) = delete;
+  CuptiActivityApi() = default;
+  CuptiActivityApi(const CuptiActivityApi&) = delete;
+  CuptiActivityApi& operator=(const CuptiActivityApi&) = delete;
 
-  virtual ~CuptiActivityInterface() {}
+  virtual ~CuptiActivityApi() {}
 
-  static CuptiActivityInterface& singleton();
+  static CuptiActivityApi& singleton();
 
   virtual int smCount();
   static void pushCorrelationID(int id, CorrelationFlowType type);

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -24,10 +24,10 @@
 #ifdef HAS_CUPTI
 #include "CuptiActivity.h"
 #include "CuptiActivity.tpp"
-#include "CuptiActivityInterface.h"
+#include "CuptiActivityApi.h"
 #endif // HAS_CUPTI
 #ifdef HAS_ROCTRACER
-#include "RoctracerActivityInterface.h"
+#include "RoctracerActivityApi.h"
 #endif
 #include "output_base.h"
 
@@ -116,11 +116,10 @@ bool CuptiActivityProfiler::applyNetFilterInternal(const std::string& name) {
   return false;
 }
 
-// This has dependence on CuptiActivityInterface
 #ifdef HAS_ROCTRACER
-CuptiActivityProfiler::CuptiActivityProfiler(RoctracerActivityInterface& cupti, bool cpuOnly)
+CuptiActivityProfiler::CuptiActivityProfiler(RoctracerActivityApi& cupti, bool cpuOnly)
 #else
-CuptiActivityProfiler::CuptiActivityProfiler(CuptiActivityInterface& cupti, bool cpuOnly)
+CuptiActivityProfiler::CuptiActivityProfiler(CuptiActivityApi& cupti, bool cpuOnly)
 #endif
     : cupti_(cupti),
       flushOverhead_{0, 0},

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -31,13 +31,13 @@
 namespace KINETO_NAMESPACE {
 
 class Config;
-class CuptiActivityInterface;
-class RoctracerActivityInterface;
+class CuptiActivityApi;
+class RoctracerActivityApi;
 
 class CuptiActivityProfiler {
  public:
-  CuptiActivityProfiler(CuptiActivityInterface& cupti, bool cpuOnly);
-  CuptiActivityProfiler(RoctracerActivityInterface& rai, bool cpuOnly);
+  CuptiActivityProfiler(CuptiActivityApi& cupti, bool cpuOnly);
+  CuptiActivityProfiler(RoctracerActivityApi& rai, bool cpuOnly);
   CuptiActivityProfiler(const CuptiActivityProfiler&) = delete;
   CuptiActivityProfiler& operator=(const CuptiActivityProfiler&) = delete;
 
@@ -301,9 +301,9 @@ class CuptiActivityProfiler {
 
   // Calls to CUPTI is encapsulated behind this interface
 #ifdef HAS_ROCTRACER
-  RoctracerActivityInterface& cupti_;		// Design failure here
+  RoctracerActivityApi& cupti_;		// Design failure here
 #else
-  CuptiActivityInterface& cupti_;
+  CuptiActivityApi& cupti_;
 #endif
 
   enum class RunloopState {

--- a/libkineto/src/CuptiEventApi.cpp
+++ b/libkineto/src/CuptiEventApi.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "CuptiEventInterface.h"
+#include "CuptiEventApi.h"
 
 #include <chrono>
 
@@ -17,12 +17,12 @@ using std::vector;
 
 namespace KINETO_NAMESPACE {
 
-CuptiEventInterface::CuptiEventInterface(CUcontext context)
+CuptiEventApi::CuptiEventApi(CUcontext context)
     : context_(context) {
   CUPTI_CALL(cuptiGetDeviceId(context_, (uint32_t*)&device_));
 }
 
-CUpti_EventGroupSets* CuptiEventInterface::createGroupSets(
+CUpti_EventGroupSets* CuptiEventApi::createGroupSets(
     vector<CUpti_EventID>& ids) {
   CUpti_EventGroupSets* group_sets = nullptr;
   CUptiResult res = CUPTI_CALL(cuptiEventGroupSetsCreate(
@@ -37,17 +37,17 @@ CUpti_EventGroupSets* CuptiEventInterface::createGroupSets(
   return group_sets;
 }
 
-void CuptiEventInterface::destroyGroupSets(CUpti_EventGroupSets* sets) {
+void CuptiEventApi::destroyGroupSets(CUpti_EventGroupSets* sets) {
   CUPTI_CALL(cuptiEventGroupSetsDestroy(sets));
 }
 
-bool CuptiEventInterface::setContinuousMode() {
+bool CuptiEventApi::setContinuousMode() {
   CUptiResult res = CUPTI_CALL(cuptiSetEventCollectionMode(
       context_, CUPTI_EVENT_COLLECTION_MODE_CONTINUOUS));
   return (res == CUPTI_SUCCESS);
 }
 
-void CuptiEventInterface::enablePerInstance(CUpti_EventGroup eventGroup) {
+void CuptiEventApi::enablePerInstance(CUpti_EventGroup eventGroup) {
   uint32_t profile_all = 1;
   CUPTI_CALL(cuptiEventGroupSetAttribute(
       eventGroup,
@@ -56,7 +56,7 @@ void CuptiEventInterface::enablePerInstance(CUpti_EventGroup eventGroup) {
       &profile_all));
 }
 
-uint32_t CuptiEventInterface::instanceCount(CUpti_EventGroup eventGroup) {
+uint32_t CuptiEventApi::instanceCount(CUpti_EventGroup eventGroup) {
   uint32_t instance_count = 0;
   size_t s = sizeof(instance_count);
   CUPTI_CALL(cuptiEventGroupGetAttribute(
@@ -64,7 +64,7 @@ uint32_t CuptiEventInterface::instanceCount(CUpti_EventGroup eventGroup) {
   return instance_count;
 }
 
-void CuptiEventInterface::enableGroupSet(CUpti_EventGroupSet& set) {
+void CuptiEventApi::enableGroupSet(CUpti_EventGroupSet& set) {
   CUptiResult res = CUPTI_CALL_NOWARN(cuptiEventGroupSetEnable(&set));
   if (res != CUPTI_SUCCESS) {
     const char* errstr = nullptr;
@@ -73,11 +73,11 @@ void CuptiEventInterface::enableGroupSet(CUpti_EventGroupSet& set) {
   }
 }
 
-void CuptiEventInterface::disableGroupSet(CUpti_EventGroupSet& set) {
+void CuptiEventApi::disableGroupSet(CUpti_EventGroupSet& set) {
   CUPTI_CALL(cuptiEventGroupSetDisable(&set));
 }
 
-void CuptiEventInterface::readEvent(
+void CuptiEventApi::readEvent(
     CUpti_EventGroup grp,
     CUpti_EventID id,
     vector<int64_t>& vals) {
@@ -90,7 +90,7 @@ void CuptiEventInterface::readEvent(
       reinterpret_cast<uint64_t*>(vals.data())));
 }
 
-vector<CUpti_EventID> CuptiEventInterface::eventsInGroup(CUpti_EventGroup grp) {
+vector<CUpti_EventID> CuptiEventApi::eventsInGroup(CUpti_EventGroup grp) {
   uint32_t group_size = 0;
   size_t s = sizeof(group_size);
   CUPTI_CALL(cuptiEventGroupGetAttribute(
@@ -102,7 +102,7 @@ vector<CUpti_EventID> CuptiEventInterface::eventsInGroup(CUpti_EventGroup grp) {
   return res;
 }
 
-CUpti_EventID CuptiEventInterface::eventId(const std::string& name) {
+CUpti_EventID CuptiEventApi::eventId(const std::string& name) {
   CUpti_EventID id{0};
   CUPTI_CALL(cuptiEventGetIdFromName(device_, name.c_str(), &id));
   return id;

--- a/libkineto/src/CuptiEventApi.h
+++ b/libkineto/src/CuptiEventApi.h
@@ -15,10 +15,10 @@ namespace KINETO_NAMESPACE {
 
 // C++ interface to CUPTI Events C API.
 // Virtual methods are here mainly to allow easier testing.
-class CuptiEventInterface {
+class CuptiEventApi {
  public:
-  explicit CuptiEventInterface(CUcontext context_);
-  virtual ~CuptiEventInterface() {}
+  explicit CuptiEventApi(CUcontext context_);
+  virtual ~CuptiEventApi() {}
 
   CUdevice device() {
     return device_;
@@ -44,7 +44,7 @@ class CuptiEventInterface {
 
  protected:
   // Unit testing
-  CuptiEventInterface() : context_(nullptr), device_(0) {}
+  CuptiEventApi() : context_(nullptr), device_(0) {}
 
  private:
   CUcontext context_;

--- a/libkineto/src/CuptiMetricApi.cpp
+++ b/libkineto/src/CuptiMetricApi.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "CuptiMetricInterface.h"
+#include "CuptiMetricApi.h"
 
 #include <chrono>
 
@@ -17,7 +17,7 @@ using std::vector;
 
 namespace KINETO_NAMESPACE {
 
-CUpti_MetricID CuptiMetricInterface::idFromName(const std::string& name) {
+CUpti_MetricID CuptiMetricApi::idFromName(const std::string& name) {
   CUpti_MetricID metric_id{~0u};
   CUptiResult res =
       CUPTI_CALL(cuptiMetricGetIdFromName(device_, name.c_str(), &metric_id));
@@ -30,7 +30,7 @@ CUpti_MetricID CuptiMetricInterface::idFromName(const std::string& name) {
 // Return a map of event IDs and names for a given metric id.
 // Note that many events don't have a name. In that case the name will
 // be set to the empty string.
-std::map<CUpti_EventID, std::string> CuptiMetricInterface::events(
+std::map<CUpti_EventID, std::string> CuptiMetricApi::events(
     CUpti_MetricID metric_id) {
   uint32_t num_events = 0;
   CUPTI_CALL(cuptiMetricGetNumEvents(metric_id, &num_events));
@@ -57,7 +57,7 @@ std::map<CUpti_EventID, std::string> CuptiMetricInterface::events(
   return res;
 }
 
-CUpti_MetricValueKind CuptiMetricInterface::valueKind(CUpti_MetricID metric) {
+CUpti_MetricValueKind CuptiMetricApi::valueKind(CUpti_MetricID metric) {
   CUpti_MetricValueKind res{CUPTI_METRIC_VALUE_KIND_FORCE_INT};
   size_t value_kind_size = sizeof(res);
   CUPTI_CALL(cuptiMetricGetAttribute(
@@ -65,7 +65,7 @@ CUpti_MetricValueKind CuptiMetricInterface::valueKind(CUpti_MetricID metric) {
   return res;
 }
 
-CUpti_MetricEvaluationMode CuptiMetricInterface::evaluationMode(
+CUpti_MetricEvaluationMode CuptiMetricApi::evaluationMode(
     CUpti_MetricID metric) {
   CUpti_MetricEvaluationMode eval_mode{
       CUPTI_METRIC_EVALUATION_MODE_PER_INSTANCE};
@@ -76,7 +76,7 @@ CUpti_MetricEvaluationMode CuptiMetricInterface::evaluationMode(
 }
 
 // FIXME: Consider caching value kind here
-SampleValue CuptiMetricInterface::calculate(
+SampleValue CuptiMetricApi::calculate(
     CUpti_MetricID metric,
     CUpti_MetricValueKind kind,
     vector<CUpti_EventID>& events,

--- a/libkineto/src/CuptiMetricApi.h
+++ b/libkineto/src/CuptiMetricApi.h
@@ -18,10 +18,10 @@ namespace KINETO_NAMESPACE {
 
 // C++ interface to CUPTI Metrics C API.
 // Virtual methods are here mainly to allow easier testing.
-class CuptiMetricInterface {
+class CuptiMetricApi {
  public:
-  explicit CuptiMetricInterface(CUdevice device) : device_(device) {}
-  virtual ~CuptiMetricInterface() {}
+  explicit CuptiMetricApi(CUdevice device) : device_(device) {}
+  virtual ~CuptiMetricApi() {}
 
   virtual CUpti_MetricID idFromName(const std::string& name);
   virtual std::map<CUpti_EventID, std::string> events(CUpti_MetricID metric_id);

--- a/libkineto/src/EventProfiler.cpp
+++ b/libkineto/src/EventProfiler.cpp
@@ -22,7 +22,7 @@
 
 #include <cupti.h>
 
-#include "CuptiEventInterface.h"
+#include "CuptiEventApi.h"
 #include "Logger.h"
 
 using namespace std::chrono;
@@ -102,7 +102,7 @@ Metric::Metric(
     CUpti_MetricID id,
     vector<CUpti_EventID> events,
     CUpti_MetricEvaluationMode eval_mode,
-    CuptiMetricInterface& cupti_metrics)
+    CuptiMetricApi& cupti_metrics)
     : name(std::move(name)),
       id_(id),
       events_(std::move(events)),
@@ -160,7 +160,7 @@ void Metric::printDescription(ostream& s) const {
 EventGroupSet::EventGroupSet(
     CUpti_EventGroupSet& set,
     map<CUpti_EventID, Event>& events,
-    CuptiEventInterface& cupti)
+    CuptiEventApi& cupti)
     : set_(set), events_(events), cuptiEvents_(cupti), enabled_(false) {
   for (int g = 0; g < set.numEventGroups; g++) {
     CUpti_EventGroup grp = set.eventGroups[g];
@@ -432,8 +432,8 @@ static void adjustConfig(Config& config, int num_sets) {
 
 // Prepare profiler
 EventProfiler::EventProfiler(
-    std::unique_ptr<CuptiEventInterface> cupti_events,
-    std::unique_ptr<CuptiMetricInterface> cupti_metrics,
+    std::unique_ptr<CuptiEventApi> cupti_events,
+    std::unique_ptr<CuptiMetricApi> cupti_metrics,
     vector<unique_ptr<SampleListener>>& loggers,
     vector<unique_ptr<SampleListener>>& onDemandLoggers)
     : cuptiEvents_(std::move(cupti_events)),

--- a/libkineto/src/EventProfiler.h
+++ b/libkineto/src/EventProfiler.h
@@ -19,8 +19,8 @@
 #include <cupti.h>
 
 #include "Config.h"
-#include "CuptiEventInterface.h"
-#include "CuptiMetricInterface.h"
+#include "CuptiEventApi.h"
+#include "CuptiMetricApi.h"
 #include "SampleListener.h"
 
 namespace KINETO_NAMESPACE {
@@ -129,7 +129,7 @@ class Metric {
       CUpti_MetricID id,
       std::vector<CUpti_EventID> events,
       CUpti_MetricEvaluationMode eval_mode,
-      CuptiMetricInterface& cupti_metrics);
+      CuptiMetricApi& cupti_metrics);
 
   struct CalculatedValues {
     std::vector<SampleValue> perInstance;
@@ -154,7 +154,7 @@ class Metric {
   std::vector<CUpti_EventID> events_;
   CUpti_MetricEvaluationMode evalMode_;
   // Calls to CUPTI is encapsulated behind this interface
-  CuptiMetricInterface& cuptiMetrics_;
+  CuptiMetricApi& cuptiMetrics_;
   CUpti_MetricValueKind valueKind_;
 };
 
@@ -169,7 +169,7 @@ class EventGroupSet {
   EventGroupSet(
       CUpti_EventGroupSet& set,
       std::map<CUpti_EventID, Event>& events,
-      CuptiEventInterface& cupti);
+      CuptiEventApi& cupti);
   ~EventGroupSet();
 
   EventGroupSet(const EventGroupSet&) = delete;
@@ -191,7 +191,7 @@ class EventGroupSet {
   CUpti_EventGroupSet& set_;
   std::map<CUpti_EventID, Event>& events_;
   // Calls to CUPTI is encapsulated behind this interface
-  CuptiEventInterface& cuptiEvents_;
+  CuptiEventApi& cuptiEvents_;
   bool enabled_;
 };
 
@@ -199,8 +199,8 @@ class EventGroupSet {
 class EventProfiler {
  public:
   explicit EventProfiler(
-      std::unique_ptr<CuptiEventInterface> cupti_events,
-      std::unique_ptr<CuptiMetricInterface> cupti_metrics,
+      std::unique_ptr<CuptiEventApi> cupti_events,
+      std::unique_ptr<CuptiMetricApi> cupti_metrics,
       std::vector<std::unique_ptr<SampleListener>>& loggers,
       std::vector<std::unique_ptr<SampleListener>>& onDemandLoggers);
   EventProfiler(const EventProfiler&) = delete;
@@ -316,8 +316,8 @@ class EventProfiler {
   void printAllSamples(std::ostream& s, CUdevice device) const;
 
   // Calls to CUPTI is encapsulated behind these interfaces
-  std::unique_ptr<CuptiEventInterface> cuptiEvents_;
-  std::unique_ptr<CuptiMetricInterface> cuptiMetrics_;
+  std::unique_ptr<CuptiEventApi> cuptiEvents_;
+  std::unique_ptr<CuptiMetricApi> cuptiMetrics_;
   // The CUpti API reports event IDs, we must map them to our event objects
   std::map<CUpti_EventID, Event> events_;
   // List of metrics

--- a/libkineto/src/EventProfilerController.cpp
+++ b/libkineto/src/EventProfilerController.cpp
@@ -12,8 +12,8 @@
 #include <vector>
 
 #include "ConfigLoader.h"
-#include "CuptiEventInterface.h"
-#include "CuptiMetricInterface.h"
+#include "CuptiEventApi.h"
+#include "CuptiMetricApi.h"
 #include "EventProfiler.h"
 #include "output_csv.h"
 
@@ -207,9 +207,9 @@ EventProfilerController::EventProfilerController(
     ConfigLoader& configLoader,
     detail::HeartbeatMonitor& heartbeatMonitor)
     : configLoader_(configLoader), heartbeatMonitor_(heartbeatMonitor) {
-  auto cupti_events = std::make_unique<CuptiEventInterface>(context);
+  auto cupti_events = std::make_unique<CuptiEventApi>(context);
   auto cupti_metrics =
-      std::make_unique<CuptiMetricInterface>(cupti_events->device());
+      std::make_unique<CuptiMetricApi>(cupti_events->device());
   configLoader_.addHandler(
       ConfigLoader::ConfigKind::EventProfiler, this);
   auto config = configLoader.getConfigCopy();

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "RoctracerActivityInterface.h"
+#include "RoctracerActivityApi.h"
 
 #include <cstring>
 #include <chrono>
@@ -27,21 +27,21 @@ namespace KINETO_NAMESPACE {
 
 constexpr size_t kBufSize(2 * 1024 * 1024);
 
-RoctracerActivityInterface& RoctracerActivityInterface::singleton() {
-  static RoctracerActivityInterface instance;
+RoctracerActivityApi& RoctracerActivityApi::singleton() {
+  static RoctracerActivityApi instance;
   return instance;
 }
 
-RoctracerActivityInterface::RoctracerActivityInterface() {
+RoctracerActivityApi::RoctracerActivityApi() {
   gpuTraceBuffers_ = std::make_unique<std::list<RoctracerActivityBuffer>>();
 }
 
-RoctracerActivityInterface::~RoctracerActivityInterface() {
+RoctracerActivityApi::~RoctracerActivityApi() {
   disableActivities(std::set<ActivityType>());
   endTracing();
 }
 
-void RoctracerActivityInterface::pushCorrelationID(int id, CorrelationFlowType type) {
+void RoctracerActivityApi::pushCorrelationID(int id, CorrelationFlowType type) {
 #ifdef HAS_ROCTRACER
   if (!singleton().externalCorrelationEnabled_) {
     return;
@@ -50,7 +50,7 @@ void RoctracerActivityInterface::pushCorrelationID(int id, CorrelationFlowType t
 #endif
 }
 
-void RoctracerActivityInterface::popCorrelationID(CorrelationFlowType type) {
+void RoctracerActivityApi::popCorrelationID(CorrelationFlowType type) {
 #ifdef HAS_ROCTRACER
   if (!singleton().externalCorrelationEnabled_) {
     return;
@@ -59,11 +59,11 @@ void RoctracerActivityInterface::popCorrelationID(CorrelationFlowType type) {
 #endif
 }
 
-void RoctracerActivityInterface::setMaxBufferSize(int size) {
+void RoctracerActivityApi::setMaxBufferSize(int size) {
   maxGpuBufferCount_ = 1 + size / kBufSize;
 }
 
-int RoctracerActivityInterface::processActivities(
+int RoctracerActivityApi::processActivities(
     ActivityLogger& logger) {
   // Find offset to map from monotonic clock to system clock.
   // This will break time-ordering of events but is status quo.
@@ -242,7 +242,7 @@ int RoctracerActivityInterface::processActivities(
   return count;
 }
 
-void RoctracerActivityInterface::clearActivities() {
+void RoctracerActivityApi::clearActivities() {
   gpuTraceBuffers_->clear();
   rows_.clear();
   kernelRows_.clear();
@@ -251,9 +251,9 @@ void RoctracerActivityInterface::clearActivities() {
   kernelLaunches_.clear();
 }
 
-void RoctracerActivityInterface::api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg)
+void RoctracerActivityApi::api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg)
 {
-  RoctracerActivityInterface *dis = &singleton();
+  RoctracerActivityApi *dis = &singleton();
 
   if (domain == ACTIVITY_DOMAIN_HIP_API && dis->loggedIds_.contains(cid)) {
     const hip_api_data_t* data = (const hip_api_data_t*)(callback_data);
@@ -423,7 +423,7 @@ void RoctracerActivityInterface::api_callback(uint32_t domain, uint32_t cid, con
   }
 }
 
-void RoctracerActivityInterface::activity_callback(const char* begin, const char* end, void* arg)
+void RoctracerActivityApi::activity_callback(const char* begin, const char* end, void* arg)
 {
   size_t size = end - begin;
   uint8_t *buffer = (uint8_t*) malloc(size);
@@ -432,7 +432,7 @@ void RoctracerActivityInterface::activity_callback(const char* begin, const char
   gpuTraceBuffers->emplace_back(buffer, size);
 }
 
-void RoctracerActivityInterface::enableActivities(
+void RoctracerActivityApi::enableActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_ROCTRACER
   if (!registered_) {
@@ -499,7 +499,7 @@ void RoctracerActivityInterface::enableActivities(
 #endif
 }
 
-void RoctracerActivityInterface::disableActivities(
+void RoctracerActivityApi::disableActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_ROCTRACER
   roctracer_stop();
@@ -513,7 +513,7 @@ void RoctracerActivityInterface::disableActivities(
 #endif
 }
 
-void RoctracerActivityInterface::endTracing() {
+void RoctracerActivityApi::endTracing() {
   if (registered_ == true) {
     roctracer_disable_domain_callback(ACTIVITY_DOMAIN_HIP_API);
     //roctracer_disable_domain_callback(ACTIVITY_DOMAIN_ROCTX);

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -113,20 +113,20 @@ struct mallocRow : public roctracerRow {
 };
 
 
-class RoctracerActivityInterface {
+class RoctracerActivityApi {
  public:
   enum CorrelationFlowType {
     Default,
     User
   };
 
-  RoctracerActivityInterface();
-  RoctracerActivityInterface(const RoctracerActivityInterface&) = delete;
-  RoctracerActivityInterface& operator=(const RoctracerActivityInterface&) = delete;
+  RoctracerActivityApi();
+  RoctracerActivityApi(const RoctracerActivityApi&) = delete;
+  RoctracerActivityApi& operator=(const RoctracerActivityApi&) = delete;
 
-  virtual ~RoctracerActivityInterface();
+  virtual ~RoctracerActivityApi();
 
-  static RoctracerActivityInterface& singleton();
+  static RoctracerActivityApi& singleton();
 
   static void pushCorrelationID(int id, CorrelationFlowType type);
   static void popCorrelationID(CorrelationFlowType type);

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -16,7 +16,7 @@
 #ifdef HAS_CUPTI
 #include "CuptiActivity.h"
 #include "CuptiActivity.tpp"
-#include "CuptiActivityInterface.h"
+#include "CuptiActivityApi.h"
 #include "CudaDeviceProperties.h"
 #endif // HAS_CUPTI
 #include "Demangle.h"

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -22,7 +22,7 @@
 #include "src/CuptiActivityProfiler.h"
 #include "src/ActivityTrace.h"
 #include "src/Config.h"
-#include "src/CuptiActivityInterface.h"
+#include "src/CuptiActivityApi.h"
 #include "src/output_base.h"
 #include "src/output_json.h"
 #include "src/output_membuf.h"
@@ -129,8 +129,8 @@ struct MockCuptiActivityBuffer {
   std::vector<CUpti_Activity*> activities;
 };
 
-// Mock parts of the CuptiActivityInterface
-class MockCuptiActivities : public CuptiActivityInterface {
+// Mock parts of the CuptiActivityApi
+class MockCuptiActivities : public CuptiActivityApi {
  public:
   virtual int smCount() override {
     return 10;

--- a/libkineto/test/EventProfilerTest.cpp
+++ b/libkineto/test/EventProfilerTest.cpp
@@ -113,9 +113,9 @@ TEST(EventTest, Percentiles) {
   EXPECT_EQ(pct[2].second.getInt(), 444);
 }
 
-class MockCuptiMetrics : public CuptiMetricInterface {
+class MockCuptiMetrics : public CuptiMetricApi {
  public:
-  MockCuptiMetrics() : CuptiMetricInterface(0) {}
+  MockCuptiMetrics() : CuptiMetricApi(0) {}
   MOCK_METHOD1(idFromName, CUpti_MetricID(const std::string& name));
   MOCK_METHOD1(
       events,
@@ -209,7 +209,7 @@ TEST(MetricTest, Calculate) {
   EXPECT_EQ(v.total.getDouble(), 0.27);
 }
 
-class MockCuptiEvents : public CuptiEventInterface {
+class MockCuptiEvents : public CuptiEventApi {
  public:
   MOCK_METHOD1(
       createGroupSets,


### PR DESCRIPTION
Summary:
CuptiInterface can be confusing since it is not a C++ interface class but a C++ wrapper for the CUPTI C API. CuptiApi hopefully conveys this better.

Also renamed RoctracerActivityInterface to RoctracerActivityApi.

Reviewed By: briancoutinho

Differential Revision: D31268099

