### PR TITLE
Refactor 4/n: Simplify activity logger step 2/3

### DIFF
--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -20,6 +20,7 @@ namespace libkineto {
 
 // Link type, used in GenericTraceActivity.flow.type
 constexpr unsigned int kLinkFwdBwd = 1;
+constexpr unsigned int kLinkAsyncCpuGpu = 2;
 
 // @lint-ignore-every CLANGTIDY cppcoreguidelines-non-private-member-variables-in-classes
 // @lint-ignore-every CLANGTIDY cppcoreguidelines-pro-type-member-init
@@ -57,6 +58,10 @@ class GenericTraceActivity : public ITraceActivity {
     return activityType;
   }
 
+  const ITraceActivity* linkedActivity() const override {
+    return nullptr;
+  }
+
   int flowType() const override {
     return flow.type;
   }
@@ -65,12 +70,12 @@ class GenericTraceActivity : public ITraceActivity {
     return flow.id;
   }
 
-  const std::string name() const override {
-    return activityName;
+  bool flowStart() const override {
+    return flow.start;
   }
 
-  const ITraceActivity* linkedActivity() const override {
-    return flow.linkedActivity;
+  const std::string name() const override {
+    return activityName;
   }
 
   const TraceSpan* traceSpan() const override {
@@ -103,13 +108,13 @@ class GenericTraceActivity : public ITraceActivity {
   ActivityType activityType;
   std::string activityName;
   struct Flow {
-    Flow(): linkedActivity(nullptr), id(0), type(0) {}
-    ITraceActivity* linkedActivity; // Only set in destination side.
+    Flow(): id(0), type(0), start(0) {}
     // Ids must be unique within each type
-    uint32_t id : 28;
+    uint32_t id : 27;
     // Type will be used to connect flows between profilers, as
     // well as look up flow information (name etc)
     uint32_t type : 4;
+    uint32_t start : 1;
   } flow;
 
  private:

--- a/libkineto/include/ITraceActivity.h
+++ b/libkineto/include/ITraceActivity.h
@@ -33,6 +33,7 @@ struct ITraceActivity {
   // Part of a flow, identified by flow id and type
   virtual int flowType() const = 0;
   virtual int flowId() const = 0;
+  virtual bool flowStart() const = 0;
   virtual ActivityType type() const = 0;
   virtual const std::string name() const = 0;
   // Optional linked activity

--- a/libkineto/include/TraceSpan.h
+++ b/libkineto/include/TraceSpan.h
@@ -36,8 +36,6 @@ struct TraceSpan {
   std::string name;
   // Prefix used to distinguish trace spans on the same timeline
   std::string prefix;
-  // Tracked by profiler for iteration trigger
-  bool tracked{false};
 };
 
 } // namespace libkineto

--- a/libkineto/src/ActivityBuffers.h
+++ b/libkineto/src/ActivityBuffers.h
@@ -19,6 +19,16 @@ namespace KINETO_NAMESPACE {
 struct ActivityBuffers {
   std::list<std::unique_ptr<libkineto::CpuTraceBuffer>> cpu;
   std::unique_ptr<CuptiActivityBufferMap> gpu;
+
+  // Add a wrapper object to the underlying struct stored in the buffer
+  template<class T>
+  const ITraceActivity& addActivityWrapper(const T& act) {
+    wrappers_.push_back(std::make_unique<T>(act));
+    return *wrappers_.back().get();
+  }
+
+ private:
+  std::vector<std::unique_ptr<const ITraceActivity>> wrappers_;
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiActivity.tpp
+++ b/libkineto/src/CuptiActivity.tpp
@@ -67,7 +67,7 @@ inline ActivityType GpuActivity<CUpti_ActivityMemset>::type() const {
 }
 
 inline void RuntimeActivity::log(ActivityLogger& logger) const {
-  logger.handleRuntimeActivity(*this);
+  logger.handleGenericActivity(*this);
 }
 
 template<class T>
@@ -75,8 +75,20 @@ inline void GpuActivity<T>::log(ActivityLogger& logger) const {
   logger.handleGpuActivity(*this);
 }
 
+inline bool RuntimeActivity::flowStart() const {
+  return activity_.cbid == CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000 ||
+      (activity_.cbid >= CUPTI_RUNTIME_TRACE_CBID_cudaMemcpy_v3020 &&
+       activity_.cbid <= CUPTI_RUNTIME_TRACE_CBID_cudaMemset2DAsync_v3020) ||
+      activity_.cbid ==
+          CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000 ||
+      activity_.cbid ==
+          CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernelMultiDevice_v9000;
+}
+
 inline const std::string RuntimeActivity::metadataJson() const {
-  return "";
+  return fmt::format(R"JSON(
+      "cbid": {}, "correlation": {})JSON",
+      activity_.cbid, activity_.correlationId);
 }
 
 template<class T>

--- a/libkineto/src/CuptiActivityBuffer.h
+++ b/libkineto/src/CuptiActivityBuffer.h
@@ -15,6 +15,8 @@
 #include <sys/types.h>
 #include <vector>
 
+#include "ITraceActivity.h"
+
 namespace KINETO_NAMESPACE {
 
 class CuptiActivityBuffer {
@@ -44,6 +46,8 @@ class CuptiActivityBuffer {
 
   std::vector<uint8_t> buf_;
   size_t size_;
+
+  std::vector<std::unique_ptr<const ITraceActivity>> wrappers_;
 };
 
 using CuptiActivityBufferMap =

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -88,6 +88,9 @@ int RoctracerActivityApi::processActivities(
     a.resource = item.tid;
     a.activityType = ActivityType::CUDA_RUNTIME;
     a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
+    a.flow.id = item.id;
+    a.flow.type = kLinkAsyncCpuGpu;
+    a.flow.start = true;
 
     logger.handleGenericActivity(a);
     ++count;
@@ -103,6 +106,9 @@ int RoctracerActivityApi::processActivities(
     a.resource = item.tid;
     a.activityType = ActivityType::CUDA_RUNTIME;
     a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
+    a.flow.id = item.id;
+    a.flow.type = kLinkAsyncCpuGpu;
+    a.flow.start = true;
 
     a.addMetadata("ptr", item.ptr);
     if (item.cid == HIP_API_ID_hipMalloc) {
@@ -123,6 +129,9 @@ int RoctracerActivityApi::processActivities(
     a.resource = item.tid;
     a.activityType = ActivityType::CUDA_RUNTIME;
     a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
+    a.flow.id = item.id;
+    a.flow.type = kLinkAsyncCpuGpu;
+    a.flow.start = true;
 
     a.addMetadata("src", item.src);
     a.addMetadata("dst", item.dst);
@@ -147,6 +156,9 @@ int RoctracerActivityApi::processActivities(
     a.resource = item.tid;
     a.activityType = ActivityType::CUDA_RUNTIME;
     a.activityName = std::string(roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, item.cid, 0));
+    a.flow.id = item.id;
+    a.flow.type = kLinkAsyncCpuGpu;
+    a.flow.start = true;
 
     if (item.functionAddr != nullptr) {
       a.addMetadataQuoted(
@@ -205,6 +217,9 @@ int RoctracerActivityApi::processActivities(
 
         a.activityType = ActivityType::CUDA_RUNTIME;
         a.activityName = std::string(name);
+        a.flow.id = item.id;
+        a.flow.type = kLinkAsyncCpuGpu;
+        a.flow.start = true;
 
         logger.handleGenericActivity(a);
         ++count;
@@ -226,6 +241,8 @@ int RoctracerActivityApi::processActivities(
 
         a.activityType = ActivityType::CONCURRENT_KERNEL;
         a.activityName = std::string(name);
+        a.flow.id = item.id;
+        a.flow.type = kLinkAsyncCpuGpu;
 
         auto it = kernelNames_.find(record->correlation_id);
         if (it != kernelNames_.end()) {

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -65,8 +65,6 @@ class ActivityLogger {
       const libkineto::ITraceActivity& activity) = 0;
 
 #ifdef HAS_CUPTI
-  virtual void handleRuntimeActivity(const RuntimeActivity& activity) = 0;
-
   virtual void handleGpuActivity(
       const GpuActivity<CUpti_ActivityKernel4>& activity) = 0;
   virtual void handleGpuActivity(

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -45,9 +45,6 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   void handleGenericActivity(const ITraceActivity& activity) override;
 
 #ifdef HAS_CUPTI
-  void handleRuntimeActivity(
-      const RuntimeActivity& activity) override;
-
   void handleGpuActivity(const GpuActivity<CUpti_ActivityKernel4>& activity) override;
   void handleGpuActivity(const GpuActivity<CUpti_ActivityMemcpy>& activity) override;
   void handleGpuActivity(const GpuActivity<CUpti_ActivityMemcpy2>& activity) override;

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -63,11 +63,6 @@ class MemoryTraceLogger : public ActivityLogger {
     activities_.push_back(wrappers_.back().get());
   }
 
-  void handleRuntimeActivity(
-      const RuntimeActivity& activity) override {
-    addActivityWrapper(activity);
-  }
-
   void handleGpuActivity(const GpuActivity<CUpti_ActivityKernel4>& activity) override {
     addActivityWrapper(activity);
   }


### PR DESCRIPTION
Summary:
1. Generalize ChromeTraceLogger::handleGenericActivity to enable it to handle Cuda runtime activities as well as the Roctracer generic activities.
This primarily involves enabling generic support for CPU -> GPU flows.

2. In the event of out-of-order GPU activities (an issue with Cuda11.0, likely fixed in later versions), no longer remove them but print warnings. Another diff will add these warnings to the metadata section.

Reviewed By: briancoutinho

Differential Revision: D31624496

