### PR TITLE
Remove a couple of noisy warnings

### DIFF
--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -325,9 +325,9 @@ bool Config::handleOption(const std::string& name, std::string& val) {
 
   // Common
   else if (!name.compare(kRequestTimestampKey)) {
-    LOG(WARNING) << kRequestTimestampKey
-                 << " has been deprecated - please use "
-                 << kProfileStartTimeKey;
+    VLOG(0) << kRequestTimestampKey
+            << " has been deprecated - please use "
+            << kProfileStartTimeKey;
     requestTimestamp_ = handleRequestTimestamp(toInt64(val));
   } else if (!name.compare(kProfileStartTimeKey)) {
     profileStartTime_ =

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -153,7 +153,11 @@ void CuptiActivityProfiler::processCpuTrace(
 #ifdef HAS_CUPTI
 inline void CuptiActivityProfiler::handleCorrelationActivity(
     const CUpti_ActivityExternalCorrelation* correlation) {
-  cpuCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  if (correlation->externalKind == CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM0) {
+    cpuCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  } else {
+    userCorrelationMap_[correlation->correlationId] = correlation->externalId;
+  }
 }
 #endif // HAS_CUPTI
 
@@ -174,19 +178,14 @@ static GenericTraceActivity createUserGpuSpan(
 }
 
 void CuptiActivityProfiler::GpuUserEventMap::insertOrExtendEvent(
-    const ITraceActivity&,
+    const ITraceActivity& userActivity,
     const ITraceActivity& gpuActivity) {
-  if (!gpuActivity.linkedActivity()) {
-    VLOG(0) << "Missing linked activity";
-    return;
-  }
-  const ITraceActivity& cpuActivity = *gpuActivity.linkedActivity();
   StreamKey key(gpuActivity.deviceId(), gpuActivity.resourceId());
   CorrelationSpanMap& correlationSpanMap = streamSpanMap_[key];
-  auto it = correlationSpanMap.find(cpuActivity.correlationId());
+  auto it = correlationSpanMap.find(userActivity.correlationId());
   if (it == correlationSpanMap.end()) {
     auto it_success = correlationSpanMap.insert({
-        cpuActivity.correlationId(), createUserGpuSpan(cpuActivity, gpuActivity)
+        userActivity.correlationId(), createUserGpuSpan(userActivity, gpuActivity)
     });
     it = it_success.first;
   }
@@ -250,6 +249,7 @@ void CuptiActivityProfiler::handleRuntimeActivity(
   if (isBlockListedRuntimeCbid(activity->cbid)) {
     return;
   }
+
   VLOG(2) << activity->correlationId
           << ": CUPTI_ACTIVITY_KIND_RUNTIME, cbid=" << activity->cbid
           << " tid=" << activity->threadId;
@@ -339,9 +339,19 @@ inline void CuptiActivityProfiler::handleGpuActivity(
   checkTimestampOrder(&act);
   VLOG(2) << act.correlationId() << ": "
           << act.name();
-  recordStream(act.deviceId(), act.resourceId());
+  recordStream(act.deviceId(), act.resourceId(), "");
   act.log(*logger);
   updateGpuNetSpan(act);
+  if (config_->selectedActivityTypes().count(ActivityType::GPU_USER_ANNOTATION)) {
+    const auto& it = userCorrelationMap_.find(act.correlationId());
+    if (it != userCorrelationMap_.end()) {
+      const auto& it2 = activityMap_.find(it->second);
+      if (it2 != activityMap_.end()) {
+        recordStream(act.deviceId(), -act.resourceId(), "context");
+        gpuUserEventMap_.insertOrExtendEvent(*it2->second, act);
+      }
+    }
+  }
 }
 
 const ITraceActivity* CuptiActivityProfiler::linkedActivity(

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -112,6 +112,7 @@ class CuptiActivityProfiler {
           ActivityLogger::ResourceInfo(
               pid,
               sysTid,
+              sysTid,
               fmt::format("thread {} ({})", sysTid, getThreadName())));
     }
   }
@@ -169,6 +170,7 @@ class CuptiActivityProfiler {
   // CUDA runtime <-> GPU Activity
   std::unordered_map<int64_t, const ITraceActivity*>
       correlatedCudaActivities_;
+  std::unordered_map<int64_t, int64_t> userCorrelationMap_;
 
   // data structure to collect cuptiActivityFlushAll() latency overhead
   struct profilerOverhead {
@@ -204,12 +206,13 @@ class CuptiActivityProfiler {
       ActivityLogger& logger);
 
   // Create resource names for streams
-  inline void recordStream(int device, int id) {
+  inline void recordStream(int device, int id, const char* postfix) {
     if (resourceInfo_.find({device, id}) == resourceInfo_.end()) {
       resourceInfo_.emplace(
           std::make_pair(device, id),
           ActivityLogger::ResourceInfo(
-              device, id, fmt::format("stream {}", id)));
+              device, id, id, fmt::format(
+                  "stream {} {}", id, postfix)));
     }
   }
 
@@ -253,6 +256,7 @@ class CuptiActivityProfiler {
     counter.overhead += overhead;
     counter.cntr++;
   }
+
   int64_t getOverhead(const profilerOverhead& counter) {
     if (counter.cntr == 0) {
       return 0;

--- a/libkineto/src/CuptiEventApi.cpp
+++ b/libkineto/src/CuptiEventApi.cpp
@@ -37,8 +37,14 @@ void CuptiEventApi::destroyGroupSets(CUpti_EventGroupSets* sets) {
 }
 
 bool CuptiEventApi::setContinuousMode() {
-  CUptiResult res = CUPTI_CALL(cuptiSetEventCollectionMode(
+  // Avoid logging noise for CUPTI_ERROR_LEGACY_PROFILER_NOT_SUPPORTED
+  CUptiResult res = CUPTI_CALL_NOWARN(cuptiSetEventCollectionMode(
       context_, CUPTI_EVENT_COLLECTION_MODE_CONTINUOUS));
+  if (res == CUPTI_ERROR_LEGACY_PROFILER_NOT_SUPPORTED) {
+    return false;
+  }
+  // Log warning on other errors
+  CUPTI_CALL(res);
   return (res == CUPTI_SUCCESS);
 }
 

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -41,9 +41,14 @@ class ActivityLogger {
   };
 
   struct ResourceInfo {
-    ResourceInfo(int64_t deviceId, int64_t id, const std::string& name) :
-        id(id), deviceId(deviceId), name(name) {}
+    ResourceInfo(
+        int64_t deviceId,
+        int64_t id,
+        int64_t sortIndex,
+        const std::string& name) :
+        id(id), sortIndex(sortIndex), deviceId(deviceId), name(name) {}
     int64_t id;
+    int64_t sortIndex;
     int64_t deviceId;
     const std::string name;
   };

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -149,7 +149,7 @@ void ChromeTraceLogger::handleResourceInfo(
       time, info.deviceId, info.id,
       info.name,
       time, info.deviceId, info.id,
-      info.id);
+      info.sortIndex);
   // clang-format on
 }
 
@@ -235,11 +235,21 @@ void ChromeTraceLogger::addIterationMarker(const TraceSpan& span) {
 
 static std::string traceActivityJson(const ITraceActivity& activity) {
   // clang-format off
+  int64_t ts = activity.timestamp();
+  int64_t duration = activity.duration();
+  if (activity.type() ==  ActivityType::GPU_USER_ANNOTATION) {
+    // The GPU user annotations start at the same time as the
+    // first associated GPU activity. Since they appear later
+    // in the trace file, this causes a visualization issue in Chrome.
+    // Make it start one us earlier.
+    ts--;
+    duration++; // Still need it to end at the orginal point
+  }
   return fmt::format(R"JSON(
     "name": "{}", "pid": {}, "tid": {},
     "ts": {}, "dur": {})JSON",
       activity.name(), activity.deviceId(), activity.resourceId(),
-      activity.timestamp(), activity.duration());
+      ts, duration);
   // clang-format on
 }
 
@@ -285,10 +295,6 @@ void ChromeTraceLogger::handleGenericActivity(
         op.traceSpan()->name,
         op.traceSpan()->iteration);
   }
-  const std::string tid =
-      op.type() == ActivityType::GPU_USER_ANNOTATION ?
-      fmt::format("stream {} annotations", op.resourceId()) :
-      fmt::format("{}", op.resourceId());
 
   // clang-format off
   traceOf_ << fmt::format(R"JSON(

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -454,6 +454,69 @@ TEST_F(CuptiActivityProfilerTest, SyncTrace) {
 #endif
 }
 
+TEST_F(CuptiActivityProfilerTest, GpuUserAnnotationTest) {
+  // Verbose logging is useful for debugging
+  std::vector<std::string> log_modules(
+      {"CuptiActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  // Start and stop profiling
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+  int64_t start_time_us = 100;
+  int64_t duration_us = 300;
+  auto start_time = time_point<system_clock>(microseconds(start_time_us));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + microseconds(duration_us));
+
+  int64_t kernelLaunchTime = 120;
+  profiler.recordThreadInfo();
+
+  // set up CPU event
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_us, start_time_us + duration_us);
+  cpuOps->addOp("annotation", kernelLaunchTime, kernelLaunchTime + 10, 1);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  // set up a coiple of GPU events and correlate with above CPU event.
+  // CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM1 is used for user annotations.
+  auto gpuOps = std::make_unique<MockCuptiActivityBuffer>();
+  gpuOps->addCorrelationActivity(1, CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM1, 1);
+  gpuOps->addKernelActivity(kernelLaunchTime + 5, kernelLaunchTime + 10, 1);
+  gpuOps->addCorrelationActivity(1, CUPTI_EXTERNAL_CORRELATION_KIND_CUSTOM1, 1);
+  gpuOps->addKernelActivity(kernelLaunchTime + 15, kernelLaunchTime + 25, 1);
+  cuptiActivities_.activityBuffer = std::move(gpuOps);
+
+  // process trace
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  std::map<std::string, int> counts;
+  for (auto& activity : *trace.activities()) {
+    counts[activity->name()]++;
+  }
+
+  // We should now have an additional annotation activity created
+  // on the GPU timeline.
+  EXPECT_EQ(counts["annotation"], 2);
+  EXPECT_EQ(counts["kernel"], 2);
+
+  auto& annotation = trace.activities()->at(0);
+  auto& kernel1 = trace.activities()->at(1);
+  auto& kernel2 = trace.activities()->at(2);
+  auto& gpu_annotation = trace.activities()->at(3);
+  EXPECT_EQ(gpu_annotation->type(), ActivityType::GPU_USER_ANNOTATION);
+  EXPECT_EQ(gpu_annotation->timestamp(), kernel1->timestamp());
+  EXPECT_EQ(
+      gpu_annotation->duration(),
+      kernel2->timestamp() + kernel2->duration() - kernel1->timestamp());
+  EXPECT_EQ(gpu_annotation->deviceId(), kernel1->deviceId());
+  EXPECT_EQ(gpu_annotation->resourceId(), kernel1->resourceId());
+  EXPECT_EQ(gpu_annotation->correlationId(), annotation->correlationId());
+  EXPECT_EQ(gpu_annotation->name(),  annotation->name());
+}
+
 TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
   using ::testing::Return;
   using ::testing::ByMove;


### PR DESCRIPTION
Summary:
Re-submitting Gisle's patch after rebase and fix merge.

Libkineto is currently logging too many messages. We should change some INFO and WARNING to VLOG.
In some cases we should also suppress common errors that we handle correctly.

Differential Revision: D31665028

Pulled By: aaronenyeshi

