### PR TITLE
Remove some Caffe2 specific features

### DIFF
--- a/libkineto/include/ActivityProfilerInterface.h
+++ b/libkineto/include/ActivityProfilerInterface.h
@@ -74,11 +74,6 @@ class ActivityProfilerInterface {
   virtual void pushUserCorrelationId(uint64_t){}
   virtual void popUserCorrelationId(){}
 
-  // Include regions with this name
-  virtual bool enableForRegion(const std::string& match) {
-    return true;
-  }
-
   // Saves information for the current thread to be used in profiler output
   // Client must record any new kernel thread where the activity has occured.
   virtual void recordThreadInfo() {}

--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -90,16 +90,6 @@ class LibkinetoApi {
     return activityProfiler_ != nullptr;
   }
 
-  void setNetSizeThreshold(int gpu_ops) {
-    netSizeThreshold_ = gpu_ops;
-  }
-
-  // Include traces with at least this many ops
-  // FIXME: Rename and move elsewhere
-  int netSizeThreshold() {
-    return netSizeThreshold_;
-  }
-
   void suppressLogMessages() {
     suppressLibkinetoLogMessages();
   }
@@ -139,7 +129,6 @@ class LibkinetoApi {
   int32_t clientRegisterThread_{0};
 
   bool isLoaded_{false};
-  std::atomic_int netSizeThreshold_{};
   std::vector<ChildActivityProfilerFactory> childProfilerFactories_;
 };
 

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -53,10 +53,6 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
     return profiler_->isActive();
   }
 
