### PR TITLE
Add option to disable input tracing

### DIFF
--- a/libkineto/include/ClientInterface.h
+++ b/libkineto/include/ClientInterface.h
@@ -13,6 +13,7 @@ class ClientInterface {
  public:
   virtual ~ClientInterface() {}
   virtual void init() = 0;
+  virtual void warmup(bool setupOpInputsCollection) = 0;
   virtual void start() = 0;
   virtual void stop() = 0;
 };

--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -65,6 +65,7 @@ class LibkinetoApi {
   void registerProfiler(std::unique_ptr<ActivityProfilerInterface> profiler) {
     activityProfiler_ = std::move(profiler);
     initClientIfRegistered();
+    initProfilerIfRegistered();
   }
 
   ActivityProfilerInterface& activityProfiler() {

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -68,6 +68,9 @@ constexpr char kActivitiesWarmupDurationSecsKey[] = "ACTIVITIES_WARMUP_PERIOD_SE
 constexpr char kActivitiesMaxGpuBufferSizeKey[] =
     "ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB";
 
+// Client Interface
+constexpr char kClientInterfaceEnableOpInputsCollection[] = "CLIENT_INTERFACE_ENABLE_OP_INPUTS_COLLECTION";
+
 // Common
 
 // Client-side timestamp used for synchronized start across hosts for
@@ -291,6 +294,11 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     activitiesMaxGpuBufferSize_ = toInt32(val) * 1024 * 1024;
   } else if (!name.compare(kActivitiesWarmupDurationSecsKey)) {
     activitiesWarmupDuration_ = seconds(toInt32(val));
+  }
+
+  // Client Interface
+  else if (!name.compare(kClientInterfaceEnableOpInputsCollection)) {
+    enableOpInputsCollection_ = toBool(val);  
   }
 
   // Common

--- a/libkineto/src/Config.h
+++ b/libkineto/src/Config.h
@@ -175,6 +175,10 @@ class Config : public AbstractConfig {
     selectedActivityTypes_ = types;
   }
 
+  bool isOpInputsCollectionEnabled() const {
+    return enableOpInputsCollection_;
+  }
+
   // Trace for this long
   std::chrono::milliseconds activitiesDuration() const {
     return activitiesDuration_;
@@ -339,6 +343,10 @@ class Config : public AbstractConfig {
 
   int activitiesMaxGpuBufferSize_;
   std::chrono::seconds activitiesWarmupDuration_;
+
+  // Client Interface
+  // Enable inputs collection when tracing ops
+  bool enableOpInputsCollection_{true};
 
   // Profile for specified iterations and duration
   std::chrono::milliseconds activitiesDuration_;

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -466,6 +466,10 @@ void CuptiActivityProfiler::configure(
   if (profilers_.size() > 0) {
     configureChildProfilers();
   }
+
+  if (libkineto::api().client()) {
+    libkineto::api().client()->warmup(config_->isOpInputsCollectionEnabled());
+  }
   LOG(INFO) << "Tracing starting in "
             << duration_cast<seconds>(profileStartTime_ - now).count() << "s";
 


### PR DESCRIPTION
Summary: Inputs in operators are seldom used for GPU inference workstream but also the worst overhead - it adds about 50% overhead in RecordFunction collection path. Add option to opt out. After this finding is more well published, we can look into making this turned off by default and have people opt in until we can handle the overhead

Reviewed By: swolchok

Differential Revision: D32689430

