### PR TITLE
Avoid macro expansion of ::max() on Windows

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -430,7 +430,7 @@ void CuptiActivityProfiler::configure(
   } else {
 
     profileStartIter_ = -1;
-    profileEndIter_ = std::numeric_limits<decltype(profileEndIter_)>::max();
+    profileEndIter_ = (std::numeric_limits<decltype(profileEndIter_)>::max)();
 
     if (profileStartTime_ < now) {
       LOG(ERROR) << "Not starting tracing - start timestamp is in the past. Time difference (ms): " << duration_cast<milliseconds>(now - profileStartTime_).count();


### PR DESCRIPTION
Summary: The usage of std::numeric_limits<T)::max() is failing on Windows due to windows.h defining max as a macro. To prevent the macro expansion, we need to use (std::numeric_limits<T)::max)(), which should still work for Linux.

Differential Revision: D34281765

Pulled By: aaronenyeshi

