### PR TITLE
blacklist cudaEvent* cbids

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -20,7 +20,8 @@ enum class ActivityType {
     GLOW_RUNTIME, // host side glow runtime events
     CPU_INSTANT_EVENT, // host side point-like events
     PYTHON_FUNCTION,
-    ENUM_COUNT
+    OVERHEAD,
+    ENUM_COUNT // This is to add buffer and not used for any profiling logic. Add your new type before it.
 };
 
 const char* toString(ActivityType t);

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -324,7 +324,11 @@ class Config : public AbstractConfig {
   void selectDefaultActivityTypes() {
     // If the user has not specified an activity list, add all types
     for (ActivityType t : activityTypes()) {
-      selectedActivityTypes_.insert(t);
+      // Do no enable this be default
+      // TODO: introduce optional types
+      if (t != ActivityType::OVERHEAD) {
+        selectedActivityTypes_.insert(t);
+      }
     }
   }
 

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -24,6 +24,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
     {"glow_runtime", ActivityType::GLOW_RUNTIME},
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
     {"python_function", ActivityType::PYTHON_FUNCTION},
+    {"overhead", ActivityType::OVERHEAD},
     {"ENUM_COUNT", ActivityType::ENUM_COUNT}
 }};
 

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -33,8 +33,8 @@ struct CuptiActivity : public ITraceActivity {
   int64_t duration() const override {
     return nsToUs(activity_.end - activity_.start);
   }
-  int64_t correlationId() const override {return activity_.correlationId;}
   // TODO(T107507796): Deprecate ITraceActivity
+  int64_t correlationId() const override {return 0;}
   int32_t getThreadId() const override {return 0;}
   const ITraceActivity* linkedActivity() const override {return linked_;}
   int flowType() const override {return kLinkAsyncCpuGpu;}
@@ -54,11 +54,39 @@ struct RuntimeActivity : public CuptiActivity<CUpti_ActivityAPI> {
       const ITraceActivity* linked,
       int32_t threadId)
       : CuptiActivity(activity, linked), threadId_(threadId) {}
+  int64_t correlationId() const override {return activity_.correlationId;}
   int64_t deviceId() const override {return processId();}
   int64_t resourceId() const override {return threadId_;}
   ActivityType type() const override {return ActivityType::CUDA_RUNTIME;}
   bool flowStart() const override;
   const std::string name() const override {return runtimeCbidName(activity_.cbid);}
+  void log(ActivityLogger& logger) const override;
+  const std::string metadataJson() const override;
+
+ private:
+  const int32_t threadId_;
+};
+
+// CUpti_ActivityAPI - CUDA runtime activities
+struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
+  explicit OverheadActivity(
+      const CUpti_ActivityOverhead* activity,
+      const ITraceActivity* linked,
+      int32_t threadId=0)
+      : CuptiActivity(activity, linked), threadId_(threadId) {}
+
+  int64_t timestamp() const override {
+    return nsToUs(unixEpochTimestamp(activity_.start));
+  }
+  int64_t duration() const override {
+    return nsToUs(activity_.end - activity_.start);
+  }
+  // TODO: Update this with PID ordering
+  int64_t deviceId() const override {return -1;}
+  int64_t resourceId() const override {return threadId_;}
+  ActivityType type() const override {return ActivityType::OVERHEAD;}
+  bool flowStart() const override;
+  const std::string name() const override {return overheadKindString(activity_.overheadKind);}
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
 
@@ -72,6 +100,7 @@ template<class T>
 struct GpuActivity : public CuptiActivity<T> {
   explicit GpuActivity(const T* activity, const ITraceActivity* linked)
       : CuptiActivity<T>(activity, linked) {}
+  int64_t correlationId() const override {return raw().correlationId;}
   int64_t deviceId() const override {return raw().deviceId;}
   int64_t resourceId() const override {return raw().streamId;}
   ActivityType type() const override;

--- a/libkineto/src/CuptiActivity.tpp
+++ b/libkineto/src/CuptiActivity.tpp
@@ -70,6 +70,18 @@ inline void RuntimeActivity::log(ActivityLogger& logger) const {
   logger.handleGenericActivity(*this);
 }
 
+inline void OverheadActivity::log(ActivityLogger& logger) const {
+  logger.handleGenericActivity(*this);
+}
+
+inline bool OverheadActivity::flowStart() const {
+  return false;
+}
+
+inline const std::string OverheadActivity::metadataJson() const {
+  return "";
+}
+
 template<class T>
 inline void GpuActivity<T>::log(ActivityLogger& logger) const {
   logger.handleGpuActivity(*this);

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -297,6 +297,9 @@ void CuptiActivityApi::enableCuptiActivities(
     if (activity == ActivityType::CUDA_RUNTIME) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_RUNTIME));
     }
