### PR TITLE
Simplify Logger observers

### DIFF
--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -155,11 +155,6 @@ void ConfigLoader::startThread() {
     }
     updateThread_ =
         std::make_unique<std::thread>(&ConfigLoader::updateConfigThread, this);
-#if !USE_GOOGLE_LOG
-    loggerObservers_ = std::make_unique<std::set<ILoggerObserver*>>();
-    // Link the Logger Observers set to the Logger.
-    SET_LOGGER_OBSERVER_SET_AND_MUTEX(loggerObservers_.get(), &loggerObserversMutex_);
-#endif // !USE_GOOGLE_LOG
   }
 }
 
@@ -173,11 +168,7 @@ ConfigLoader::~ConfigLoader() {
     updateThread_->join();
   }
 #if !USE_GOOGLE_LOG
-  {
-    std::lock_guard<std::mutex> lock(loggerObserversMutex_);
-    // Un-link the observers since I am being deleted.
-    SET_LOGGER_OBSERVER_SET_AND_MUTEX(nullptr, nullptr);
-  }
+  Logger::clearLoggerObservers();
 #endif // !USE_GOOGLE_LOG
 }
 

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -23,8 +23,12 @@ namespace KINETO_NAMESPACE {
 std::atomic_int Logger::severityLevel_{VERBOSE};
 std::atomic_int Logger::verboseLogLevel_{-1};
 std::atomic<uint64_t> Logger::verboseLogModules_{~0ull};
-std::set<ILoggerObserver*>* Logger::loggerObservers_{nullptr};
-std::mutex* Logger::loggerObserversMutex_{nullptr};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wglobal-constructors"
+std::mutex Logger::loggerObserversMutex_;
+#pragma GCC diagnostic pop
+
 
 Logger::Logger(int severity, int line, const char* filePath, int errnum)
     : buf_(), out_(LIBKINETO_DBG_STREAM), errnum_(errnum), messageSeverity_(severity) {
@@ -46,15 +50,12 @@ Logger::~Logger() {
   }
 #endif
 
-  auto mutex = LoggerObserversMutex();
-  if (mutex) {
-    std::lock_guard<std::mutex> guard(*mutex);
-    // Output to observers. Current Severity helps keep track of which bucket the output goes.
-    if (loggerObservers()) {
-      for (auto observer : *loggerObservers()) {
-        if (observer) {
-          observer->write(buf_.str(), (LoggerOutputType) messageSeverity_);
-        }
+  {
+    std::lock_guard<std::mutex> guard(loggerObserversMutex_);
+    for (auto* observer : loggerObservers()) {
+      // Output to observers. Current Severity helps keep track of which bucket the output goes.
+      if (observer) {
+        observer->write(buf_.str(), (LoggerOutputType) messageSeverity_);
       }
     }
   }
@@ -76,23 +77,13 @@ void Logger::setVerboseLogModules(const std::vector<std::string>& modules) {
 }
 
 void Logger::addLoggerObserver(ILoggerObserver* observer) {
-  auto mutex = LoggerObserversMutex();
-  if (mutex) {
-    std::lock_guard<std::mutex> guard(*mutex);
-    if (loggerObservers()) {
-      loggerObservers()->insert(observer);
-    }
-  }
+  std::lock_guard<std::mutex> guard(loggerObserversMutex_);
+  loggerObservers().insert(observer);
 }
 
 void Logger::removeLoggerObserver(ILoggerObserver* observer) {
-  auto mutex = LoggerObserversMutex();
-  if (mutex) {
-    std::lock_guard<std::mutex> guard(*mutex);
-    if (loggerObservers()) {
-      loggerObservers()->erase(observer);
-    }
-  }
+  std::lock_guard<std::mutex> guard(loggerObserversMutex_);
+  loggerObservers().erase(observer);
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/test/LoggerObserverTest.cpp
+++ b/libkineto/test/LoggerObserverTest.cpp
@@ -17,26 +17,7 @@ constexpr char InfoTestStr[] = "Checking LOG(INFO)";
 constexpr char WarningTestStr[] = "Checking LOG(WARNING)";
 constexpr char ErrorTestStr[] = "Checking LOG(ERROR)";
 
-class LoggerObserverTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    loggerObservers_ = std::make_unique<std::set<ILoggerObserver*>>();
-    // Link the Logger Observers set to the Logger.
-    SET_LOGGER_OBSERVER_SET_AND_MUTEX(loggerObservers_.get(), &loggerObserversMutex_);
-  }
-  void TearDown() override {
-    {
-      std::lock_guard<std::mutex> lock(loggerObserversMutex_);
-      // Un-link the observers since I am being deleted.
-      SET_LOGGER_OBSERVER_SET_AND_MUTEX(nullptr, nullptr);
-    }
-  }
-
-  std::unique_ptr<std::set<ILoggerObserver*>> loggerObservers_;
-  std::mutex loggerObserversMutex_;
-};
-
-TEST_F(LoggerObserverTest, SingleCollectorObserver) {
+TEST(LoggerObserverTest, SingleCollectorObserver) {
   // Add a LoggerObserverCollector to collect all logs during the trace.
   std::unique_ptr<LoggerCollector> lCollector = std::make_unique<LoggerCollector>();
   Logger::addLoggerObserver(lCollector.get());
@@ -67,7 +48,7 @@ void* writeSeveralMessages(void* ptr) {
   return nullptr;
 }
 
-TEST_F(LoggerObserverTest, FourCollectorObserver) {
+TEST(LoggerObserverTest, FourCollectorObserver) {
   // There shouldn't be too many CUPTIActivityProfilers active at the same time.
   std::unique_ptr<LoggerCollector> lc1 = std::make_unique<LoggerCollector>();
   std::unique_ptr<LoggerCollector> lc2 = std::make_unique<LoggerCollector>();


### PR DESCRIPTION
Summary: This seems like a simpler way to set up the kineto Logger observers. Unlike a previous attempt to do it this way, we 1) suppress the -Wglobal-constructors diagnostic and 2) work around SIOF by putting our global singleton set on the heap.

Reviewed By: aaronenyeshi

Differential Revision: D33690834

