### PR TITLE
Fix namespace errors in PyTorch CI

### DIFF
--- a/libkineto/include/IActivityProfiler.h
+++ b/libkineto/include/IActivityProfiler.h
@@ -17,6 +17,8 @@
 
 namespace libkineto {
 
+using namespace KINETO_NAMESPACE;
+
 #ifdef _MSC_VER
 // workaround for the predefined ERROR macro on Windows
 #undef ERROR

--- a/libkineto/include/ILoggerObserver.h
+++ b/libkineto/include/ILoggerObserver.h
@@ -14,7 +14,7 @@ constexpr char kPostProcessingStage[] = "Post Processing";
 #include <map>
 #include <vector>
 
-namespace KINETO_NAMESPACE {
+namespace libkineto {
 
 enum LoggerOutputType {
   VERBOSE = 0,
@@ -45,6 +45,6 @@ class ILoggerObserver {
 
 };
 
-} // namespace KINETO_NAMESPACE
+} // namespace libkineto
 
 #endif // !USE_GOOGLE_LOG

--- a/libkineto/src/ILoggerObserver.cpp
+++ b/libkineto/src/ILoggerObserver.cpp
@@ -9,7 +9,7 @@
 #include <array>
 #include <fmt/format.h>
 
-namespace KINETO_NAMESPACE {
+namespace libkineto {
 
 struct LoggerTypeName {
   constexpr LoggerTypeName(const char* n, LoggerOutputType t) : name(n), type(t) {};
@@ -48,7 +48,7 @@ LoggerOutputType toLoggerOutputType(const std::string& str) {
   throw std::invalid_argument(fmt::format("Invalid activity type: {}", str));
 }
 
-} // namespace KINETO_NAMESPACE
+} // namespace libkineto
 
 
 #endif // !USE_GOOGLE_LOG

--- a/libkineto/src/LoggerCollector.h
+++ b/libkineto/src/LoggerCollector.h
@@ -15,6 +15,8 @@
 
 namespace KINETO_NAMESPACE {
 
+using namespace libkineto;
+
 class LoggerCollector : public ILoggerObserver {
  public:
   LoggerCollector() : buckets_() {}


### PR DESCRIPTION
Summary: PyTorch CI has some issues with the two namespaces such as Config defined in KINETO_NAMESPACE. Add using namespace to the failed areas.

Reviewed By: briancoutinho

Differential Revision: D34249427

Pulled By: aaronenyeshi

