### PR TITLE
Don't reset verbose level

### DIFF
--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -38,7 +38,6 @@ constexpr char kOnDemandConfigFile[] = "libkineto.conf";
 
 constexpr std::chrono::seconds kConfigUpdateIntervalSecs(300);
 constexpr std::chrono::seconds kOnDemandConfigUpdateIntervalSecs(5);
-constexpr std::chrono::seconds kOnDemandConfigVerboseLogDurationSecs(120);
 
 #ifdef __linux__
 static struct sigaction originalUsr2Handler = {};
@@ -250,7 +249,6 @@ void ConfigLoader::updateConfigThread() {
   auto now = system_clock::now();
   auto next_config_load_time = now;
   auto next_on_demand_load_time = now + onDemandConfigUpdateIntervalSecs_;
-  auto next_log_level_reset_time = now;
   seconds interval = configUpdateIntervalSecs_;
   if (interval > onDemandConfigUpdateIntervalSecs_) {
     interval = onDemandConfigUpdateIntervalSecs_;
@@ -286,12 +284,6 @@ void ConfigLoader::updateConfigThread() {
       SET_LOG_VERBOSITY_LEVEL(
           onDemandConfig->verboseLogLevel(),
           onDemandConfig->verboseLogModules());
-      next_log_level_reset_time = now + kOnDemandConfigVerboseLogDurationSecs;
-    }
-    if (now > next_log_level_reset_time) {
-      VLOG(0) << "Resetting verbose level";
-      SET_LOG_VERBOSITY_LEVEL(
-          config_->verboseLogLevel(), config_->verboseLogModules());
     }
   }
 }

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -152,7 +152,11 @@ void CuptiActivityProfiler::processCpuTrace(
 #ifdef HAS_CUPTI
 inline void CuptiActivityProfiler::handleCorrelationActivity(
     const CUpti_ActivityExternalCorrelation* correlation) {
-  cpuCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  if (correlation->externalKind == CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM0) {
+    cpuCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  } else {
+    userCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  }
 }
 #endif // HAS_CUPTI
 
@@ -173,19 +177,14 @@ static GenericTraceActivity createUserGpuSpan(
 }
 
 void CuptiActivityProfiler::GpuUserEventMap::insertOrExtendEvent(
-    const ITraceActivity&,
+    const ITraceActivity& userActivity,
     const ITraceActivity& gpuActivity) {
-  if (!gpuActivity.linkedActivity()) {
-    VLOG(0) << "Missing linked activity";
-    return;
-  }
-  const ITraceActivity& cpuActivity = *gpuActivity.linkedActivity();
   StreamKey key(gpuActivity.deviceId(), gpuActivity.resourceId());
   CorrelationSpanMap& correlationSpanMap = streamSpanMap_[key];
-  auto it = correlationSpanMap.find(cpuActivity.correlationId());
+  auto it = correlationSpanMap.find(userActivity.correlationId());
   if (it == correlationSpanMap.end()) {
     auto it_success = correlationSpanMap.insert({
-        cpuActivity.correlationId(), createUserGpuSpan(cpuActivity, gpuActivity)
+        userActivity.correlationId(), createUserGpuSpan(userActivity, gpuActivity)
     });
     it = it_success.first;
   }
@@ -236,6 +235,7 @@ void CuptiActivityProfiler::handleRuntimeActivity(
     // Ignore these
     return;
   }
+
   VLOG(2) << activity->correlationId
           << ": CUPTI_ACTIVITY_KIND_RUNTIME, cbid=" << activity->cbid
           << " tid=" << activity->threadId;
@@ -314,9 +314,19 @@ inline void CuptiActivityProfiler::handleGpuActivity(
   checkTimestampOrder(&act);
   VLOG(2) << act.correlationId() << ": "
           << act.name();
-  recordStream(act.deviceId(), act.resourceId());
+  recordStream(act.deviceId(), act.resourceId(), "");
   act.log(*logger);
   updateGpuNetSpan(act);
+  if (config_->selectedActivityTypes().count(ActivityType::GPU_USER_ANNOTATION)) {
+    const auto& it = userCorrelationMap_.find(act.correlationId());
+    if (it != userCorrelationMap_.end()) {
+      const auto& it2 = activityMap_.find(it->second);
+      if (it2 != activityMap_.end()) {
+        recordStream(act.deviceId(), -act.resourceId(), "context");
+        gpuUserEventMap_.insertOrExtendEvent(*it2->second, act);
+      }
+    }
+  }
 }
 
 const ITraceActivity* CuptiActivityProfiler::linkedActivity(

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -111,6 +111,7 @@ class CuptiActivityProfiler {
           ActivityLogger::ResourceInfo(
               pid,
               sysTid,
+              sysTid,
               fmt::format("thread {} ({})", sysTid, getThreadName())));
     }
   }
@@ -168,6 +169,7 @@ class CuptiActivityProfiler {
   // CUDA runtime <-> GPU Activity
   std::unordered_map<int64_t, const ITraceActivity*>
       correlatedCudaActivities_;
+  std::unordered_map<int64_t, int64_t> userCorrelationMap_;
 
   // data structure to collect cuptiActivityFlushAll() latency overhead
   struct profilerOverhead {
@@ -195,12 +197,13 @@ class CuptiActivityProfiler {
       ActivityLogger& logger);
 
   // Create resource names for streams
-  inline void recordStream(int device, int id) {
+  inline void recordStream(int device, int id, const char* postfix) {
     if (resourceInfo_.find({device, id}) == resourceInfo_.end()) {
       resourceInfo_.emplace(
           std::make_pair(device, id),
           ActivityLogger::ResourceInfo(
-              device, id, fmt::format("stream {}", id)));
+              device, id, id, fmt::format(
+                  "stream {} {}", id, postfix)));
     }
   }
 
@@ -242,6 +245,7 @@ class CuptiActivityProfiler {
     counter.overhead += overhead;
     counter.cntr++;
   }
+
   int64_t getOverhead(const profilerOverhead& counter) {
     if (counter.cntr == 0) {
       return 0;

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -46,9 +46,14 @@ class ActivityLogger {
   };
 
   struct ResourceInfo {
-    ResourceInfo(int64_t deviceId, int64_t id, const std::string& name) :
-        id(id), deviceId(deviceId), name(name) {}
+    ResourceInfo(
+        int64_t deviceId,
+        int64_t id,
+        int64_t sortIndex,
+        const std::string& name) :
+        id(id), sortIndex(sortIndex), deviceId(deviceId), name(name) {}
     int64_t id;
+    int64_t sortIndex;
     int64_t deviceId;
     const std::string name;
   };

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -154,7 +154,7 @@ void ChromeTraceLogger::handleResourceInfo(
       time, info.deviceId, info.id,
       info.name,
       time, info.deviceId, info.id,
-      info.id);
+      info.sortIndex);
   // clang-format on
 }
 
@@ -210,11 +210,21 @@ void ChromeTraceLogger::addIterationMarker(const TraceSpan& span) {
 
 static std::string traceActivityJson(const ITraceActivity& activity) {
   // clang-format off
+  int64_t ts = activity.timestamp();
+  int64_t duration = activity.duration();
+  if (activity.type() ==  ActivityType::GPU_USER_ANNOTATION) {
+    // The GPU user annotations start at the same time as the
+    // first associated GPU activity. Since they appear later
+    // in the trace file, this causes a visualization issue in Chrome.
+    // Make it start one us earlier.
+    ts--;
+    duration++; // Still need it to end at the orginal point
+  }
   return fmt::format(R"JSON(
     "name": "{}", "pid": {}, "tid": {},
     "ts": {}, "dur": {})JSON",
       activity.name(), activity.deviceId(), activity.resourceId(),
-      activity.timestamp(), activity.duration());
+      ts, duration);
   // clang-format on
 }
 
@@ -260,10 +270,6 @@ void ChromeTraceLogger::handleGenericActivity(
         op.traceSpan()->name,
         op.traceSpan()->iteration);
   }
-  const std::string tid =
-      op.type() == ActivityType::GPU_USER_ANNOTATION ?
-      fmt::format("stream {} annotations", op.resourceId()) :
-      fmt::format("{}", op.resourceId());
 
   // clang-format off
   traceOf_ << fmt::format(R"JSON(


### PR DESCRIPTION
Summary: If setting verbose log level via on-demand request, just leave it on permanently and leave it to the user to turn it off again. It can be annoying and confusing that it's automatically disabled after some time.

Reviewed By: briancoutinho

Differential Revision: D31665029

