### PR TITLE
Add Config options to configure CUPTI profiler

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -16,6 +16,7 @@ enum class ActivityType {
     CONCURRENT_KERNEL, // on-device kernels
     EXTERNAL_CORRELATION,
     CUDA_RUNTIME, // host side cuda runtime events
+    CUDA_PROFILER_RANGE, // CUPTI Profiler range for performance metrics
     GLOW_RUNTIME, // host side glow runtime events
     CPU_INSTANT_EVENT, // host side point-like events
     PYTHON_FUNCTION,

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -20,6 +20,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
     {"kernel", ActivityType::CONCURRENT_KERNEL},
     {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
     {"cuda_runtime", ActivityType::CUDA_RUNTIME},
+    {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
     {"glow_runtime", ActivityType::GLOW_RUNTIME},
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
     {"python_function", ActivityType::PYTHON_FUNCTION},

--- a/libkineto/src/CuptiRangeProfilerConfig.cpp
+++ b/libkineto/src/CuptiRangeProfilerConfig.cpp
@@ -1,0 +1,68 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <CuptiRangeProfilerConfig.h>
+#include <Logger.h>
+
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <fmt/format.h>
+#include <ostream>
+
+using namespace std::chrono;
+
+namespace KINETO_NAMESPACE {
+
+// number of ranges affect the size of counter data binary used by
+// the CUPTI Profiler. these defaults can be tuned
+constexpr int KMaxAutoRanges = 1500; // supports 1500 kernels
+constexpr int KMaxUserRanges = 10;   // enable upto 10 sub regions marked by user
+
+constexpr char kCuptiProfilerMetricsKey[] = "CUPTI_PROFILER_METRICS";
+constexpr char kCuptiProfilerPerKernelKey[] = "CUPTI_PROFILER_ENABLE_PER_KERNEL";
+constexpr char kCuptiProfilerMaxRangesKey[] = "CUPTI_PROFILER_MAX_RANGES";
+
+CuptiRangeProfilerConfig::CuptiRangeProfilerConfig(Config& cfg)
+    : parent_(&cfg),
+      cuptiProfilerPerKernel_(false),
+      cuptiProfilerMaxRanges_(0) {}
+
+bool CuptiRangeProfilerConfig::handleOption(const std::string& name, std::string& val) {
+  VLOG(0) << " handling : " << name << " = " << val;
+  // Cupti Range based Profiler configuration
+  if (!name.compare(kCuptiProfilerMetricsKey)) {
+    activitiesCuptiMetrics_ = splitAndTrim(val, ',');
+  } else if (!name.compare(kCuptiProfilerPerKernelKey)) {
+    cuptiProfilerPerKernel_ = toBool(val);
+  } else if (!name.compare(kCuptiProfilerMaxRangesKey)) {
+    cuptiProfilerMaxRanges_ = toInt64(val);
+  } else {
+    return false;
+  }
+  return true;
+}
+
+void CuptiRangeProfilerConfig::setDefaults() {
+  if (activitiesCuptiMetrics_.size() > 0 && cuptiProfilerMaxRanges_ == 0) {
+    cuptiProfilerMaxRanges_ =
+      cuptiProfilerPerKernel_ ? KMaxAutoRanges : KMaxUserRanges;
+  }
+}
+
+void CuptiRangeProfilerConfig::printActivityProfilerConfig(std::ostream& s) const {
+  if (activitiesCuptiMetrics_.size() > 0) {
+    s << "Cupti Profiler metrics : "
+      << fmt::format("{}", fmt::join(activitiesCuptiMetrics_, ", ")) << std::endl;
+    s << "Cupti Profiler measure per kernel : "
+      << cuptiProfilerPerKernel_ << std::endl;
+    s << "Cupti Profiler max ranges : " << cuptiProfilerMaxRanges_ << std::endl;
+  }
+}
+
+void CuptiRangeProfilerConfig::registerFactory() {
+  Config::addConfigFactory(
+      kCuptiProfilerConfigName,
+      [](Config& cfg) { return new CuptiRangeProfilerConfig(cfg); });
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiRangeProfilerConfig.h
+++ b/libkineto/src/CuptiRangeProfilerConfig.h
@@ -1,0 +1,86 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "Config.h"
+
+#include <chrono>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace KINETO_NAMESPACE {
+
+constexpr char kCuptiProfilerConfigName[] = "cupti_rb_profiler";
+
+class CuptiRangeProfilerConfig : public AbstractConfig {
+ public:
+  bool handleOption(const std::string& name, std::string& val) override;
+
+  void validate(
+      const std::chrono::time_point<std::chrono::system_clock>&
+      fallbackProfileStartTime) override {}
+
+  static CuptiRangeProfilerConfig& get(const Config& cfg) {
+    return dynamic_cast<CuptiRangeProfilerConfig&>(cfg.feature(
+          kCuptiProfilerConfigName));
+  }
+
+  Config& parent() const {
+    return *parent_;
+  }
+
+  std::vector<std::string> activitiesCuptiMetrics() const {
+    return activitiesCuptiMetrics_;
+  }
+
+  bool cuptiProfilerPerKernel() const {
+    return cuptiProfilerPerKernel_;
+  }
+
+  int64_t cuptiProfilerMaxRanges() const {
+    return cuptiProfilerMaxRanges_;
+  }
+
+  void setSignalDefaults() override {
+    setDefaults();
+  }
+
+  void setClientDefaults() override {
+    setDefaults();
+  }
+
+  void printActivityProfilerConfig(std::ostream& s) const override;
+
+  static void registerFactory();
+ protected:
+  AbstractConfig* cloneDerived(AbstractConfig& parent) const override {
+    CuptiRangeProfilerConfig* clone = new CuptiRangeProfilerConfig(*this);
+    clone->parent_ = dynamic_cast<Config*>(&parent);
+    return clone;
+  }
+
+ private:
+ CuptiRangeProfilerConfig() = delete;
+  explicit CuptiRangeProfilerConfig(Config& parent);
+  explicit CuptiRangeProfilerConfig(
+      const CuptiRangeProfilerConfig& other) = default;
+
+  // some defaults will depend on other configuration
+  void setDefaults();
+
+  // Associated Config object
+  Config* parent_;
+
+  // Counter metrics exposed via CUPTI Profiler API
+  std::vector<std::string> activitiesCuptiMetrics_;
+
+  // Collect profiler metrics per kernel - autorange made
+  bool cuptiProfilerPerKernel_{false};
+
+  // max number of ranges to configure the profiler for.
+  // this has to be set before hand to reserve space for the output
+  int64_t cuptiProfilerMaxRanges_ = 0;
+};
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -89,7 +89,8 @@ TEST(ParseTest, ActivityTypes) {
                             ActivityType::CONCURRENT_KERNEL,
                             ActivityType::EXTERNAL_CORRELATION,
                             ActivityType::GLOW_RUNTIME,
-                            ActivityType::CUDA_RUNTIME}));
+                            ActivityType::CUDA_RUNTIME,
+                            ActivityType::CUDA_PROFILER_RANGE}));
 
   Config cfg2;
   EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES=gpu_memcpy,gpu_MeMsEt,kernel"));

