### PR TITLE
cherry pick the tensor core fix

### DIFF
--- a/tb_plugin/torch_tb_profiler/profiler/tensor_core.py
+++ b/tb_plugin/torch_tb_profiler/profiler/tensor_core.py
@@ -26,8 +26,7 @@ class TC_Allowlist(metaclass=TC_Allowlist_Meta):
 
 class TC_OP_Allowlist(metaclass=TC_Allowlist_Meta):
     # Refer to https://github.com/pytorch/pytorch/blob/69b2bf70f9c0e591ce5e566afa59e19618031ead/aten/src/ATen/autocast_mode.cpp#L290-L351 # noqa: E501
-    allowlist = ['aten::_convolution', 'aten::_convolution_nogroup',
-                 'aten::conv1d', 'aten::conv2d', 'aten::conv3d', 'aten::conv_tbc',
+    allowlist = ['aten::_convolution', 'aten::conv1d', 'aten::conv2d', 'aten::conv3d', 'aten::conv_tbc',
                  'aten::conv_transpose1d', 'aten::conv_transpose2d', 'aten::conv_transpose3d',
                  'aten::convolution', 'aten::cudnn_convolution', 'aten::cudnn_convolution_transpose',
                  'aten::prelu', 'aten::addmm', 'aten::addmv', 'aten::addr',


### PR DESCRIPTION
https://github.com/pytorch/kineto/commit/4b7c7bb3d31b653c4edd3e14568320b527c15134

Remove unused _convolution_nogroup op (#68829)
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/68829

Test Plan: Imported from OSS

Reviewed By: zou3519, albanD

Differential Revision: D32627578

Pulled By: jbschlosser

fbshipit-source-id: 8a4c0ac58aae184a465b1fd40cce880a60d67339