### PR TITLE
Refactor 5/n: Simplify activity logger step 3/3

### DIFF
--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -295,9 +295,9 @@ bool Config::handleOption(const std::string& name, std::string& val) {
 
   // Common
   else if (!name.compare(kRequestTimestampKey)) {
-    LOG(WARNING) << kRequestTimestampKey
-                 << " has been deprecated - please use "
-                 << kProfileStartTimeKey;
+    VLOG(0) << kRequestTimestampKey
+            << " has been deprecated - please use "
+            << kProfileStartTimeKey;
     requestTimestamp_ = handleRequestTimestamp(toInt64(val));
   } else if (!name.compare(kProfileStartTimeKey)) {
     profileStartTime_ =

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -38,7 +38,6 @@ constexpr char kOnDemandConfigFile[] = "libkineto.conf";
 
 constexpr std::chrono::seconds kConfigUpdateIntervalSecs(300);
 constexpr std::chrono::seconds kOnDemandConfigUpdateIntervalSecs(5);
-constexpr std::chrono::seconds kOnDemandConfigVerboseLogDurationSecs(120);
 
 #ifdef __linux__
 static struct sigaction originalUsr2Handler = {};
@@ -217,6 +216,10 @@ void ConfigLoader::updateBaseConfig() {
       daemonConfigLoader()->setCommunicationFabric(config_->ipcFabricEnabled());
     }
     setupSignalHandler(config_->sigUsr2Enabled());
+    SET_LOG_VERBOSITY_LEVEL(
+        config_->verboseLogLevel(),
+        config_->verboseLogModules());
+    VLOG(0) << "Detected base config change";
   }
 }
 
@@ -250,7 +253,6 @@ void ConfigLoader::updateConfigThread() {
   auto now = system_clock::now();
   auto next_config_load_time = now;
   auto next_on_demand_load_time = now + onDemandConfigUpdateIntervalSecs_;
-  auto next_log_level_reset_time = now;
   seconds interval = configUpdateIntervalSecs_;
   if (interval > onDemandConfigUpdateIntervalSecs_) {
     interval = onDemandConfigUpdateIntervalSecs_;
@@ -286,12 +288,6 @@ void ConfigLoader::updateConfigThread() {
       SET_LOG_VERBOSITY_LEVEL(
           onDemandConfig->verboseLogLevel(),
           onDemandConfig->verboseLogModules());
-      next_log_level_reset_time = now + kOnDemandConfigVerboseLogDurationSecs;
-    }
-    if (now > next_log_level_reset_time) {
-      VLOG(0) << "Resetting verbose level";
-      SET_LOG_VERBOSITY_LEVEL(
-          config_->verboseLogLevel(), config_->verboseLogModules());
     }
   }
 }

--- a/libkineto/src/CudaDeviceProperties.cpp
+++ b/libkineto/src/CudaDeviceProperties.cpp
@@ -84,6 +84,36 @@ int smCount(uint32_t deviceId) {
      props[deviceId].multiProcessorCount;
 }
 