+    if (activity == ActivityType::OVERHEAD) {
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_OVERHEAD));
+    }
   }
 #endif
 
@@ -322,6 +325,9 @@ void CuptiActivityApi::disableCuptiActivities(
     }
     if (activity == ActivityType::CUDA_RUNTIME) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_RUNTIME));
+    }
+    if (activity == ActivityType::OVERHEAD) {
+      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_OVERHEAD));
     }
   }
   externalCorrelationEnabled_ = false;

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -114,6 +114,12 @@ void CuptiActivityApi::setMaxBufferSize(int size) {
   maxGpuBufferCount_ = 1 + size / kBufSize;
 }
 
+void CuptiActivityApi::forceLoadCupti() {
+#ifdef HAS_CUPTI
+  CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+#endif
+}
+
 #ifdef HAS_CUPTI
 void CUPTIAPI CuptiActivityApi::bufferRequestedTrampoline(
     uint8_t** buffer,

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -61,6 +61,8 @@ class CuptiActivityApi {
   std::atomic_bool stopCollection{false};
   int64_t flushOverhead{0};
 
+  static void forceLoadCupti();
+
  private:
 #ifdef HAS_CUPTI
   int processActivitiesForBuffer(

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -226,15 +226,28 @@ inline bool CuptiActivityProfiler::outOfRange(const ITraceActivity& act) {
   return out_of_range;
 }
 
+inline static bool isBlackListedRuntimeCbid(CUpti_CallbackId cbid) {
+  // Some CUDA calls that are very frequent and also not very interesting.
+  // Filter these out to reduce trace size.
+  if (cbid == CUPTI_RUNTIME_TRACE_CBID_cudaGetDevice_v3020 ||
+      cbid == CUPTI_RUNTIME_TRACE_CBID_cudaSetDevice_v3020 ||
+      cbid == CUPTI_RUNTIME_TRACE_CBID_cudaGetLastError_v3020 ||
+      // Don't care about cudaEvents
+      cbid == CUPTI_RUNTIME_TRACE_CBID_cudaEventCreate_v3020 ||
+      cbid == CUPTI_RUNTIME_TRACE_CBID_cudaEventCreateWithFlags_v3020 ||
+      cbid == CUPTI_RUNTIME_TRACE_CBID_cudaEventRecord_v3020 ||
+      cbid == CUPTI_RUNTIME_TRACE_CBID_cudaEventDestroy_v3020 ||
+      cbid == CUPTI_RUNTIME_TRACE_CBID_cudaEventSynchronize_v3020) {
+    return true;
+  }
+
+  return false;
+}
+
 void CuptiActivityProfiler::handleRuntimeActivity(
     const CUpti_ActivityAPI* activity,
     ActivityLogger* logger) {
-  // Some CUDA calls that are very frequent and also not very interesting.
-  // Filter these out to reduce trace size.
-  if (activity->cbid == CUPTI_RUNTIME_TRACE_CBID_cudaGetDevice_v3020 ||
-      activity->cbid == CUPTI_RUNTIME_TRACE_CBID_cudaSetDevice_v3020 ||
-      activity->cbid == CUPTI_RUNTIME_TRACE_CBID_cudaGetLastError_v3020) {
-    // Ignore these
+  if (isBlackListedRuntimeCbid(activity->cbid)) {
     return;
   }
   VLOG(2) << activity->correlationId

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -239,6 +239,8 @@ class CuptiActivityProfiler {
       const CUpti_ActivityExternalCorrelation* correlation);
   void handleRuntimeActivity(
       const CUpti_ActivityAPI* activity, ActivityLogger* logger);
+  void handleOverheadActivity(
+      const CUpti_ActivityOverhead* activity, ActivityLogger* logger);
   void handleGpuActivity(const ITraceActivity& act,
       ActivityLogger* logger);
   template <class T>
@@ -302,6 +304,8 @@ class CuptiActivityProfiler {
   std::map<
       std::pair<int64_t, int64_t>,
       ActivityLogger::ResourceInfo> resourceInfo_;
+
+  std::vector<ActivityLogger::OverheadInfo> overheadInfo_;
 
   // the overhead to flush the activity buffer
   profilerOverhead flushOverhead_;

--- a/libkineto/src/cupti_strings.cpp
+++ b/libkineto/src/cupti_strings.cpp
@@ -59,6 +59,27 @@ const char* memoryKindString(
   }
 }
 
+const char* overheadKindString(
+    CUpti_ActivityOverheadKind kind) {
+  switch (kind) {
+    case CUPTI_ACTIVITY_OVERHEAD_UNKNOWN:
+      return "Unknown";
+    case CUPTI_ACTIVITY_OVERHEAD_DRIVER_COMPILER:
+      return "Driver Compiler";
+    case CUPTI_ACTIVITY_OVERHEAD_CUPTI_BUFFER_FLUSH:
+      return "Buffer Flush";
+    case CUPTI_ACTIVITY_OVERHEAD_CUPTI_INSTRUMENTATION:
+      return "Instrumentation";
+    case CUPTI_ACTIVITY_OVERHEAD_CUPTI_RESOURCE:
+      return "Resource";
+    case CUPTI_ACTIVITY_OVERHEAD_FORCE_INT:
+      return "Force Int";
+    default:
+      return "Unrecognized";
+  }
+}
+
+
 
 static const char* runtimeCbidNames[] = {
     "INVALID",

--- a/libkineto/src/cupti_strings.h
+++ b/libkineto/src/cupti_strings.h
@@ -9,5 +9,6 @@ namespace libkineto {
 const char* memoryKindString(CUpti_ActivityMemoryKind kind);
 const char* memcpyKindString(CUpti_ActivityMemcpyKind kind);
 const char* runtimeCbidName(CUpti_CallbackId cbid);
+const char* overheadKindString(CUpti_ActivityOverheadKind kind);
 
 } // namespace libkineto

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -48,11 +48,18 @@ class ActivityLogger {
     const std::string name;
   };
 
+  struct OverheadInfo {
+    OverheadInfo(const std::string& name) : name(name) {}
+    const std::string name;
+  };
+
   virtual void handleDeviceInfo(
       const DeviceInfo& info,
       uint64_t time) = 0;
 
   virtual void handleResourceInfo(const ResourceInfo& info, int64_t time) = 0;
+
+  virtual void handleOverheadInfo(const OverheadInfo& info, int64_t time) = 0;
 
   virtual void handleTraceSpan(const TraceSpan& span) = 0;
 

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -153,6 +153,36 @@ void ChromeTraceLogger::handleResourceInfo(
   // clang-format on
 }
 
+void ChromeTraceLogger::handleOverheadInfo(
+    const OverheadInfo& info,
+    int64_t time) {
+  if (!traceOf_) {
+    return;
+  }
+
+  // TOOD: reserve pid = -1 for overhead but we need to rethink how to scale this for
+  // other metadata
+  // clang-format off
+  traceOf_ << fmt::format(R"JSON(
+  {{
+    "name": "process_name", "ph": "M", "ts": {}, "pid": -1, "tid": 0,
+    "args": {{
+      "name": "{}"
+    }}
+  }},
+  {{
+    "name": "process_sort_index", "ph": "M", "ts": {}, "pid": -1, "tid": 0,
+    "args": {{
+      "sort_index": {}
+    }}
+  }},)JSON",
+      time,
+      info.name,
+      time,
+      0x100000All);
+  // clang-format on
+}
+
 void ChromeTraceLogger::handleTraceSpan(const TraceSpan& span) {
   if (!traceOf_) {
     return;

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -33,6 +33,8 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
       const DeviceInfo& info,
       uint64_t time) override;
 
+  void handleOverheadInfo(const OverheadInfo& info, int64_t time) override;
+
   void handleResourceInfo(const ResourceInfo& info, int64_t time) override;
 
   void handleTraceSpan(const TraceSpan& span) override;

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -41,6 +41,8 @@ class MemoryTraceLogger : public ActivityLogger {
     resourceInfoList_.emplace_back(info, time);
   }
 
+  void handleOverheadInfo(const OverheadInfo& info, int64_t time) override {}
+
   void handleTraceSpan(const TraceSpan& span) override {
     // Handled separately
   }

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -68,8 +68,9 @@ TEST(ParseTest, DefaultActivityTypes) {
   Config cfg;
   cfg.validate(std::chrono::system_clock::now());
   auto all_activities = activityTypes();
+  // TODO: introduce optional activities
   EXPECT_EQ(cfg.selectedActivityTypes(),
-    std::set<ActivityType>(all_activities.begin(), all_activities.end()));
+    std::set<ActivityType>(all_activities.begin(), all_activities.end() - 1));
 }
 
 TEST(ParseTest, ActivityTypes) {


### PR DESCRIPTION
Summary: Sigrid has some `cudaEvent*` API calls that show up in Kineto traces. It is not leveraged so just filter them out

Differential Revision: D34332058

