### PR TITLE
Collect trace duration, event count, and devices in Logger

### DIFF
--- a/libkineto/include/ILoggerObserver.h
+++ b/libkineto/include/ILoggerObserver.h
@@ -35,6 +35,7 @@ class ILoggerObserver {
   virtual ~ILoggerObserver() = default;
   virtual void write(const std::string& message, LoggerOutputType ot) = 0;
   virtual const std::map<LoggerOutputType, std::vector<std::string>> extractCollectorMetadata() = 0;
+  virtual void reset() = 0;
   virtual void addDevice(const int64_t device) = 0;
   virtual void setTraceDurationMS(const int64_t duration) = 0;
   virtual void addEventCount(const int64_t count) = 0;

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -155,11 +155,6 @@ void ConfigLoader::startThread() {
     }
     updateThread_ =
         std::make_unique<std::thread>(&ConfigLoader::updateConfigThread, this);
-#if !USE_GOOGLE_LOG
-    loggerObservers_ = std::make_unique<std::set<ILoggerObserver*>>();
-    // Link the Logger Observers set to the Logger.
-    SET_LOGGER_OBSERVER_SET_AND_MUTEX(loggerObservers_.get(), &loggerObserversMutex_);
-#endif // !USE_GOOGLE_LOG
   }
 }
 
@@ -173,11 +168,7 @@ ConfigLoader::~ConfigLoader() {
     updateThread_->join();
   }
 #if !USE_GOOGLE_LOG
-  {
-    std::lock_guard<std::mutex> lock(loggerObserversMutex_);
-    // Un-link the observers since I am being deleted.
-    SET_LOGGER_OBSERVER_SET_AND_MUTEX(nullptr, nullptr);
-  }
+  Logger::clearLoggerObservers();
 #endif // !USE_GOOGLE_LOG
 }
 

--- a/libkineto/src/CudaDeviceProperties.cpp
+++ b/libkineto/src/CudaDeviceProperties.cpp
@@ -36,6 +36,7 @@ static const std::vector<cudaDeviceProp> createDeviceProps() {
       return {};
     }
     props.push_back(prop);
+    LOGGER_OBSERVER_ADD_DEVICE(i);
   }
   return props;
 }

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -79,6 +79,9 @@ void Logger::setVerboseLogModules(const std::vector<std::string>& modules) {
 }
 
 void Logger::addLoggerObserver(ILoggerObserver* observer) {
+  if (observer == nullptr) {
+    return;
+  }
 #if !USE_GOOGLE_LOG
   std::lock_guard<std::mutex> guard(loggerObserversMutex_);
   loggerObservers().insert(observer);
@@ -90,6 +93,27 @@ void Logger::removeLoggerObserver(ILoggerObserver* observer) {
   std::lock_guard<std::mutex> guard(loggerObserversMutex_);
   loggerObservers().erase(observer);
 #endif
+}
+
+void Logger::addLoggerObserverDevice(int64_t device) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex_);
+  for (auto observer : loggerObservers()) {
+    observer->addDevice(device);
+  }
+}
+
+void Logger::addLoggerObserverEventCount(int64_t count) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex_);
+  for (auto observer : loggerObservers()) {
+    observer->addEventCount(count);
+  }
+}
+
+void Logger::setLoggerObserverTraceDurationMS(int64_t duration) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex_);
+  for (auto observer : loggerObservers()) {
+    observer->setTraceDurationMS(duration);
+  }
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -12,6 +12,9 @@
 
 #define SET_LOG_SEVERITY_LEVEL(level)
 #define SET_LOG_VERBOSITY_LEVEL(level, modules)
+#define LOGGER_OBSERVER_ADD_DEVICE(device)
+#define LOGGER_OBSERVER_ADD_EVENT_COUNT(count)
+#define LOGGER_OBSERVER_SET_TRACE_DURATION_MS(duration)
 #define UST_LOGGER_MARK_COMPLETED(stage)
 
 #else // !USE_GOOGLE_LOG
