### PR TITLE
Use atomic<int64_t> instead of atomic_int64_t. The later is available in GCC7, but not GCC5

### DIFF
--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -76,7 +77,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   std::unique_ptr<ActivityLogger> logger_;
   std::thread* profilerThread_{nullptr};
   std::atomic_bool stopRunloop_{false};
-  std::atomic_int64_t iterationCount_{-1};
+  std::atomic<std::int64_t> iterationCount_{-1};
   ConfigLoader& configLoader_;
 };
 

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -18,7 +18,7 @@ namespace KINETO_NAMESPACE {
 constexpr size_t MAX_CB_FNS_PER_CB = 8;
 
 // Reader Writer lock types
-using ReaderWriterLock = std::shared_mutex;
+using ReaderWriterLock = std::shared_timed_mutex;
 using ReaderLockGuard = std::shared_lock<ReaderWriterLock>;
 using WriteLockGuard = std::unique_lock<ReaderWriterLock>;
 


### PR DESCRIPTION
Summary: Since PyTorch CI builds for GCC5, we need to use std::atomic<std::int64_t> for iterationCount, because atomic_int64_t is not available until after GCC5.

Reviewed By: briancoutinho

Differential Revision: D34190739

Pulled By: aaronenyeshi

