### PR TITLE
kineto] enable iteration tracking and trace trigger using it

### DIFF
--- a/libkineto/include/ActivityProfilerInterface.h
+++ b/libkineto/include/ActivityProfilerInterface.h
@@ -58,6 +58,10 @@ class ActivityProfilerInterface {
     return nullptr;
   }
 
+  // Re-evaluate internal state to allow for triggering operations based
+  // on number of iteration. each implicitly increments the iteration count
+  virtual void step() {}
+
   // *** TraceActivity API ***
   // FIXME: Pass activityProfiler interface into clientInterface?
   virtual void pushCorrelationId(uint64_t id){}

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -102,17 +102,18 @@ void ActivityProfilerController::profilerLoop() {
 
     if (!profiler_->isActive()) {
       std::lock_guard<std::mutex> lock(asyncConfigLock_);
-      if (asyncRequestConfig_) {
+      if (asyncRequestConfig_
+          && !asyncRequestConfig_->hasProfileStartIteration()) {
         // Note on now + kProfilerIntervalMsecs
         // Profiler interval does not align perfectly upto startTime - warmup. Waiting until the next tick
         // won't allow sufficient time for the profiler to warm up. So check if we are very close to the warmup time and trigger warmup
         if (now + kProfilerIntervalMsecs
             >= (asyncRequestConfig_->requestTimestamp() - asyncRequestConfig_->activitiesWarmupDuration())) {
-          LOG(INFO) << "Received on-demand activity trace request";
-          logger_ = makeLogger(*asyncRequestConfig_);
-          profiler_->setLogger(logger_.get());
-          profiler_->configure(*asyncRequestConfig_, now);
-          asyncRequestConfig_ = nullptr;
+          LOG(INFO) << "Received on-demand activity trace request by "
+                    << " profile timestamp = "
+                    << asyncRequestConfig_->
+                    requestTimestamp().time_since_epoch().count();
+          activateConfig(now);
         }
       }
     }
@@ -132,14 +133,63 @@ void ActivityProfilerController::profilerLoop() {
   VLOG(0) << "Exited activity profiling loop";
 }
 
+void ActivityProfilerController::step() {
+  int64_t currentIter = ++iterationCount_;
+  VLOG(0) << "Step called , iteration  = " << currentIter;
+
+  // optimization to not take the lock unless necessary
+  if (asyncRequestConfig_ && !profiler_->isActive()) {
+    std::lock_guard<std::mutex> lock(asyncConfigLock_);
+
+    auto startIter = asyncRequestConfig_->profileStartIteration() -
+      asyncRequestConfig_->activitiesWarmupIterations();
+
+    if (asyncRequestConfig_->hasProfileStartIteration()
+        && currentIter >= startIter) {
+      LOG(INFO) << "Received on-demand activity trace request by profile"
+                << " start iteration = "
+                << asyncRequestConfig_->profileStartIteration()
+                << " current iteration = " << currentIter;
+      if (currentIter > startIter) {
+        // adjust the start iteration if it is in the past
+        auto newProfileStart = currentIter +
+          asyncRequestConfig_->activitiesWarmupIterations();
+        asyncRequestConfig_->setProfileStartIteration(newProfileStart);
+        LOG(INFO) << "Start iteration updated to " << newProfileStart;
+      }
+      activateConfig(system_clock::now());
+    }
+  }
+
+  if (profiler_->isActive()) {
+    auto now = system_clock::now();
+    auto next_wakeup_time = now + kProfilerIntervalMsecs;
+    profiler_->performRunLoopStep(now, next_wakeup_time, currentIter);
+  }
+}
+
+void ActivityProfilerController::activateConfig(
+    std::chrono::time_point<std::chrono::system_clock> now) {
+  logger_ = makeLogger(*asyncRequestConfig_);
+  profiler_->setLogger(logger_.get());
+  profiler_->configure(*asyncRequestConfig_, now);
+  asyncRequestConfig_ = nullptr;
+}
+
 void ActivityProfilerController::scheduleTrace(const Config& config) {
   VLOG(1) << "scheduleTrace";
   if (profiler_->isActive()) {
     LOG(ERROR) << "Ignored request - profiler busy";
     return;
   }
+  if (config.hasProfileStartIteration() && iterationCount_ < 0) {
+    LOG(ERROR) << "Ignored profile iteration count based request as "
+               << "application is not updating iteration count";
+    return;
+  }
   std::lock_guard<std::mutex> lock(asyncConfigLock_);
   asyncRequestConfig_ = config.clone();
+
   // start a profilerLoop() thread to handle request
   if (!profilerThread_) {
     profilerThread_ =

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -42,6 +42,8 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
     profiler_->startTrace(std::chrono::system_clock::now());
   }
 
+  void step();
+
   std::unique_ptr<ActivityTraceInterface> stopTrace();
 
   bool isActive() {
@@ -66,6 +68,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
 
  private:
   void profilerLoop();
+  void activateConfig(std::chrono::time_point<std::chrono::system_clock> now);
 
   std::unique_ptr<Config> asyncRequestConfig_;
   std::mutex asyncConfigLock_;
@@ -73,6 +76,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   std::unique_ptr<ActivityLogger> logger_;
   std::thread* profilerThread_{nullptr};
   std::atomic_bool stopRunloop_{false};
+  std::atomic_int64_t iterationCount_{-1};
   ConfigLoader& configLoader_;
 };
 

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -52,6 +52,10 @@ ActivityProfilerProxy::stopTrace() {
   return controller_->stopTrace();
 }
 
+void ActivityProfilerProxy::step() {
+  controller_->step();
+}
+
 bool ActivityProfilerProxy::isActive() {
   return controller_->isActive();
 }

--- a/libkineto/src/ActivityProfilerProxy.h
+++ b/libkineto/src/ActivityProfilerProxy.h
@@ -44,6 +44,7 @@ class ActivityProfilerProxy : public ActivityProfilerInterface {
 
   void prepareTrace(const std::set<ActivityType>& activityTypes) override;
   void startTrace() override;
+  void step() override;
   std::unique_ptr<ActivityTraceInterface> stopTrace() override;
 
   void pushCorrelationId(uint64_t id) override;

--- a/libkineto/src/Config.h
+++ b/libkineto/src/Config.h
@@ -179,15 +179,15 @@ class Config : public AbstractConfig {
     return activitiesDuration_;
   }
 
+  // Trace for this many iterations, determined by external API
+  int activitiesRunIterations() const {
+    return activitiesRunIterations_;
+  }
+
   std::chrono::milliseconds activitiesDurationDefault() const;
 
   void setActivitiesDuration(std::chrono::milliseconds duration) {
     activitiesDuration_ = duration;
-  }
-
-  // Trace for this many iterations, determined by external API
-  int activitiesExternalIterations() const {
-    return activitiesExternalAPIIterations_;
   }
 
   int activitiesMaxGpuBufferSize() const {
@@ -196,6 +196,10 @@ class Config : public AbstractConfig {
 
   std::chrono::seconds activitiesWarmupDuration() const {
     return activitiesWarmupDuration_;
+  }
+
+  int activitiesWarmupIterations() const {
+    return activitiesWarmupIterations_;
   }
 
   // Timestamp at which the profiling to start, requested by the user.
@@ -212,6 +216,18 @@ class Config : public AbstractConfig {
   bool hasProfileStartTime() const {
     return requestTimestamp_.time_since_epoch().count() > 0 ||
         profileStartTime_.time_since_epoch().count() > 0;
+  }
+
+  int profileStartIteration() const {
+    return profileStartIteration_;
+  }
+
+  bool hasProfileStartIteration() const {
+    return profileStartIteration_ >= 0 && activitiesRunIterations_ > 0;
+  }
+
+  void setProfileStartIteration(int64_t iter) {
+    profileStartIteration_ = iter;
   }
 
   const std::chrono::seconds maxRequestAge() const;
@@ -355,6 +371,7 @@ class Config : public AbstractConfig {
 
   int activitiesMaxGpuBufferSize_;
   std::chrono::seconds activitiesWarmupDuration_;
+  int activitiesWarmupIterations_;
 
   // Client Interface
   // Enable inputs collection when tracing ops
@@ -362,7 +379,9 @@ class Config : public AbstractConfig {
 
   // Profile for specified iterations and duration
   std::chrono::milliseconds activitiesDuration_;
-  int activitiesExternalAPIIterations_;
+  int activitiesRunIterations_;
+
+  // Below are not used
   // Use this net name for iteration count
   std::string activitiesExternalAPIIterationsTarget_;
   // Only profile nets that includes this in the name
@@ -377,6 +396,9 @@ class Config : public AbstractConfig {
 
   // Synchronized start timestamp
   std::chrono::time_point<std::chrono::system_clock> profileStartTime_;
+  // or start iteration
+  int profileStartIteration_;
+
   // DEPRECATED
   std::chrono::time_point<std::chrono::system_clock> requestTimestamp_;
 

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -50,7 +50,8 @@ class CuptiActivityProfiler {
   // memory usage limit (ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB) during warmup.
   const std::chrono::time_point<std::chrono::system_clock> performRunLoopStep(
       const std::chrono::time_point<std::chrono::system_clock>& now,
-      const std::chrono::time_point<std::chrono::system_clock>& nextWakeupTime);
+      const std::chrono::time_point<std::chrono::system_clock>& nextWakeupTime,
+      int64_t currentIter = -1);
 
   // Used for async requests
   void setLogger(ActivityLogger* logger) {
@@ -175,6 +176,14 @@ class CuptiActivityProfiler {
     int cntr;
   };
 
+  bool isWarmupDone(
+      const std::chrono::time_point<std::chrono::system_clock>& now,
+      int64_t currentIter) const;
+
+  bool isCollectionDone(
+      const std::chrono::time_point<std::chrono::system_clock>& now,
+      int64_t currentIter) const;
+
   void startTraceInternal(
       const std::chrono::time_point<std::chrono::system_clock>& now);
 
@@ -274,6 +283,7 @@ class CuptiActivityProfiler {
   // Start and end time used for triggering and stopping profiling
   std::chrono::time_point<std::chrono::system_clock> profileStartTime_;
   std::chrono::time_point<std::chrono::system_clock> profileEndTime_;
+  int64_t profileStartIter_ = -1, profileEndIter_ = -1;
 
 
   // All recorded trace spans, both CPU and GPU


### PR DESCRIPTION
Summary:
## Overview

Kineto traces can be triggered asynchronously using Config files. This method only supports specifying a trace start time and trace duration.
Enabling tracing based on the iteration count rather than a combination of {start time, duration} has several added advantages
1. Tools triggering traces externally can obtain traces containing whole iterations i.e  they do not need to tune the duration based on the iteration time
2. This provides feature parity between the pytorch profiler and external interface to Kineto.

## Implementation

We add new Config options for profiling using iteration counts
```
PROFILE_START_ITERATION=200   // iteration to start profile
ACTIVITIES_WARMUP_ITERATIONS=1   // iterations to warmup BEFORE the profiler start iteration above
ACTIVITIES_ITERATIONS=3  // number of iterations to profile
```

Further, we add a 'step()' method into Kineto's public interface. This will do two things :
1) increment the iteration count internally.
2) if an external config is present it can evaluate if we need to start/warmup/complete the traces.

The step method can then be inserted into the AI framework layer such as within the pytorch profiler step() implementation.

## Additional Details

What happens if **current iteration  > (start - warmup iters)**?  In this case, the behavior is to move the start to the next iteration boundary. Profiler then does the warmup and profile capture.

**Avoiding Race conditions:**
Since we are introducing a second method to trigger traces we need to update the state of profiler in both paths (step() method and the periodic profiling thread). So far we have ensured there are no races between two threads updating the state, thus avoiding a lock. Depending on if the config uses iteration count or profile start time state transitions are mainly done via one of the two paths only. Let me know if that makes sense.

Differential Revision: D33027010

