### PR TITLE
Refactor memory parser logic and move the result into MemorySnapshot

### DIFF
--- a/tb_plugin/test/test_profiler.py
+++ b/tb_plugin/test/test_profiler.py
@@ -1600,7 +1600,7 @@ class TestProfiler(unittest.TestCase):
 
         profile = parse_json_trace(json_content)
         profile.process()
-        memory_stats = profile.memory_parser.get_memory_statistics()
+        memory_stats = profile.memory_snapshot.get_memory_statistics(profile.tid2tree)
 
         self.assertEqual(len(memory_stats), 2)
         self.assertIn("GPU0", memory_stats)

--- a/tb_plugin/torch_tb_profiler/plugin.py
+++ b/tb_plugin/torch_tb_profiler/plugin.py
@@ -295,7 +295,7 @@ class TorchProfilerPlugin(base_plugin.TBPlugin):
             end_ts = int(end_ts)
 
         return self.respond_as_json(
-            RunProfile.get_memory_stats(profile, start_ts=start_ts, end_ts=end_ts, memory_metric=memory_metric))
+            profile.get_memory_stats(start_ts=start_ts, end_ts=end_ts, memory_metric=memory_metric))
 
     @wrappers.Request.application
     def memory_curve_route(self, request: werkzeug.Request):
@@ -303,7 +303,7 @@ class TorchProfilerPlugin(base_plugin.TBPlugin):
         time_metric = request.args.get("time_metric", "ms")
         memory_metric = request.args.get("memory_metric", "MB")
         return self.respond_as_json(
-            RunProfile.get_memory_curve(profile, time_metric=time_metric, memory_metric=memory_metric))
+            profile.get_memory_curve(time_metric=time_metric, memory_metric=memory_metric))
 
     @wrappers.Request.application
     def memory_events_route(self, request: werkzeug.Request):

--- a/tb_plugin/torch_tb_profiler/profiler/event_parser.py
+++ b/tb_plugin/torch_tb_profiler/profiler/event_parser.py
@@ -421,7 +421,6 @@ class EventParser(NodeParserMixin, StepParser):
                 prefix = " " * prefix_len
                 print(prefix, node.name)
                 print(prefix, "time:", node.start_time, "-->", node.end_time)
-                print(prefix, "memory:", node.memory_records)
 
         def push(node: OperatorNode):
             ctx.name_stack.append(node.name)

--- a/tb_plugin/torch_tb_profiler/profiler/node.py
+++ b/tb_plugin/torch_tb_profiler/profiler/node.py
@@ -84,7 +84,6 @@ class OperatorNode(HostNode):
         self.callstack = callstack
         self.self_host_duration = self_host_duration
         self.self_device_duration = self_device_duration
-        self.memory_records = []
         # self.parent_node = None
         self.tc_eligible = self.name in TC_OP_Allowlist
         self.tc_self_duration = 0  # Time of TC kernels launched by this op excluding its children operators.

--- a/tb_plugin/torch_tb_profiler/profiler/run_generator.py
+++ b/tb_plugin/torch_tb_profiler/profiler/run_generator.py
@@ -57,9 +57,9 @@ class RunGenerator(object):
 
         profile_run.tid2tree = self.profile_data.tid2tree
 
-        if self.profile_data.memory_parser:
+        if self.profile_data.memory_snapshot:
             profile_run.views.append(consts.MEMORY_VIEW)
-            profile_run.memory_parser = self.profile_data.memory_parser
+            profile_run.memory_snapshot = self.profile_data.memory_snapshot
 
         profile_run.gpu_infos = {}
         for gpu_id in profile_run.gpu_ids:


### PR DESCRIPTION
Refactor memory parser logic and move the result into MemorySnapshot so that the tid2tree is not maintained in MemoryParser