### PR TITLE
Fix roctracerActivityBuffer activity flow id to be correlation_id

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -430,7 +430,7 @@ void CuptiActivityProfiler::configure(
   } else {
 
     profileStartIter_ = -1;
-    profileEndIter_ = std::numeric_limits<decltype(profileEndIter_)>::max();
+    profileEndIter_ = (std::numeric_limits<decltype(profileEndIter_)>::max)();
 
     if (profileStartTime_ < now) {
       LOG(ERROR) << "Not starting tracing - start timestamp is in the past. Time difference (ms): " << duration_cast<milliseconds>(now - profileStartTime_).count();

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -212,7 +212,7 @@ int RoctracerActivityApi::processActivities(
 
         a.activityType = ActivityType::CUDA_RUNTIME;
         a.activityName = std::string(name);
-        a.flow.id = item.id;
+        a.flow.id = record->correlation_id;
         a.flow.type = kLinkAsyncCpuGpu;
         a.flow.start = true;
 
@@ -236,7 +236,7 @@ int RoctracerActivityApi::processActivities(
 
         a.activityType = ActivityType::CONCURRENT_KERNEL;
         a.activityName = std::string(name);
-        a.flow.id = item.id;
+        a.flow.id = record->correlation_id;
         a.flow.type = kLinkAsyncCpuGpu;
 
         auto it = kernelNames_.find(record->correlation_id);


### PR DESCRIPTION
Summary: This looks like a typo from copy and paste, since item does not exist. The GenericTraceActivity's flow id should be the record's correlation_id saved in the buffer.

Reviewed By: briancoutinho

Differential Revision: D34321823

Pulled By: aaronenyeshi

