### PR TITLE
fill self_host_duration for backward node

### DIFF
--- a/tb_plugin/torch_tb_profiler/profiler/node.py
+++ b/tb_plugin/torch_tb_profiler/profiler/node.py
@@ -181,8 +181,8 @@ class BackwardNode(OperatorNode):
         super().__init__(**kwargs)
 
     def fill_stats(self):
-        '''Override the timestamps and duration for BackwardNode only
-        '''
+        """Override the timestamps and duration for BackwardNode only
+        """
         self.children.sort(key=lambda x: (x.start_time, -x.end_time))
         self.start_time = self.children[0].start_time
         self.end_time = self.children[-1].end_time

--- a/tb_plugin/torch_tb_profiler/profiler/node.py
+++ b/tb_plugin/torch_tb_profiler/profiler/node.py
@@ -180,6 +180,22 @@ class BackwardNode(OperatorNode):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+    def fill_stats(self):
+        '''Override the timestamps and duration for BackwardNode only
+        '''
+        self.children.sort(key=lambda x: (x.start_time, -x.end_time))
+        self.start_time = self.children[0].start_time
+        self.end_time = self.children[-1].end_time
+
+        self.self_host_duration = self.end_time - self.start_time
+        for child in self.children:
+            self.device_duration += child.device_duration
+            self.self_host_duration -= (child.end_time - child.start_time)
+            self.tc_total_duration += child.tc_total_duration
+            # Mark TC eligible as True if any child operator is TC eligible.
+            if not self.tc_eligible and child.tc_eligible:
+                self.tc_eligible = True
+
 
 class RuntimeNode(HostNode):
     def __init__(self, device_nodes: Optional[List['DeviceNode']] = None, **kwargs):

--- a/tb_plugin/torch_tb_profiler/profiler/op_tree.py
+++ b/tb_plugin/torch_tb_profiler/profiler/op_tree.py
@@ -283,9 +283,7 @@ class OpTreeBuilder:
             OpTreeBuilder._build_backward_module(child, parent, fwd_bwd_map, result)
 
         if isinstance(node, ModuleNode) and parent and parent.children:
-            parent.children.sort(key=lambda x: (x.start_time, -x.end_time))
-            parent.start_time = parent.children[0].start_time
-            parent.end_time = parent.children[-1].end_time
+            parent.fill_stats()
             parent.tid = parent.children[0].tid
 
     @staticmethod


### PR DESCRIPTION
Override BackwardNode.fill_stats to fix the device_duration of BackwardNode.