--- a/libkineto/test/CuptiRangeProfilerConfigTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerConfigTest.cpp
@@ -1,0 +1,67 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "src/Config.h"
+#include "src/CuptiRangeProfilerConfig.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <time.h>
+#include <chrono>
+
+using namespace std::chrono;
+using namespace KINETO_NAMESPACE;
+
+class CuptiRangeProfilerConfigTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CuptiRangeProfilerConfig::registerFactory();
+  }
+};
+
+TEST_F(CuptiRangeProfilerConfigTest, ConfigureProfiler) {
+  Config cfg;
+  std::vector<std::string> metrics = {
+    "kineto__cuda_core_flops",
+    "sm__inst_executed.sum",
+    "l1tex__data_bank_conflicts_pipe_lsu.sum",
+  };
+  auto metricsConfigStr =
+        fmt::format("CUPTI_PROFILER_METRICS = {}", fmt::join(metrics, ","));
+
+  EXPECT_TRUE(cfg.parse(metricsConfigStr));
+  EXPECT_TRUE(cfg.parse("CUPTI_PROFILER_ENABLE_PER_KERNEL = true"));
+  EXPECT_TRUE(cfg.parse("CUPTI_PROFILER_MAX_RANGES = 42"));
+
+  const CuptiRangeProfilerConfig& cupti_cfg =
+    CuptiRangeProfilerConfig::get(cfg);
+
+  EXPECT_EQ(cupti_cfg.activitiesCuptiMetrics(), metrics);
+  EXPECT_EQ(cupti_cfg.cuptiProfilerPerKernel(), true);
+  EXPECT_EQ(cupti_cfg.cuptiProfilerMaxRanges(), 42);
+
+}
+
+TEST_F(CuptiRangeProfilerConfigTest, RangesDefaults) {
+  Config cfg, cfg_auto;
+
+  // do not set max ranges in config, check defaults are sane
+  EXPECT_TRUE(cfg.parse("CUPTI_PROFILER_METRICS = kineto__cuda_core_flops"));
+  EXPECT_TRUE(cfg.parse("CUPTI_PROFILER_ENABLE_PER_KERNEL = false"));
+
+  cfg.setSignalDefaults();
+
+  EXPECT_TRUE(cfg_auto.parse("CUPTI_PROFILER_METRICS = kineto__cuda_core_flops"));
+  EXPECT_TRUE(cfg_auto.parse("CUPTI_PROFILER_ENABLE_PER_KERNEL = true"));
+
+  cfg_auto.setClientDefaults();
+
+  int user_ranges, auto_ranges;
+
+  user_ranges = CuptiRangeProfilerConfig::get(cfg).cuptiProfilerMaxRanges();
+  auto_ranges = CuptiRangeProfilerConfig::get(cfg_auto).cuptiProfilerMaxRanges();
+
+  EXPECT_GE(user_ranges, 1) << " in user range mode default to at least 1 ranges";
+  EXPECT_GE(auto_ranges, 1000) << " in auto range mode default to at least 1000 ranges";
+
+  EXPECT_GT(auto_ranges, user_ranges);
+}


### PR DESCRIPTION
Summary:
Add a new Config file subtype for the CUPTI Range Profiler
* Support setting metric names and range type (per kernel)
* Add default max ranges parameter based on per kernel profiling or not
* Add new activity type : `{"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE}`,

Reviewed By: aaronenyeshi

Differential Revision: D31971370

