### PR TITLE
Enable CUPTI Profiler API to track multiple threads/context

### DIFF
--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -8,7 +8,9 @@
 #include <mutex>
 #include <shared_mutex>
 
+#ifdef HAS_CUPTI
 #include "cupti_call.h"
+#endif
 #include "Logger.h"
 
 
@@ -83,6 +85,8 @@ void CuptiCallbackApi::__callback_switchboard(
           cblist = &callbacks_.runtime[
             CUDA_LAUNCH_KERNEL - __RUNTIME_CB_DOMAIN_START];
           break;
+        default:
+          break;
       }
       break;
 
@@ -95,6 +99,8 @@ void CuptiCallbackApi::__callback_switchboard(
         case CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING:
           cblist = &callbacks_.resource[
             RESOURCE_CONTEXT_DESTROYED - __RESOURCE_CB_DOMAIN_START];
+          break;
+        default:
           break;
       }
       break;

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -12,6 +12,10 @@
 #include <mutex>
 #include <set>
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "CuptiCallbackApiMock.h"
+
 namespace KINETO_NAMESPACE {
 
 using namespace libkineto;
@@ -25,20 +29,6 @@ using namespace libkineto;
  *  Note: one design choice we made is to only support simple function pointers
  *  in order to speed up the implementation for fast path.
  */
-
-#ifndef HAS_CUPTI
-enum CUpti_CallbackDomain {
-  CUPTI_CB_DOMAIN_RESOURCE,
-  CUPTI_CB_DOMAIN_RUNTIME_API,
-};
-enum CUpti_CallbackData {
-  CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
-  CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
-  CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
-};
-
-using CUpti_CallbackId = size_t;
-#endif
 
 using CuptiCallbackFn = void(*)(
     CUpti_CallbackDomain domain,

--- a/libkineto/src/CuptiCallbackApiMock.h
+++ b/libkineto/src/CuptiCallbackApiMock.h
@@ -1,0 +1,32 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// Provides data structures to mock CUPTI Callback API
+#ifndef HAS_CUPTI
+
+enum CUpti_CallbackDomain {
+  CUPTI_CB_DOMAIN_RESOURCE,
+  CUPTI_CB_DOMAIN_RUNTIME_API,
+};
+enum CUpti_CallbackId {
+  CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+  CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
+  CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
+};
+
+using CUcontext = void*;
+
+struct CUpti_ResourceData {
+  CUcontext context;
+};
+
+constexpr int CUPTI_API_ENTER = 0;
+constexpr int CUPTI_API_EXIT = 0;
+
+struct CUpti_CallbackData {
+  CUcontext context;
+  const char* symbolName;
+  int callbackSite;
+};
+#endif // HAS_CUPTI

--- a/libkineto/src/CuptiNvPerfMetric.cpp
+++ b/libkineto/src/CuptiNvPerfMetric.cpp
@@ -1,10 +1,13 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#ifdef HAS_CUPTI
+#include <cuda_runtime_api.h>
 #if defined(CUDART_VERSION) && CUDART_VERSION > 10000 && CUDART_VERSION < 11040
 #include <nvperf_cuda_host.h>
 #include <nvperf_host.h>
 #include <nvperf_target.h>
-#endif
+#endif // cuda version > 10.00 and < 11.04
+#endif // HAS_CUPTI
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude

--- a/libkineto/src/CuptiRangeProfilerApi.cpp
+++ b/libkineto/src/CuptiRangeProfilerApi.cpp
@@ -2,12 +2,24 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAS_CUPTI
+#include <cupti.h>
+#include <nvperf_host.h>
+#endif // HAS_CUPTI
+#include <mutex>
+#include <unordered_map>
 
+#ifdef HAS_CUPTI
+#include "cupti_call.h"
+#endif
+
+#include "time_since_epoch.h"
 #include "Logger.h"
 #include "Demangle.h"
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "CuptiCallbackApiMock.h"
 #include "CuptiRangeProfilerApi.h"
 
 #if HAS_CUPTI_PROFILER
@@ -19,13 +31,36 @@
 namespace KINETO_NAMESPACE {
 
 #if HAS_CUPTI_PROFILER
+constexpr char kRootUserRangeName[] = "__profile__";
+constexpr int kCallbacksCountToFlush = 500;
+
+// Should we set Counter availability image ourselves?
+// Disabled this right now as this call conflicts with DCGM
+// It is not clear why it should conflict except it being a profiler API call
+//  TODO Revisit
+constexpr bool kSetCounterAvail = false;
+
+// Shared state to track one Cupti Profiler API per Device
+namespace {
+// per device profiler maps
+std::unordered_map<uint32_t, CuptiRBProfilerSession*> profiler_map;
+std::unordered_map<uint32_t, bool> enable_flag;
+std::unordered_map<uint32_t, bool> disable_flag;
+
+std::mutex contextMutex_;
+std::unordered_map<CUcontext, int> ctx_to_dev;
+std::set<uint32_t> active_devices;
+}
+
+// forward declarations
+void __trackCudaCtx(CUcontext ctx, uint32_t device_id, CUpti_CallbackId cbid);
+void __trackCudaKernelLaunch(CUcontext ctx, const char* kernelName);
 
 /// Helper functions
 
 // Available raw counters
 std::vector<uint8_t> getCounterAvailiability(CUcontext cuContext) {
   std::vector<uint8_t> counterAvailabilityImage;
-
   CUpti_Profiler_GetCounterAvailability_Params getCounterAvailabilityParams = {
       CUpti_Profiler_GetCounterAvailability_Params_STRUCT_SIZE, nullptr};
   getCounterAvailabilityParams.ctx = cuContext;
@@ -55,6 +90,161 @@ std::string getChipName(int deviceId) {
   return getChipNameParams.pChipName;
 }
 
+inline uint32_t getDevID(CUcontext ctx) {
+  uint32_t device_id = UINT32_MAX;
+  CUPTI_CALL(cuptiGetDeviceId(ctx, &device_id));
+  if (device_id == UINT32_MAX) {
+    LOG(ERROR) << "Could not determine dev id for = " << ctx;
+  }
+  return device_id;
+}
+
+// We use CUPTI Callback functions in three ways :
+//   1. Track cuda contexts and maintain a list of active GPUs to profile
+//   2. Callbacks on kernel launches to track the name of automatic
+//      ranges that correspond to names of kernels
+//   3. Lastly CUPTI profiler has to be enabled on the same thread executing
+//      the CUDA kernels. We use Callbacks to enable the profiler
+//      asynchronously from another thread.
+
+void disableKernelCallbacks();
+
+void trackCudaCtx(
+    CUpti_CallbackDomain /*domain*/,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo) {
+  auto *d = reinterpret_cast<const CUpti_ResourceData*>(cbInfo);
+  auto ctx = d->context;
+  uint32_t device_id = getDevID(ctx);
+
+  if (device_id == UINT32_MAX) {
+    return;
+  }
+
+  __trackCudaCtx(ctx, device_id, cbid);
+}
+
+void __trackCudaCtx(CUcontext ctx, uint32_t device_id, CUpti_CallbackId cbid) {
+  std::lock_guard<std::mutex> g(contextMutex_);
+  if (cbid == CUPTI_CBID_RESOURCE_CONTEXT_CREATED) {
+    VLOG(0) << "CUPTI Profiler observed CUDA Context created = "
+            << ctx << " device id = " << device_id;
+    active_devices.insert(device_id);
+    if constexpr (kSetCounterAvail) {
+      if (active_devices.size() == 1) {
+      CuptiRBProfilerSession::setCounterAvailabilityImage(
+          getCounterAvailiability(ctx));
+      }
+    }
+    ctx_to_dev[ctx] = device_id;
+
+  } else if (cbid == CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING) {
+    VLOG(0) << "CUPTI Profiler observed CUDA Context destroyed = "
+            << ctx << " device id = " << device_id;
+    auto it = active_devices.find(device_id);
+    if (it != active_devices.end()) {
+      active_devices.erase(it);
+      ctx_to_dev.erase(ctx);
+    }
+  }
+}
+
+void trackCudaKernelLaunch(
+    CUpti_CallbackDomain /*domain*/,
+    CUpti_CallbackId /*cbid*/,
+    const CUpti_CallbackData* cbInfo) {
+  VLOG(1) << " Trace : Callback name = "
+          << (cbInfo->symbolName ?  cbInfo->symbolName: "")
+          << " context ptr = " << cbInfo->context;
+  auto ctx = cbInfo->context;
+  // should be in CUPTI_API_ENTER call site
+  if (cbInfo->callbackSite != CUPTI_API_ENTER) {
+    return;
+  }
+  __trackCudaKernelLaunch(ctx, cbInfo->symbolName);
+}
+
+void __trackCudaKernelLaunch(
+    CUcontext ctx,
+    const char* kernelName) {
+  VLOG(0) << " Tracking kernel name = " << (kernelName ? kernelName : "")
+          << " context ptr = " << ctx;
+
+  uint32_t device_id = 0;
+  if (auto it = ctx_to_dev.find(ctx); it == ctx_to_dev.end()) {
+    // Warning here could be too noisy
+    VLOG(0) << " Could not find corresponding device to ctx = " << ctx;
+    return;
+  } else {
+    device_id = it->second;
+  }
+
+  auto pit = profiler_map.find(device_id);
+  if (pit == profiler_map.end() || pit->second == nullptr) {
+    return;
+  }
+  auto profiler = pit->second;
+
+  if (enable_flag[device_id]) {
+    LOG(INFO) << "Callback handler is enabling cupti profiler";
+    profiler->startAndEnable();
+    enable_flag[device_id] = false;
+
+  } else if (disable_flag[device_id]) {
+    LOG(INFO) << "Callback handler is disabling cupti profiler";
+    profiler->disableAndStop();
+    return;
+  }
+
+  if (profiler->curRange_ == CUPTI_AutoRange) {
+    profiler->logKernelName(kernelName ? kernelName : "__missing__");
+  }
+
+  /* TODO add per kernel time logging
+  if (measure_per_kernel) {
+    profiler->kernelStartTs_.push_back(
+        std::chrono::high_resolution_clock::now());
+  }
+  */
+
+  // periodically flush profiler data from GPU
+  if (profiler->numCallbacks_ % kCallbacksCountToFlush == 0) {
+    profiler->flushCounterData();
+  }
+  profiler->numCallbacks_++;
+}
+
+void enableKernelCallbacks() {
+  auto& cbapi = CuptiCallbackApi::singleton();
+  bool status = cbapi.enableCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000);
+  if (!status) {
+    LOG(WARNING) << "CUPTI Range Profiler unable to "
+                 << "enable cuda kernel launch callback";
+    return;
+  }
+  LOG(INFO) << "CUPTI Profiler kernel callbacks enabled";
+}
+
+void disableKernelCallbacks() {
+  auto& cbapi = CuptiCallbackApi::singleton();
+  bool status = cbapi.disableCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000);
+  if (!status) {
+    LOG(WARNING) << "CUPTI Range Profiler unable to "
+                 << "disable cuda kernel launch callback";
+    return;
+  }
+  LOG(INFO) << "CUPTI Profiler kernel callbacks disabled";
+}
+
+// static
+std::set<uint32_t> CuptiRBProfilerSession::getActiveDevices() {
+  std::lock_guard<std::mutex> g(contextMutex_);
+  return active_devices;
+}
 
 // static
 void CuptiRBProfilerSession::initCupti() {
@@ -73,6 +263,35 @@ void CuptiRBProfilerSession::deInitCupti() {
 // static
 void CuptiRBProfilerSession::staticInit() {
   CuptiRBProfilerSession::initCupti();
+
+  // Register CUPTI callbacks
+  auto& cbapi = CuptiCallbackApi::singleton();
+  CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RESOURCE;
+  bool status = cbapi.registerCallback(
+      domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED, trackCudaCtx);
+  status = status && cbapi.registerCallback(
+      domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED, trackCudaCtx);
+  status = status && cbapi.enableCallback(
+      domain, CUPTI_CBID_RESOURCE_CONTEXT_CREATED);
+  status = status && cbapi.enableCallback(
+      domain, CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING);
+
+  if (!status) {
+    LOG(WARNING) << "CUPTI Range Profiler unable to attach cuda context "
+                 << "create and destroy callbacks";
+    CUPTI_CALL(cbapi.getCuptiStatus());
+    return;
+  }
+
+  domain = CUPTI_CB_DOMAIN_RUNTIME_API;
+  status = cbapi.registerCallback(
+      domain, CuptiCallbackApi::CUDA_LAUNCH_KERNEL, trackCudaKernelLaunch);
+
+  if (!status) {
+    LOG(WARNING) << "CUPTI Range Profiler unable to attach cuda kernel "
+                 << "launch callback";
+    return;
+  }
 }
 
 // static
@@ -143,8 +362,14 @@ CuptiRBProfilerSession::CuptiRBProfilerSession(
   endPassParams_ = {CUpti_Profiler_EndPass_Params_STRUCT_SIZE, nullptr};
 
   initSuccess_ = true;
+  profiler_map[deviceId] = this;
+}
 
-  // TODO profiler_map[deviceId] = this;
+// used in unittests only
+CuptiRBProfilerSession::CuptiRBProfilerSession(int deviceId, CUcontext ctx)
+  : deviceId_(deviceId), cuContext_(ctx) {
+  initSuccess_ = true;
+  profiler_map[deviceId] = this;
 }
 
 void CuptiRBProfilerSession::startInternal(
@@ -157,6 +382,16 @@ void CuptiRBProfilerSession::startInternal(
   if (!initSuccess_) {
     LOG(WARNING) << __func__ << "() bailing out since initialization failed";
     return;
+  }
+
+  if (cuContext_ == nullptr) {
+    for (const auto& it : ctx_to_dev) {
+      if (it.second == deviceId_) {
+        cuContext_ = it.first;
+        break;
+      }
+    }
+    LOG(INFO) << " Cupti Profiler using CUDA context = " << cuContext_;
   }
 
   profilerStartTs_ = std::chrono::high_resolution_clock::now();
@@ -202,6 +437,11 @@ void CuptiRBProfilerSession::startInternal(
     return;
   }
   profilerInitDoneTs_ = std::chrono::high_resolution_clock::now();
+
+  if (curRange_ == CUPTI_AutoRange) {
+    enableKernelCallbacks();
+  }
+  profilingActive_ = true;
 }
 
 void CuptiRBProfilerSession::stop() {
@@ -219,7 +459,10 @@ void CuptiRBProfilerSession::stop() {
       CUpti_Profiler_EndSession_Params_STRUCT_SIZE, nullptr};
   CUPTI_CALL(cuptiProfilerEndSession(&endSessionParams));
 
+  disableKernelCallbacks();
+
   profilerStopTs_ = std::chrono::high_resolution_clock::now();
+  profilingActive_ = false;
 }
 
 void CuptiRBProfilerSession::beginPass() {
@@ -267,16 +510,6 @@ void CuptiRBProfilerSession::disable() {
   CUPTI_CALL(cuptiProfilerDisableProfiling(&disableProfilingParams));
 }
 
-void CuptiRBProfilerSession::asyncStartAndEnable(
-    CUpti_ProfilerRange /*profilerRange*/,
-    CUpti_ProfilerReplayMode /*profilerReplayMode*/) {
-  /* TBD */
-}
-
-void CuptiRBProfilerSession::asyncDisableAndStop() {
-  /* TBD */
-}
-
 /// User range based profiling
 void CuptiRBProfilerSession::pushRange(const std::string& rangeName) {
   LOG(INFO) << " CUPTI pushrange ( " << rangeName << " )";
@@ -287,17 +520,66 @@ void CuptiRBProfilerSession::pushRange(const std::string& rangeName) {
 }
 
 void CuptiRBProfilerSession::popRange() {
-  LOG(INFO) << "Pop User range";
+  LOG(INFO) << " CUPTI pop range";
   CUpti_Profiler_PopRange_Params popRangeParams = {
       CUpti_Profiler_PopRange_Params_STRUCT_SIZE, nullptr};
   CUPTI_CALL(cuptiProfilerPopRange(&popRangeParams));
 }
 
-CuptiProfilerResult CuptiRBProfilerSession::evalualteMetrics(
+void CuptiRBProfilerSession::startAndEnable() {
+  startInternal(curRange_, curReplay_);
+  if (curReplay_ == CUPTI_UserReplay) {
+    beginPass();
+  }
+  enable();
+  if (curRange_ == CUPTI_UserRange) {
+    pushRange(kRootUserRangeName);
+  }
+  enable_flag[deviceId_] = false;
+}
+
+void CuptiRBProfilerSession::disableAndStop() {
+  if (curRange_ == CUPTI_UserRange) {
+    popRange();
+  }
+  disable();
+  if (curReplay_ == CUPTI_UserReplay) {
+    endPass();
+    flushCounterData();
+  }
+  stop();
+  disable_flag[deviceId_] = false;
+}
+
+void CuptiRBProfilerSession::asyncStartAndEnable(
+    CUpti_ProfilerRange profilerRange,
+    CUpti_ProfilerReplayMode profilerReplayMode) {
+  LOG(INFO) << "Starting CUPTI profiler asynchronously on device = "
+            << deviceId_ << " profiler range = "
+            << ((profilerRange == CUPTI_AutoRange) ? "autorange" : "userrange")
+            << " replay mode = "
+            << ((profilerReplayMode == CUPTI_KernelReplay) ? "kernel" : "user");
+  curReplay_ = profilerReplayMode;
+  curRange_ = profilerRange;
+  enable_flag[deviceId_] = true;
+  enableKernelCallbacks();
+}
+
+void CuptiRBProfilerSession::asyncDisableAndStop() {
+  LOG(INFO) << "Stopping CUPTI profiler asynchronously on device = "
+            << deviceId_ << " cu context = " << cuContext_;
+  disable_flag[deviceId_] = true;
+}
+
+
+CuptiProfilerResult CuptiRBProfilerSession::evaluateMetrics(
     bool verbose) {
   if (!initSuccess_) {
     LOG(WARNING) << "Profiling failed, no results to return";
     return {};
+  }
+  if (profilingActive_) {
+    disableAndStop();
   }
 
   LOG(INFO) << "Total kernels logged = " << kernelNames_.size();
@@ -307,7 +589,6 @@ CuptiProfilerResult CuptiRBProfilerSession::evalualteMetrics(
     }
     LOG(INFO) << "Profiler Range data : ";
   }
-  LOG(INFO) << "Profiler Range data : ";
 
   auto results = nvperf::evalMetricValues(
       chipName_, counterDataImage, metricNames_, verbose /*verbose*/);
@@ -322,6 +603,14 @@ CuptiProfilerResult CuptiRBProfilerSession::evalualteMetrics(
   LOG(INFO) << "Total profiler init time = " << init_dur_ms.count() << " ms";
 
   return results;
+}
+
+std::unique_ptr<TraceSpan> CuptiRBProfilerSession::getProfilerTraceSpan() {
+  return std::make_unique<TraceSpan>(
+      timeSinceEpoch(profilerStartTs_),
+      timeSinceEpoch(profilerStopTs_),
+      "__cupti_profiler__"
+  );
 }
 
 void CuptiRBProfilerSession::saveCounterData(
@@ -423,7 +712,7 @@ void CuptiRBProfilerSession::asyncStartAndEnable(
     CUpti_ProfilerRange /*profilerRange*/,
     CUpti_ProfilerReplayMode /*profilerReplayMode*/) {}
 void CuptiRBProfilerSession::asyncDisableAndStop() {}
-CuptiProfilerResult CuptiRBProfilerSession::evalualteMetrics(bool verbose) {
+CuptiProfilerResult CuptiRBProfilerSession::evaluateMetrics(bool verbose) {
   static CuptiProfilerResult res;
   return res;
 };
@@ -443,4 +732,19 @@ std::vector<uint8_t>& CuptiRBProfilerSession::counterAvailabilityImage() {
 }
 #endif // HAS_CUPTI_PROFILER
 
+namespace testing {
+
+void trackCudaCtx(CUcontext ctx, uint32_t device_id, CUpti_CallbackId cbid) {
+#if HAS_CUPTI_PROFILER
+  __trackCudaCtx(ctx, device_id, cbid);
+#endif // HAS_CUPTI_PROFILER
+}
+
+void trackCudaKernelLaunch(CUcontext ctx, const char* kernelName) {
+#if HAS_CUPTI_PROFILER
+  __trackCudaKernelLaunch(ctx, kernelName);
+#endif // HAS_CUPTI_PROFILER
+}
+
+} // namespace testing
 } // namespace KINETO_NAMESPACE

--- a/libkineto/test/CuptiRangeProfilerApiTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerApiTest.cpp
@@ -1,0 +1,113 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include <array>
+#include <set>
+
+#include "include/libkineto.h"
+#include "include/Config.h"
+#include "src/CuptiRangeProfilerApi.h"
+
+#include "src/Logger.h"
+#include "test/CuptiRangeProfilerTestUtil.h"
+
+using namespace KINETO_NAMESPACE;
+
+#if HAS_CUPTI_PROFILER
+
+TEST(CuptiRangeProfilerApiTest, contextTracking) {
+  std::vector<std::string> log_modules(
+      {"CuptiRangeProfilerApi.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(1, log_modules);
+
+  std::array<int64_t, 3> data;
+  std::array<CUcontext, 3> contexts;
+  for (int i = 0; i < data.size(); i++) {
+    contexts[i] = reinterpret_cast<CUcontext>(&data[i]);
+  }
+
+  // simulate creating contexts, this calls the trackCudaContexts
+  // function that would otherwise be called via a callback
+  uint32_t dev = 0;
+  for (auto ctx : contexts) {
+    simulateCudaContextCreate(ctx, dev++);
+  }
+
+  EXPECT_EQ(
+      CuptiRBProfilerSession::getActiveDevices(),
+      std::set<uint32_t>({0, 1, 2}));
+
+  simulateCudaContextDestroy(contexts[1], 1);
+
+  EXPECT_EQ(
+      CuptiRBProfilerSession::getActiveDevices(),
+      std::set<uint32_t>({0, 2}));
+
+  simulateCudaContextDestroy(contexts[0], 0);
+  simulateCudaContextDestroy(contexts[2], 2);
+
+  EXPECT_TRUE(
+      CuptiRBProfilerSession::getActiveDevices().empty());
+}
+
+TEST(CuptiRangeProfilerApiTest, asyncLaunchUserRange) {
+  std::vector<std::string> log_modules(
+      {"CuptiRangeProfilerApi.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(1, log_modules);
+
+  // this is bad but the pointer is never accessed
+  CUcontext ctx0 = reinterpret_cast<CUcontext>(10);
+  simulateCudaContextCreate(ctx0, 0 /*device_id*/);
+
+  auto session = std::make_unique<MockCuptiRBProfilerSession>(0, ctx0);
+  session->asyncStartAndEnable(CUPTI_UserRange, CUPTI_UserReplay);
+
+  simulateKernelLaunch(ctx0, "hello");
+  simulateKernelLaunch(ctx0, "foo");
+  simulateKernelLaunch(ctx0, "bar");
+
+  session->asyncDisableAndStop();
+  // stop happens after next kernel is run
+  simulateKernelLaunch(ctx0, "bar");
+  simulateCudaContextDestroy(ctx0, 0 /*device_id*/);
+
+  EXPECT_EQ(session->passes_ended, 1);
+  EXPECT_EQ(session->ranges_ended, 1);
+  EXPECT_TRUE(session->enabled);
+}
+
+TEST(CuptiRangeProfilerApiTest, asyncLaunchAutoRange) {
+  std::vector<std::string> log_modules(
+      {"CuptiRangeProfilerApi.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(1, log_modules);
+
+  // this is bad but the pointer is never accessed
+  CUcontext ctx0 = reinterpret_cast<CUcontext>(10);
+  CUcontext ctx1 = reinterpret_cast<CUcontext>(11);
+
+  simulateCudaContextCreate(ctx0, 0 /*device_id*/);
+
+  auto session = std::make_unique<MockCuptiRBProfilerSession>(0, ctx0);
+  session->asyncStartAndEnable(CUPTI_AutoRange, CUPTI_KernelReplay);
+
+  simulateKernelLaunch(ctx0, "hello");
+  simulateKernelLaunch(ctx0, "foo");
+  simulateKernelLaunch(ctx1, "kernel_on_different_device");
+  simulateKernelLaunch(ctx0, "bar");
+
+  session->asyncDisableAndStop();
+  // stop happens after next kernel is run
+  simulateKernelLaunch(ctx0, "bar");
+  simulateCudaContextDestroy(ctx0, 0 /*device_id*/);
+
+  EXPECT_EQ(session->passes_ended, 0);
+  EXPECT_EQ(session->ranges_ended, 0);
+  EXPECT_TRUE(session->enabled);
+
+  EXPECT_EQ(
+      session->getKernelNames(),
+      std::vector<std::string>({"hello", "foo", "bar"}))
+    << "Kernel names were not tracked";
+}
+
+#endif // HAS_CUPTI_PROFILER

--- a/libkineto/test/CuptiRangeProfilerTestUtil.h
+++ b/libkineto/test/CuptiRangeProfilerTestUtil.h
@@ -1,0 +1,96 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <stdlib.h>
+#include <gtest/gtest.h>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "CuptiRangeProfilerApi.h"
+
+namespace KINETO_NAMESPACE {
+
+#if HAS_CUPTI_PROFILER
+
+class MockCuptiRBProfilerSession : public CuptiRBProfilerSession {
+ public:
+  MockCuptiRBProfilerSession(int deviceId, CUcontext ctx)
+    : CuptiRBProfilerSession(deviceId, ctx) {}
+
+  void beginPass() override {
+    LOG(INFO) << " Mock CUPTI begin pass";
+    passes_started++;
+  }
+
+  bool endPass() override {
+    passes_ended++;
+    return true;
+  }
+
+  void flushCounterData() override {}
+
+  void pushRange(const std::string& rangeName) override {
+    LOG(INFO) << " Mock CUPTI pushrange ( " << rangeName << " )";
+    ranges_started++;
+  }
+
+  void popRange() override {
+    LOG(INFO) << " Mock CUPTI poprange";
+    ranges_ended++;
+  }
+
+  void stop() override {
+    runChecks();
+  }
+
+  void enable() override {
+    enabled = true;
+  }
+  void disable() override {}
+
+  CuptiProfilerResult evaluateMetrics(bool /*verbose*/) override {
+    return result;
+  }
+
+protected:
+  void startInternal(
+      CUpti_ProfilerRange profilerRange,
+      CUpti_ProfilerReplayMode profilerReplayMode) override {
+    curRange_ = profilerRange;
+    curReplay_ = profilerReplayMode;
+  }
+
+private:
+  void runChecks() {
+    EXPECT_EQ(passes_started, passes_ended);
+    EXPECT_EQ(ranges_started, ranges_ended);
+  }
+
+ public:
+  int passes_started = 0;
+  int passes_ended = 0;
+  int ranges_started = 0;
+  int ranges_ended = 0;
+  bool enabled = false;
+
+  CuptiProfilerResult result;
+
+};
+
+inline void simulateCudaContextCreate(CUcontext context, uint32_t dev) {
+  testing::trackCudaCtx(
+      context, dev, CUPTI_CBID_RESOURCE_CONTEXT_CREATED);
+}
+
+inline void simulateCudaContextDestroy(CUcontext context, uint32_t dev) {
+  testing::trackCudaCtx(
+      context, dev, CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING);
+}
+
+inline void simulateKernelLaunch(
+    CUcontext context, const std::string& kernelName) {
+  testing::trackCudaKernelLaunch(context, kernelName.c_str());
+}
+
+#endif // HAS_CUPTI_PROFILER
+
+} // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Summary:
# Summary

The CUPTI Ranger profiler API is confined to each CUDA context. This makes it harder to use in applications that are multi-threaded, such as pytorch models
with different threads for forward and backward pass computation.

In this patch we leverage CUPTI Callback API to track the CUDA contexts and kernel launches.
* Also, introduce an asynchronous mode to start and stop the CUPTI Range profiling API that is triggered using Kernel launch callbacks
* Track the name of kernels to use with auto-range model as CUPTI only provides a number for range ID.

## Testing
1. Enabled mocking the callbacks for Cuda context create/destroy and kernel launches.
2. Added a unit test to check callback triggered logic and asynchronous start and stop of ranges.

Differential Revision: D32008907

