### PR TITLE
Use shared_timed_mutex instead of shared_mutex due to PyTorch using C++14.

### DIFF
--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -18,7 +18,7 @@ namespace KINETO_NAMESPACE {
 constexpr size_t MAX_CB_FNS_PER_CB = 8;
 
 // Reader Writer lock types
-using ReaderWriterLock = std::shared_mutex;
+using ReaderWriterLock = std::shared_timed_mutex;
 using ReaderLockGuard = std::shared_lock<ReaderWriterLock>;
 using WriteLockGuard = std::unique_lock<ReaderWriterLock>;
 


### PR DESCRIPTION
Summary:
std::shared_mutex is not available in C++14, and shows an error when incorporated into PyTorch CI. This patch replaces it with shared_timed_mutex, which is available, and is shared_mutex in GCC5.0.

To use std::shared_mutex, we must use C++17.

Differential Revision: D34190117

Pulled By: aaronenyeshi