+float blocksPerSm(const CUpti_ActivityKernel4& kernel) {
+  return (kernel.gridX * kernel.gridY * kernel.gridZ) /
+      (float) smCount(kernel.deviceId);
+}
+
+float warpsPerSm(const CUpti_ActivityKernel4& kernel) {
+  constexpr int threads_per_warp = 32;
+  return blocksPerSm(kernel) *
+      (kernel.blockX * kernel.blockY * kernel.blockZ) /
+      threads_per_warp;
+}
+
+float kernelOccupancy(const CUpti_ActivityKernel4& kernel) {
+  float blocks_per_sm = -1.0;
+  int sm_count = smCount(kernel.deviceId);
+  if (sm_count) {
+    blocks_per_sm =
+        (kernel.gridX * kernel.gridY * kernel.gridZ) / (float) sm_count;
+  }
+  return kernelOccupancy(
+      kernel.deviceId,
+      kernel.registersPerThread,
+      kernel.staticSharedMemory,
+      kernel.dynamicSharedMemory,
+      kernel.blockX,
+      kernel.blockY,
+      kernel.blockZ,
+      blocks_per_sm);
+}
+
 float kernelOccupancy(
     uint32_t deviceId,
     uint16_t registersPerThread,

--- a/libkineto/src/CudaDeviceProperties.h
+++ b/libkineto/src/CudaDeviceProperties.h
@@ -10,11 +10,16 @@
 #include <stdint.h>
 #include <string>
 
+#include <cupti.h>
+
 namespace KINETO_NAMESPACE {
 
 int smCount(uint32_t deviceId);
+float blocksPerSm(const CUpti_ActivityKernel4& kernel);
+float warpsPerSm(const CUpti_ActivityKernel4& kernel);
 
 // Return estimated achieved occupancy for a kernel
+float kernelOccupancy(const CUpti_ActivityKernel4& kernel);
 float kernelOccupancy(
     uint32_t deviceId,
     uint16_t registersPerThread,

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -11,6 +11,7 @@
 
 #include "ITraceActivity.h"
 #include "CuptiActivityPlatform.h"
+#include "GenericTraceActivity.h"
 #include "ThreadUtil.h"
 #include "cupti_strings.h"
 

--- a/libkineto/src/CuptiActivity.tpp
+++ b/libkineto/src/CuptiActivity.tpp
@@ -9,6 +9,7 @@
 
 #include <fmt/format.h>
 
+#include "CudaDeviceProperties.h"
 #include "Demangle.h"
 #include "output_base.h"
 
@@ -26,7 +27,45 @@ inline ActivityType GpuActivity<CUpti_ActivityKernel4>::type() const {
   return ActivityType::CONCURRENT_KERNEL;
 }
 
-static inline std::string memcpyName(uint8_t kind, uint8_t src, uint8_t dst) {
+template<class T>
+inline void GpuActivity<T>::log(ActivityLogger& logger) const {
+  logger.handleGenericActivity(*this);
+}
+
+constexpr int64_t us(int64_t timestamp) {
+  // It's important that this conversion is the same here and in the CPU trace.
+  // No rounding!
+  return timestamp / 1000;
+}
+
+template<>
+inline const std::string GpuActivity<CUpti_ActivityKernel4>::metadataJson() const {
+  const CUpti_ActivityKernel4& kernel = raw();
+  // clang-format off
+  return fmt::format(R"JSON(
+      "queued": {}, "device": {}, "context": {},
+      "stream": {}, "correlation": {},
+      "registers per thread": {},
+      "shared memory": {},
+      "blocks per SM": {},
+      "warps per SM": {},
+      "grid": [{}, {}, {}],
+      "block": [{}, {}, {}],
+      "est. achieved occupancy %": {})JSON",
+      us(kernel.queued), kernel.deviceId, kernel.contextId,
+      kernel.streamId, kernel.correlationId,
+      kernel.registersPerThread,
+      kernel.staticSharedMemory + kernel.dynamicSharedMemory,
+      blocksPerSm(kernel),
+      warpsPerSm(kernel),
+      kernel.gridX, kernel.gridY, kernel.gridZ,
+      kernel.blockX, kernel.blockY, kernel.blockZ,
+      (int) (0.5 + kernelOccupancy(kernel) * 100.0));
+  // clang-format on
+}
+
+
+inline std::string memcpyName(uint8_t kind, uint8_t src, uint8_t dst) {
   return fmt::format(
       "Memcpy {} ({} -> {})",
       memcpyKindString((CUpti_ActivityMemcpyKind)kind),
@@ -44,6 +83,25 @@ inline const std::string GpuActivity<CUpti_ActivityMemcpy>::name() const {
   return memcpyName(raw().copyKind, raw().srcKind, raw().dstKind);
 }
 
+inline std::string bandwidth(uint64_t bytes, uint64_t duration) {
+  return duration == 0 ? "\"N/A\"" : fmt::format("{}", bytes * 1.0 / duration);
+}
+
+template<>
+inline const std::string GpuActivity<CUpti_ActivityMemcpy>::metadataJson() const {
+  const CUpti_ActivityMemcpy& memcpy = raw();
+  // clang-format off
+  return fmt::format(R"JSON(
+      "device": {}, "context": {},
+      "stream": {}, "correlation": {},
+      "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
+      memcpy.deviceId, memcpy.contextId,
+      memcpy.streamId, memcpy.correlationId,
+      memcpy.bytes, bandwidth(memcpy.bytes, memcpy.end - memcpy.start));
+  // clang-format on
+}
+
+
 template<>
 inline ActivityType GpuActivity<CUpti_ActivityMemcpy2>::type() const {
   return ActivityType::GPU_MEMCPY;
@@ -52,6 +110,22 @@ inline ActivityType GpuActivity<CUpti_ActivityMemcpy2>::type() const {
 template<>
 inline const std::string GpuActivity<CUpti_ActivityMemcpy2>::name() const {
   return memcpyName(raw().copyKind, raw().srcKind, raw().dstKind);
+}
+
+template<>
+inline const std::string GpuActivity<CUpti_ActivityMemcpy2>::metadataJson() const {
+  const CUpti_ActivityMemcpy2& memcpy = raw();
+  // clang-format off
+  return fmt::format(R"JSON(
+      "fromDevice": {}, "inDevice": {}, "toDevice": {},
+      "fromContext": {}, "inContext": {}, "toContext": {},
+      "stream": {}, "correlation": {},
+      "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
+      memcpy.srcDeviceId, memcpy.deviceId, memcpy.dstDeviceId,
+      memcpy.srcContextId, memcpy.contextId, memcpy.dstContextId,
+      memcpy.streamId, memcpy.correlationId,
+      memcpy.bytes, bandwidth(memcpy.bytes, memcpy.end - memcpy.start));
+  // clang-format on
 }
 
 template<>
@@ -66,13 +140,22 @@ inline ActivityType GpuActivity<CUpti_ActivityMemset>::type() const {
   return ActivityType::GPU_MEMSET;
 }
 
+template<>
+inline const std::string GpuActivity<CUpti_ActivityMemset>::metadataJson() const {
+  const CUpti_ActivityMemset& memset = raw();
+  // clang-format off
+  return fmt::format(R"JSON(
+      "device": {}, "context": {},
+      "stream": {}, "correlation": {},
+      "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
+      memset.deviceId, memset.contextId,
+      memset.streamId, memset.correlationId,
+      memset.bytes, bandwidth(memset.bytes, memset.end - memset.start));
+  // clang-format on
+}
+ 
 inline void RuntimeActivity::log(ActivityLogger& logger) const {
   logger.handleGenericActivity(*this);
-}
-
-template<class T>
-inline void GpuActivity<T>::log(ActivityLogger& logger) const {
-  logger.handleGpuActivity(*this);
 }
 
 inline bool RuntimeActivity::flowStart() const {
@@ -86,8 +169,7 @@ inline bool RuntimeActivity::flowStart() const {
 }
 
 inline const std::string RuntimeActivity::metadataJson() const {
-  return fmt::format(R"JSON(
-      "cbid": {}, "correlation": {})JSON",
+  return fmt::format(R"JSON("cbid": {}, "correlation": {})JSON",
       activity_.cbid, activity_.correlationId);
 }
 

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -63,41 +63,6 @@ void CuptiActivityApi::popCorrelationID(CorrelationFlowType type) {
 #endif
 }
 
-static int getSMCount() {
-#ifdef HAS_CUPTI
-  // There may be a simpler way to get the number of SMs....
-  // Look for domain_d - this has 80 instances on Volta and
-  // 56 instances on Pascal, corresponding to the number of SMs
-  // FIXME: This does not work on Turing and later
-  uint32_t domainCount{0};
-  CUPTI_CALL(cuptiDeviceGetNumEventDomains(0, &domainCount));
-  std::vector<CUpti_EventDomainID> ids(domainCount);
-  size_t sz = sizeof(CUpti_EventDomainID) * domainCount;
-  CUPTI_CALL(cuptiDeviceEnumEventDomains(0, &sz, ids.data()));
-  for (CUpti_EventDomainID id : ids) {
-    char name[16];
-    name[0] = '\0';
-    sz = sizeof(name);
-    CUPTI_CALL(cuptiEventDomainGetAttribute(
-        id, CUPTI_EVENT_DOMAIN_ATTR_NAME, &sz, name));
-    if (strncmp(name, "domain_d", sz) == 0) {
-      uint32_t count{0};
-      sz = sizeof(count);
-      CUPTI_CALL(cuptiDeviceGetEventDomainAttribute(
-          0, id, CUPTI_EVENT_DOMAIN_ATTR_TOTAL_INSTANCE_COUNT, &sz, &count));
-      return count;
-    }
-  }
-#endif
-
-  return -1;
-}
-
-int CuptiActivityApi::smCount() {
-  static int sm_count = getSMCount();
-  return sm_count;
-}
-
 static bool nextActivityRecord(
     uint8_t* buffer,
     size_t valid_size,

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -45,7 +45,6 @@ class CuptiActivityApi {
 
   static CuptiActivityApi& singleton();
 
-  virtual int smCount();
   static void pushCorrelationID(int id, CorrelationFlowType type);
   static void popCorrelationID(CorrelationFlowType type);
 

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -152,7 +152,11 @@ void CuptiActivityProfiler::processCpuTrace(
 #ifdef HAS_CUPTI
 inline void CuptiActivityProfiler::handleCorrelationActivity(
     const CUpti_ActivityExternalCorrelation* correlation) {
-  cpuCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  if (correlation->externalKind == CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM0) {
+    cpuCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  } else {
+    userCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  }
 }
 #endif // HAS_CUPTI
 
@@ -173,19 +177,14 @@ static GenericTraceActivity createUserGpuSpan(
 }
 
 void CuptiActivityProfiler::GpuUserEventMap::insertOrExtendEvent(
-    const ITraceActivity&,
+    const ITraceActivity& userActivity,
     const ITraceActivity& gpuActivity) {
-  if (!gpuActivity.linkedActivity()) {
-    VLOG(0) << "Missing linked activity";
-    return;
-  }
-  const ITraceActivity& cpuActivity = *gpuActivity.linkedActivity();
   StreamKey key(gpuActivity.deviceId(), gpuActivity.resourceId());
   CorrelationSpanMap& correlationSpanMap = streamSpanMap_[key];
-  auto it = correlationSpanMap.find(cpuActivity.correlationId());
+  auto it = correlationSpanMap.find(userActivity.correlationId());
   if (it == correlationSpanMap.end()) {
     auto it_success = correlationSpanMap.insert({
-        cpuActivity.correlationId(), createUserGpuSpan(cpuActivity, gpuActivity)
+        userActivity.correlationId(), createUserGpuSpan(userActivity, gpuActivity)
     });
     it = it_success.first;
   }
@@ -236,6 +235,7 @@ void CuptiActivityProfiler::handleRuntimeActivity(
     // Ignore these
     return;
   }
+
   VLOG(2) << activity->correlationId
           << ": CUPTI_ACTIVITY_KIND_RUNTIME, cbid=" << activity->cbid
           << " tid=" << activity->threadId;
@@ -314,9 +314,19 @@ inline void CuptiActivityProfiler::handleGpuActivity(
   checkTimestampOrder(&act);
   VLOG(2) << act.correlationId() << ": "
           << act.name();
-  recordStream(act.deviceId(), act.resourceId());
+  recordStream(act.deviceId(), act.resourceId(), "");
   act.log(*logger);
   updateGpuNetSpan(act);
+  if (config_->selectedActivityTypes().count(ActivityType::GPU_USER_ANNOTATION)) {
+    const auto& it = userCorrelationMap_.find(act.correlationId());
+    if (it != userCorrelationMap_.end()) {
+      const auto& it2 = activityMap_.find(it->second);
+      if (it2 != activityMap_.end()) {
+        recordStream(act.deviceId(), -act.resourceId(), "context");
+        gpuUserEventMap_.insertOrExtendEvent(*it2->second, act);
+      }
+    }
+  }
 }
 
 const ITraceActivity* CuptiActivityProfiler::linkedActivity(

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -111,6 +111,7 @@ class CuptiActivityProfiler {
           ActivityLogger::ResourceInfo(
               pid,
               sysTid,
+              sysTid,
               fmt::format("thread {} ({})", sysTid, getThreadName())));
     }
   }
@@ -168,6 +169,7 @@ class CuptiActivityProfiler {
   // CUDA runtime <-> GPU Activity
   std::unordered_map<int64_t, const ITraceActivity*>
       correlatedCudaActivities_;
+  std::unordered_map<int64_t, int64_t> userCorrelationMap_;
 
   // data structure to collect cuptiActivityFlushAll() latency overhead
   struct profilerOverhead {
@@ -195,12 +197,13 @@ class CuptiActivityProfiler {
       ActivityLogger& logger);
 
   // Create resource names for streams
-  inline void recordStream(int device, int id) {
+  inline void recordStream(int device, int id, const char* postfix) {
     if (resourceInfo_.find({device, id}) == resourceInfo_.end()) {
       resourceInfo_.emplace(
           std::make_pair(device, id),
           ActivityLogger::ResourceInfo(
-              device, id, fmt::format("stream {}", id)));
+              device, id, id, fmt::format(
+                  "stream {} {}", id, postfix)));
     }
   }
 
@@ -242,6 +245,7 @@ class CuptiActivityProfiler {
     counter.overhead += overhead;
     counter.cntr++;
   }
+
   int64_t getOverhead(const profilerOverhead& counter) {
     if (counter.cntr == 0) {
       return 0;

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -23,6 +23,12 @@
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+
+#ifdef HAS_CUPTI
+#include <cupti.h>
+#include "CuptiActivity.h"
+#endif // HAS_CUPTI
+
 #include "ThreadUtil.h"
 #include "TraceSpan.h"
 #include "libkineto.h"

--- a/libkineto/src/CuptiEventApi.cpp
+++ b/libkineto/src/CuptiEventApi.cpp
@@ -42,8 +42,14 @@ void CuptiEventApi::destroyGroupSets(CUpti_EventGroupSets* sets) {
 }
 
 bool CuptiEventApi::setContinuousMode() {
-  CUptiResult res = CUPTI_CALL(cuptiSetEventCollectionMode(
+  // Avoid logging noise for CUPTI_ERROR_LEGACY_PROFILER_NOT_SUPPORTED
+  CUptiResult res = CUPTI_CALL_NOWARN(cuptiSetEventCollectionMode(
       context_, CUPTI_EVENT_COLLECTION_MODE_CONTINUOUS));
+  if (res == CUPTI_ERROR_LEGACY_PROFILER_NOT_SUPPORTED) {
+    return false;
+  }
+  // Log warning on other errors
+  CUPTI_CALL(res);
   return (res == CUPTI_SUCCESS);
 }
 

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -13,10 +13,6 @@
 #include <thread>
 #include <unordered_map>
 
-#ifdef HAS_CUPTI
-#include <cupti.h>
-#include "CuptiActivity.h"
-#endif // HAS_CUPTI
 #include "ActivityBuffers.h"
 #include "GenericTraceActivity.h"
 #include "ThreadUtil.h"
@@ -24,8 +20,6 @@
 
 namespace KINETO_NAMESPACE {
   class Config;
-  class GpuKernelActivity;
-  struct RuntimeActivity;
 }
 
 namespace libkineto {
@@ -68,17 +62,6 @@ class ActivityLogger {
 
   virtual void handleGenericActivity(
       const libkineto::ITraceActivity& activity) = 0;
-
-#ifdef HAS_CUPTI
-  virtual void handleGpuActivity(
-      const GpuActivity<CUpti_ActivityKernel4>& activity) = 0;
-  virtual void handleGpuActivity(
-      const GpuActivity<CUpti_ActivityMemcpy>& activity) = 0;
-  virtual void handleGpuActivity(
-      const GpuActivity<CUpti_ActivityMemcpy2>& activity) = 0;
-  virtual void handleGpuActivity(
-      const GpuActivity<CUpti_ActivityMemset>& activity) = 0;
-#endif // HAS_CUPTI
 
   virtual void handleTraceStart(
       const std::unordered_map<std::string, std::string>& metadata) = 0;

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -46,9 +46,14 @@ class ActivityLogger {
   };
 
   struct ResourceInfo {
-    ResourceInfo(int64_t deviceId, int64_t id, const std::string& name) :
-        id(id), deviceId(deviceId), name(name) {}
+    ResourceInfo(
+        int64_t deviceId,
+        int64_t id,
+        int64_t sortIndex,
+        const std::string& name) :
+        id(id), sortIndex(sortIndex), deviceId(deviceId), name(name) {}
     int64_t id;
+    int64_t sortIndex;
     int64_t deviceId;
     const std::string name;
   };

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -154,7 +154,7 @@ void ChromeTraceLogger::handleResourceInfo(
       time, info.deviceId, info.id,
       info.name,
       time, info.deviceId, info.id,
-      info.id);
+      info.sortIndex);
   // clang-format on
 }
 
@@ -210,11 +210,21 @@ void ChromeTraceLogger::addIterationMarker(const TraceSpan& span) {
 
 static std::string traceActivityJson(const ITraceActivity& activity) {
   // clang-format off
+  int64_t ts = activity.timestamp();
+  int64_t duration = activity.duration();
+  if (activity.type() ==  ActivityType::GPU_USER_ANNOTATION) {
+    // The GPU user annotations start at the same time as the
+    // first associated GPU activity. Since they appear later
+    // in the trace file, this causes a visualization issue in Chrome.
+    // Make it start one us earlier.
+    ts--;
+    duration++; // Still need it to end at the orginal point
+  }
   return fmt::format(R"JSON(
     "name": "{}", "pid": {}, "tid": {},
     "ts": {}, "dur": {})JSON",
       activity.name(), activity.deviceId(), activity.resourceId(),
-      activity.timestamp(), activity.duration());
+      ts, duration);
   // clang-format on
 }
 
@@ -260,10 +270,6 @@ void ChromeTraceLogger::handleGenericActivity(
         op.traceSpan()->name,
         op.traceSpan()->iteration);
   }
-  const std::string tid =
-      op.type() == ActivityType::GPU_USER_ANNOTATION ?
-      fmt::format("stream {} annotations", op.resourceId()) :
-      fmt::format("{}", op.resourceId());
 
   // clang-format off
   traceOf_ << fmt::format(R"JSON(

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -44,13 +44,6 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
 
   void handleGenericActivity(const ITraceActivity& activity) override;
 
-#ifdef HAS_CUPTI
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityKernel4>& activity) override;
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemcpy>& activity) override;
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemcpy2>& activity) override;
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemset>& activity) override;
-#endif // HAS_CUPTI
-
   void handleTraceStart(
       const std::unordered_map<std::string, std::string>& metadata) override;
 

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -12,16 +12,8 @@
 #include <unordered_map>
 #include <vector>
 
-#ifdef HAS_CUPTI
-#include <cupti.h>
-#endif
-
 #include "Config.h"
 #include "GenericTraceActivity.h"
-#ifdef HAS_CUPTI
-#include "CuptiActivity.h"
-#include "CuptiActivity.tpp"
-#endif // HAS_CUPTI
 #include "output_base.h"
 
 namespace KINETO_NAMESPACE {
@@ -55,27 +47,6 @@ class MemoryTraceLogger : public ActivityLogger {
   void handleGenericActivity(const ITraceActivity& activity) override {
     activities_.push_back(&activity);
   }
-
-#ifdef HAS_CUPTI
-  template<class T>
-  void addActivityWrapper(const T& act) {
-    wrappers_.push_back(std::make_unique<T>(act));
-    activities_.push_back(wrappers_.back().get());
-  }
-
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityKernel4>& activity) override {
-    addActivityWrapper(activity);
-  }
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemcpy>& activity) override {
-    addActivityWrapper(activity);
-  }
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemcpy2>& activity) override {
-    addActivityWrapper(activity);
-  }
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemset>& activity) override {
-    addActivityWrapper(activity);
-  }
-#endif // HAS_CUPTI
 
   void handleTraceStart(
       const std::unordered_map<std::string, std::string>& metadata) override {

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -132,10 +132,6 @@ struct MockCuptiActivityBuffer {
 // Mock parts of the CuptiActivityApi
 class MockCuptiActivities : public CuptiActivityApi {
  public:
-  virtual int smCount() override {
-    return 10;
-  }
-
   virtual const std::pair<int, int> processActivities(
       CuptiActivityBufferMap&, /*unused*/
       std::function<void(const CUpti_Activity*)> handler) override {


### PR DESCRIPTION
Summary: Remove all CUPTI-specific code from the trace loggers by using handleGenericActivity for all CUPTI activities.

Differential Revision: D31665030