-  bool traceInclusionFilter(const std::string& match) {
-    return profiler_->applyNetFilter(match);
-  }
-
   void transferCpuTrace(
       std::unique_ptr<libkineto::CpuTraceBuffer> cpuTrace) {
     return profiler_->transferCpuTrace(std::move(cpuTrace));

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -86,10 +86,6 @@ void ActivityProfilerProxy::transferCpuTrace(
   controller_->transferCpuTrace(std::move(traceBuffer));
 }
 
-bool ActivityProfilerProxy::enableForRegion(const std::string& match) {
-  return controller_->traceInclusionFilter(match);
-}
-
 void ActivityProfilerProxy::addMetadata(
     const std::string& key, const std::string& value) {
   controller_->addMetadata(key, value);

--- a/libkineto/src/ActivityProfilerProxy.h
+++ b/libkineto/src/ActivityProfilerProxy.h
@@ -60,8 +60,6 @@ class ActivityProfilerProxy : public ActivityProfilerInterface {
   void transferCpuTrace(
      std::unique_ptr<CpuTraceBuffer> traceBuffer) override;
 
-  bool enableForRegion(const std::string& match) override;
-
   void addMetadata(const std::string& key, const std::string& value) override;
 
   virtual void addChildActivityProfiler(

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -34,8 +34,6 @@ constexpr milliseconds kDefaultSamplePeriodMsecs(1000);
 constexpr milliseconds kDefaultMultiplexPeriodMsecs(1000);
 constexpr milliseconds kDefaultActivitiesProfileDurationMSecs(500);
 constexpr int kDefaultActivitiesExternalAPIIterations(3);
-constexpr int kDefaultActivitiesExternalAPINetSizeThreshold(0);
-constexpr int kDefaultActivitiesExternalAPIGpuOpCountThreshold(0);
 constexpr int kDefaultActivitiesMaxGpuBufferSize(128 * 1024 * 1024);
 constexpr seconds kDefaultActivitiesWarmupDurationSecs(5);
 constexpr seconds kDefaultBufferUntilWarmup(10);
@@ -66,10 +64,6 @@ constexpr char kActivitiesLogFileKey[] = "ACTIVITIES_LOG_FILE";
 constexpr char kActivitiesDurationKey[] = "ACTIVITIES_DURATION_SECS";
 constexpr char kActivitiesDurationMsecsKey[] = "ACTIVITIES_DURATION_MSECS";
 constexpr char kActivitiesIterationsKey[] = "ACTIVITIES_ITERATIONS";
-constexpr char kActivitiesIterationsTargetKey[] = "ACTIVITIES_ITERATIONS_TARGET";
-constexpr char kActivitiesNetFilterKey[] = "ACTIVITIES_NET_FILTER";
-constexpr char kActivitiesMinNetSizeKey[] = "ACTIVITIES_MIN_NET_SIZE";
-constexpr char kActivitiesMinGpuOpCountKey[] = "ACTIVITIES_MIN_GPU_OP_COUNT";
 constexpr char kActivitiesWarmupDurationSecsKey[] = "ACTIVITIES_WARMUP_PERIOD_SECS";
 constexpr char kActivitiesMaxGpuBufferSizeKey[] =
     "ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB";
@@ -179,12 +173,8 @@ Config::Config()
       activitiesLogUrl_(fmt::format("file://{}", activitiesLogFile_)),
       activitiesMaxGpuBufferSize_(kDefaultActivitiesMaxGpuBufferSize),
       activitiesWarmupDuration_(kDefaultActivitiesWarmupDurationSecs),
-      activitiesOnDemandDuration_(kDefaultActivitiesProfileDurationMSecs),
+      activitiesDuration_(kDefaultActivitiesProfileDurationMSecs),
       activitiesExternalAPIIterations_(kDefaultActivitiesExternalAPIIterations),
-      activitiesExternalAPINetSizeThreshold_(
-          kDefaultActivitiesExternalAPINetSizeThreshold),
-      activitiesExternalAPIGpuOpCountThreshold_(
-          kDefaultActivitiesExternalAPIGpuOpCountThreshold),
       activitiesOnDemandTimestamp_(milliseconds(0)),
       profileStartTime_(milliseconds(0)),
       requestTimestamp_(milliseconds(0)),
@@ -275,26 +265,18 @@ bool Config::handleOption(const std::string& name, std::string& val) {
 
   // Activity Profiler
   else if (!name.compare(kActivitiesDurationKey)) {
-    activitiesOnDemandDuration_ =
+    activitiesDuration_ =
         duration_cast<milliseconds>(seconds(toInt32(val)));
     activitiesOnDemandTimestamp_ = timestamp();
   } else if (!name.compare(kActivityTypesKey)) {
     vector<string> activity_types = splitAndTrim(toLower(val), ',');
     setActivityTypes(activity_types);
   } else if (!name.compare(kActivitiesDurationMsecsKey)) {
-    activitiesOnDemandDuration_ = milliseconds(toInt32(val));
+    activitiesDuration_ = milliseconds(toInt32(val));
     activitiesOnDemandTimestamp_ = timestamp();
   } else if (!name.compare(kActivitiesIterationsKey)) {
     activitiesExternalAPIIterations_ = toInt32(val);
     activitiesOnDemandTimestamp_ = timestamp();
-  } else if (!name.compare(kActivitiesIterationsTargetKey)) {
-    activitiesExternalAPIIterationsTarget_ = val;
-  } else if (!name.compare(kActivitiesNetFilterKey)) {
-    activitiesExternalAPIFilter_ = splitAndTrim(val, ',');
-  } else if (!name.compare(kActivitiesMinNetSizeKey)) {
-    activitiesExternalAPINetSizeThreshold_ = toInt32(val);
-  } else if (!name.compare(kActivitiesMinGpuOpCountKey)) {
-    activitiesExternalAPIGpuOpCountThreshold_ = toInt32(val);
   } else if (!name.compare(kLogVerboseLevelKey)) {
     verboseLogLevel_ = toInt32(val);
   } else if (!name.compare(kLogVerboseModulesKey)) {
@@ -330,7 +312,7 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   return true;
 }
 
-std::chrono::milliseconds Config::activitiesOnDemandDurationDefault() const {
+std::chrono::milliseconds Config::activitiesDurationDefault() const {
   return kDefaultActivitiesProfileDurationMSecs;
 };
 
@@ -411,27 +393,17 @@ void Config::setReportPeriod(milliseconds msecs) {
 
 void Config::printActivityProfilerConfig(std::ostream& s) const {
   s << "Log file: " << activitiesLogFile() << std::endl;
-  s << fmt::format(
-           "Net filter: {}",
-           fmt::join(activitiesOnDemandExternalFilter(), ", "))
-    << std::endl;
-  s << "Target net for iteration count: " << activitiesOnDemandExternalTarget()
-    << std::endl;
-  s << "Net Iterations: " << activitiesOnDemandExternalIterations()
+  s << "Trace Iterations: " << activitiesExternalIterations()
     << std::endl;
   if (hasProfileStartTime()) {
     std::time_t t_c = system_clock::to_time_t(requestTimestamp());
     LOG(INFO) << "Trace start time: "
               << fmt::format("{:%Y-%m-%d %H:%M:%S}", fmt::localtime(t_c));
   }
-  s << "Trace duration: " << activitiesOnDemandDuration().count() << "ms"
+  s << "Trace duration: " << activitiesDuration().count() << "ms"
     << std::endl;
   s << "Warmup duration: " << activitiesWarmupDuration().count() << "s"
     << std::endl;
-  s << "Net size threshold: " << activitiesOnDemandExternalNetSizeThreshold()
-    << std::endl;
-  s << "GPU op count threshold: "
-    << activitiesOnDemandExternalGpuOpCountThreshold() << std::endl;
   s << "Max GPU buffer size: " << activitiesMaxGpuBufferSize() / 1024 / 1024
     << "MB" << std::endl;
 

--- a/libkineto/src/Config.h
+++ b/libkineto/src/Config.h
@@ -176,39 +176,19 @@ class Config : public AbstractConfig {
   }
 
   // Trace for this long
-  std::chrono::milliseconds activitiesOnDemandDuration() const {
-    return activitiesOnDemandDuration_;
+  std::chrono::milliseconds activitiesDuration() const {
+    return activitiesDuration_;
   }
 
-  std::chrono::milliseconds activitiesOnDemandDurationDefault() const;
+  std::chrono::milliseconds activitiesDurationDefault() const;
 
-  void setActivitiesOnDemandDuration(std::chrono::milliseconds duration) {
-    activitiesOnDemandDuration_ = duration;
+  void setActivitiesDuration(std::chrono::milliseconds duration) {
+    activitiesDuration_ = duration;
   }
 
   // Trace for this many iterations, determined by external API
-  int activitiesOnDemandExternalIterations() const {
+  int activitiesExternalIterations() const {
     return activitiesExternalAPIIterations_;
-  }
-
-  const std::string& activitiesOnDemandExternalTarget() const {
-    return activitiesExternalAPIIterationsTarget_;
-  }
-
-  const std::vector<std::string>& activitiesOnDemandExternalFilter() const {
-    return activitiesExternalAPIFilter_;
-  }
-
-  // Only profile nets with at least this many operators.
-  // Controlled by external API.
-  int activitiesOnDemandExternalNetSizeThreshold() const {
-    return activitiesExternalAPINetSizeThreshold_;
-  }
-
-  // Only profile nets with at least this many GPU operators.
-  // Controlled by external API.
-  int activitiesOnDemandExternalGpuOpCountThreshold() const {
-    return activitiesExternalAPIGpuOpCountThreshold_;
   }
 
   int activitiesMaxGpuBufferSize() const {
@@ -361,7 +341,7 @@ class Config : public AbstractConfig {
   std::chrono::seconds activitiesWarmupDuration_;
 
   // Profile for specified iterations and duration
-  std::chrono::milliseconds activitiesOnDemandDuration_;
+  std::chrono::milliseconds activitiesDuration_;
   int activitiesExternalAPIIterations_;
   // Use this net name for iteration count
   std::string activitiesExternalAPIIterationsTarget_;


### PR DESCRIPTION
Summary: To facilitate simplification and refactoring I'm removing some Caffe2 features that are not used for PyTorch. We might want to reintroduce similar features in the future post-refactoring, but there is no immediate use case.

Reviewed By: robieta

Differential Revision: D31538895

