### PR TITLE
Ensures using valid Range Profiler headers with ifdefs

### DIFF
--- a/libkineto/src/CuptiNvPerfMetric.cpp
+++ b/libkineto/src/CuptiNvPerfMetric.cpp
@@ -1,9 +1,13 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#if defined(CUDART_VERSION) && CUDART_VERSION > 10000 && CUDART_VERSION < 11040
 #include <nvperf_cuda_host.h>
 #include <nvperf_host.h>
 #include <nvperf_target.h>
+#endif
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "ScopeExit.h"
 #include "CuptiNvPerfMetric.h"
 #include "Logger.h"
@@ -11,7 +15,7 @@
 namespace KINETO_NAMESPACE {
 
 // Add a namespace to isolate these utility functions that are only
-// giong to be used by the CuptiRangeProfiler. These included calls
+// going to be used by the CuptiRangeProfiler. These included calls
 // to NVIDIA PerfWorks APIs.
 namespace nvperf {
 

--- a/libkineto/src/CuptiNvPerfMetric.h
+++ b/libkineto/src/CuptiNvPerfMetric.h
@@ -6,6 +6,8 @@
 #include <vector>
 #include <fmt/format.h>
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "Logger.h"
 
 namespace KINETO_NAMESPACE {

--- a/libkineto/src/CuptiRangeProfilerApi.cpp
+++ b/libkineto/src/CuptiRangeProfilerApi.cpp
@@ -1,20 +1,24 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include <cupti.h>
-#include <nvperf_host.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "cupti_call.h"
 #include "Logger.h"
 #include "Demangle.h"
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "CuptiRangeProfilerApi.h"
 
+#if HAS_CUPTI_PROFILER
+#include <cupti.h>
+#include <nvperf_host.h>
+#include "cupti_call.h"
+#endif // HAS_CUPTI_PROFILER
 
 namespace KINETO_NAMESPACE {
 
-#ifdef HAS_CUPTI
+#if HAS_CUPTI_PROFILER
 
 /// Helper functions
 
@@ -392,6 +396,6 @@ bool CuptiRBProfilerSession::createCounterDataImage() {
 
   return true;
 }
-#endif // HAS_CUPTI
+#endif // HAS_CUPTI_PROFILER
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/test/CuptiProfilerApiTest.cu
+++ b/libkineto/test/CuptiProfilerApiTest.cu
@@ -6,6 +6,8 @@
 
 #include <cuda.h>
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "src/Logger.h"
 #include "src/CuptiRangeProfilerApi.h"
 
@@ -146,6 +148,7 @@ void VectorAddSubtract() {
   cleanUp(h_A, h_B, h_C, h_D, d_A, d_B, d_C, d_D);
 }
 
+#if HAS_CUPTI_PROFILER
 bool runTestWithAutoRange(
     int deviceNum,
     const std::vector<std::string>& metricNames,
@@ -244,6 +247,7 @@ bool runTestWithUserRange(
   }
   return true;
 }
+#endif // HAS_CUPTI_PROFILER
 
 int main(int argc, char* argv[]) {
 
@@ -298,6 +302,7 @@ int main(int argc, char* argv[]) {
 
   VectorAddSubtract();
 
+#if HAS_CUPTI_PROFILER
   CuptiRBProfilerSession::staticInit();
 
   if (!runTestWithUserRange(deviceNum, metricNames, cuContext)) {
@@ -306,6 +311,7 @@ int main(int argc, char* argv[]) {
     LOG(ERROR) << "Failed to profiler test benchmark in auto range";
   }
   CuptiRBProfilerSession::deInitCupti();
+#endif // HAS_CUPTI_PROFILER
   DRIVER_API_CALL(cuCtxDestroy(cuContext));
 
 


### PR DESCRIPTION
Summary: Guard the use of nvperf_host.h and cupti_profiler_target.h, which are only available cuda-10.1 and above (CUDA_VERSION >= 10010). Since CUPTIRangeProfiler based on NvPerfMetric, which is available cuda version > 10.00 and < 11.04, add that to ifdef too (#if defined(CUDART_VERSION) && CUDART_VERSION > 10000 && CUDART_VERSION < 11040).

Reviewed By: briancoutinho

Differential Revision: D34190649

Pulled By: aaronenyeshi