@@ -99,7 +102,15 @@ class Logger {
   static void addLoggerObserver(ILoggerObserver* observer);
 
   static void removeLoggerObserver(ILoggerObserver* observer);
+
+  static void addLoggerObserverDevice(int64_t device);
+
+  static void addLoggerObserverEventCount(int64_t count);
+
+  static void setLoggerObserverTraceDurationMS(int64_t duration);
+
 #endif
+
  private:
   std::stringstream buf_;
   std::ostream& out_;
@@ -197,6 +208,15 @@ struct __to_constant__ {
 #define SET_LOG_VERBOSITY_LEVEL(level, modules)   \
   libkineto::Logger::setVerboseLogLevel(level); \
   libkineto::Logger::setVerboseLogModules(modules)
+
+#define LOGGER_OBSERVER_ADD_DEVICE(device_count) \
+  libkineto::Logger::addLoggerObserverDevice(device_count)
+
+#define LOGGER_OBSERVER_ADD_EVENT_COUNT(count) \
+  libkineto::Logger::addLoggerObserverEventCount(count)
+
+#define LOGGER_OBSERVER_SET_TRACE_DURATION_MS(duration) \
+  libkineto::Logger::setLoggerObserverTraceDurationMS(duration)
 
 // UST Logger Semantics to describe when a stage is complete.
 #define UST_LOGGER_MARK_COMPLETED(stage) \

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -12,7 +12,6 @@
 
 #define SET_LOG_SEVERITY_LEVEL(level)
 #define SET_LOG_VERBOSITY_LEVEL(level, modules)
-#define SET_LOGGER_OBSERVER_SET_AND_MUTEX(observers, lock)
 #define UST_LOGGER_MARK_COMPLETED(stage)
 
 #else // !USE_GOOGLE_LOG
@@ -91,26 +90,16 @@ class Logger {
     return verboseLogModules_;
   }
 
-  static inline void setLoggerObservers(std::set<ILoggerObserver*>* observers) {
-    loggerObservers_ = observers;
-  }
-
-  static inline std::set<ILoggerObserver*>* loggerObservers() {
-    return loggerObservers_;
-  }
-
-  static inline void setLoggerObserversMutex(std::mutex* mutex) {
-    loggerObserversMutex_ = mutex;
-  }
-
-  static inline std::mutex* LoggerObserversMutex() {
-    return loggerObserversMutex_;
+#if !USE_GOOGLE_LOG
+  static void clearLoggerObservers() {
+    std::lock_guard<std::mutex> g(loggerObserversMutex_);
+    loggerObservers().clear();
   }
 
   static void addLoggerObserver(ILoggerObserver* observer);
 
   static void removeLoggerObserver(ILoggerObserver* observer);
-
+#endif
  private:
   std::stringstream buf_;
   std::ostream& out_;
@@ -119,8 +108,13 @@ class Logger {
   static std::atomic_int severityLevel_;
   static std::atomic_int verboseLogLevel_;
   static std::atomic<uint64_t> verboseLogModules_;
-  static std::set<ILoggerObserver*>* loggerObservers_;
-  static std::mutex* loggerObserversMutex_;
+#if !USE_GOOGLE_LOG
+  static std::set<ILoggerObserver*>& loggerObservers() {
+    static auto* inst = new std::set<ILoggerObserver*>();
+    return *inst;
+  }
+  static std::mutex loggerObserversMutex_;
+#endif
 };
 
 class VoidLogger {
@@ -203,10 +197,6 @@ struct __to_constant__ {
 #define SET_LOG_VERBOSITY_LEVEL(level, modules)   \
   libkineto::Logger::setVerboseLogLevel(level); \
   libkineto::Logger::setVerboseLogModules(modules)
-
-#define SET_LOGGER_OBSERVER_SET_AND_MUTEX(observers, lock) \
-  libkineto::Logger::setLoggerObservers(observers); \
-  libkineto::Logger::setLoggerObserversMutex(lock)
 
 // UST Logger Semantics to describe when a stage is complete.
 #define UST_LOGGER_MARK_COMPLETED(stage) \

--- a/libkineto/src/LoggerCollector.h
+++ b/libkineto/src/LoggerCollector.h
@@ -30,6 +30,11 @@ class LoggerCollector : public ILoggerObserver {
     return buckets_;
   }
 
+  void reset() override {
+    trace_duration_ms = 0;
+    event_count = 0;
+  }
+
   void addDevice(const int64_t device) override {
     devices.insert(device);
   }
@@ -47,7 +52,7 @@ class LoggerCollector : public ILoggerObserver {
 
   // These are useful metadata to collect from CUPTIActivityProfiler for internal tracking.
   std::set<int64_t> devices;
-  int64_t trace_duration_ms;
+  int64_t trace_duration_ms{0};
   std::atomic<uint64_t> event_count{0};
 
 };


### PR DESCRIPTION
Summary: Push to UST Logger the trace duration in milliseconds, the number of event counts collected in a trace, and the devices.

Differential Revision: D33071551

