### PR TITLE
Enable rounding up profile start iteration

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -226,8 +226,20 @@ class Config : public AbstractConfig {
     return profileStartIteration_ >= 0 && activitiesRunIterations_ > 0;
   }
 
-  void setProfileStartIteration(int64_t iter) {
+  void setProfileStartIteration(int iter) {
     profileStartIteration_ = iter;
+  }
+
+  int profileStartIterationRoundUp() const {
+    return profileStartIterationRoundUp_;
+  }
+
+  // calculate the start iteration accounting for warmup
+  int startIterationIncludingWarmup() const {
+    if (!hasProfileStartIteration()) {
+      return -1;
+    }
+    return profileStartIteration_ - activitiesWarmupIterations_;
   }
 
   const std::chrono::seconds maxRequestAge() const;
@@ -402,6 +414,7 @@ class Config : public AbstractConfig {
   std::chrono::time_point<std::chrono::system_clock> profileStartTime_;
   // or start iteration
   int profileStartIteration_;
+  int profileStartIterationRoundUp_;
 
   // DEPRECATED
   std::chrono::time_point<std::chrono::system_clock> requestTimestamp_;


### PR DESCRIPTION
Summary:
## Summary
In cases where you need to remotely trigger a trace having a fixed profiler start iteration can be difficult.
You may want multiple distributed ranks (GPUs/servers) to capture same set of iterations. One idea to achieve synchrony
is to have profiler iterations that are a multiple of some integer. This reduces the probability of network delays causing mismatch in profiled iterations.

## Details
1. Add PROFILE_START_ITERATION_ROUNDUP config parameter.
2. If current iterations > start iteration, round up to nearest multiple of PROFILE_START_ITERATION_ROUNDUP

Reviewed By: aaronenyeshi

Differential Revision: D34248399

