### PR TITLE
Fix invalid Windows Paths in JSON trace file

### DIFF
--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -81,6 +81,8 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
 
   void metadataToJSON(const std::unordered_map<std::string, std::string>& metadata);
 
+  std::string& sanitizeStrForJSON(std::string& value);
+
   std::string fileName_;
   std::ofstream traceOf_;
 };


### PR DESCRIPTION
Summary: Since we added LoggerObserver support, some of the LOGs contain Windows paths that use backslashes. This is not valid in JSON, because it required additional backslashes. To fix this, we change all backslashes to forward slash.

Reviewed By: malfet

Differential Revision: D34490978

Pulled By: aaronenyeshi

