### PR TITLE
Remove static init / destruction of LoggerObservers, instead use the lifetime of ConfigLoader to own LoggerObservers and lock

### DIFF
--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -17,6 +17,10 @@
 
 #include "Config.h"
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "ILoggerObserver.h"
+
 namespace libkineto {
   class LibkinetoApi;
 }
@@ -138,6 +142,11 @@ class ConfigLoader {
   std::mutex updateThreadMutex_;
   std::atomic_bool stopFlag_{false};
   std::atomic_bool onDemandSignal_{false};
+
+#if !USE_GOOGLE_LOG
+  std::unique_ptr<std::set<ILoggerObserver*>> loggerObservers_;
+  std::unique_ptr<std::mutex> loggerObserversMutex_;
+#endif // !USE_GOOGLE_LOG
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -16,8 +16,6 @@
 #include <cstring>
 #include <iomanip>
 #include <iostream>
-#include <mutex>
-#include <set>
 #include <time.h>
 
 #include <fmt/chrono.h>
@@ -30,14 +28,8 @@ namespace KINETO_NAMESPACE {
 std::atomic_int Logger::severityLevel_{VERBOSE};
 std::atomic_int Logger::verboseLogLevel_{-1};
 std::atomic<uint64_t> Logger::verboseLogModules_{~0ull};
-static std::set<ILoggerObserver*>& LoggerObservers() {
-  static std::set<ILoggerObserver*> observers;
-  return observers;
-}
-static std::mutex& mutex() {
-  static std::mutex mutex_;
-  return mutex_;
-}
+std::set<ILoggerObserver*>* Logger::loggerObservers_{nullptr};
+std::mutex* Logger::loggerObserversMutex_{nullptr};
 
 Logger::Logger(int severity, int line, const char* filePath, int errnum)
     : buf_(), out_(LIBKINETO_DBG_STREAM), errnum_(errnum), messageSeverity_(severity) {
@@ -59,11 +51,16 @@ Logger::~Logger() {
   }
 #endif
 
-  {
-    std::lock_guard<std::mutex> guard(mutex());
+  auto mutex = LoggerObserversMutex();
+  if (mutex) {
+    std::lock_guard<std::mutex> guard(*mutex);
     // Output to observers. Current Severity helps keep track of which bucket the output goes.
-    for (auto& observer : LoggerObservers()) {
-      observer->write(buf_.str(), (LoggerOutputType) messageSeverity_);
+    if (loggerObservers()) {
+      for (auto observer : *loggerObservers()) {
+        if (observer) {
+          observer->write(buf_.str(), (LoggerOutputType) messageSeverity_);
+        }
+      }
     }
   }
 
@@ -84,13 +81,23 @@ void Logger::setVerboseLogModules(const std::vector<std::string>& modules) {
 }
 
 void Logger::addLoggerObserver(ILoggerObserver* observer) {
-  std::lock_guard<std::mutex> guard(mutex());
-  LoggerObservers().insert(observer);
+  auto mutex = LoggerObserversMutex();
+  if (mutex) {
+    std::lock_guard<std::mutex> guard(*mutex);
+    if (loggerObservers()) {
+      loggerObservers()->insert(observer);
+    }
+  }
 }
 
 void Logger::removeLoggerObserver(ILoggerObserver* observer) {
-  std::lock_guard<std::mutex> guard(mutex());
-  LoggerObservers().erase(observer);
+  auto mutex = LoggerObserversMutex();
+  if (mutex) {
+    std::lock_guard<std::mutex> guard(*mutex);
+    if (loggerObservers()) {
+      loggerObservers()->erase(observer);
+    }
+  }
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -26,12 +26,15 @@
 
 #define SET_LOG_SEVERITY_LEVEL(level)
 #define SET_LOG_VERBOSITY_LEVEL(level, modules)
+#define SET_LOGGER_OBSERVER_SET_AND_MUTEX(observers, lock)
 
 #else // !USE_GOOGLE_LOG
 #include <stdio.h>
 #include <atomic>
 #include <map>
+#include <mutex>
 #include <ostream>
+#include <set>
 #include <string>
 #include <sstream>
 #include <vector>
@@ -101,6 +104,22 @@ class Logger {
     return verboseLogModules_;
   }
 
+  static inline void setLoggerObservers(std::set<ILoggerObserver*>* observers) {
+    loggerObservers_ = observers;
+  }
+
+  static inline std::set<ILoggerObserver*>* loggerObservers() {
+    return loggerObservers_;
+  }
+
+  static inline void setLoggerObserversMutex(std::mutex* mutex) {
+    loggerObserversMutex_ = mutex;
+  }
+
+  static inline std::mutex* LoggerObserversMutex() {
+    return loggerObserversMutex_;
+  }
+
   static void addLoggerObserver(ILoggerObserver* observer);
 
   static void removeLoggerObserver(ILoggerObserver* observer);
@@ -113,6 +132,8 @@ class Logger {
   static std::atomic_int severityLevel_;
   static std::atomic_int verboseLogLevel_;
   static std::atomic<uint64_t> verboseLogModules_;
+  static std::set<ILoggerObserver*>* loggerObservers_;
+  static std::mutex* loggerObserversMutex_;
 };
 
 class VoidLogger {
@@ -195,5 +216,9 @@ struct __to_constant__ {
 #define SET_LOG_VERBOSITY_LEVEL(level, modules)   \
   libkineto::Logger::setVerboseLogLevel(level); \
   libkineto::Logger::setVerboseLogModules(modules)
+
+#define SET_LOGGER_OBSERVER_SET_AND_MUTEX(observers, lock) \
+  libkineto::Logger::setLoggerObservers(observers); \
+  libkineto::Logger::setLoggerObserversMutex(lock)
 
 #endif // USE_GOOGLE_LOG


### PR DESCRIPTION
Summary: Rather than using a static function to initialize the LoggerObserver and mutex, move these two into the ConfigLoader. Add additional checks to avoid segmentation faults or accesses to heap after free.

Differential Revision: D32972989

