### PR TITLE
Add CUPTI Range profiler

### DIFF
--- a/libkineto/include/IActivityProfiler.h
+++ b/libkineto/include/IActivityProfiler.h
@@ -18,6 +18,7 @@
 namespace libkineto {
 
 using namespace KINETO_NAMESPACE;
+struct CpuTraceBuffer;
 
 #ifdef _MSC_VER
 // workaround for the predefined ERROR macro on Windows
@@ -52,14 +53,14 @@ class IActivityProfilerSession {
     return status_;
   }
 
-  // returns list of Trace Activities
-  virtual std::vector<GenericTraceActivity>& activities() = 0;
-
   // returns errors with this trace
   virtual std::vector<std::string> errors() = 0;
 
   // processes trace activities using logger
   virtual void processTrace(ActivityLogger& logger) = 0;
+
+  // release ownership of the trace events and metadata
+  virtual std::unique_ptr<CpuTraceBuffer> getTraceBuffer() = 0;
 
   // XXX define trace formats
   // virtual save(string name, TraceFormat format)

--- a/libkineto/include/time_since_epoch.h
+++ b/libkineto/include/time_since_epoch.h
@@ -6,8 +6,9 @@
 
 namespace libkineto {
 
+template <class ClockT>
 inline int64_t timeSinceEpoch(
-      const std::chrono::time_point<std::chrono::system_clock>& t) {
+      const std::chrono::time_point<ClockT>& t) {
     return std::chrono::duration_cast<std::chrono::microseconds>(
                t.time_since_epoch())
         .count();

--- a/libkineto/sample_programs/kineto_cupti_profiler.cpp
+++ b/libkineto/sample_programs/kineto_cupti_profiler.cpp
@@ -1,0 +1,52 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <chrono>
+#include <thread>
+
+#include <common/logging/logging.h>
+#include <libkineto.h>
+
+#include "kineto/libkineto/sample_programs/kineto_playground.cuh"
+
+using namespace kineto;
+
+static const std::string kFileName = "/tmp/kineto_playground_trace.json";
+
+int main() {
+  warmup();
+
+  // Kineto config
+  std::set<libkineto::ActivityType> types_cupti_prof = {
+    libkineto::ActivityType::CUDA_PROFILER_RANGE,
+  };
+
+  // Use a special kineto__cuda_core_flop metric that counts individual
+  // CUDA core floating point instructions by operation type (fma,fadd,fmul,dadd ...)
+  // You can also use kineto__tensor_core_insts or any metric
+  // or any metric defined by CUPTI Profiler below
+  //   https://docs.nvidia.com/cupti/Cupti/r_main.html#r_profiler
+
+  std::string profiler_config = "ACTIVITIES_WARMUP_PERIOD_SECS=0\n "
+    "CUPTI_PROFILER_METRICS=kineto__cuda_core_flops\n "
+    "CUPTI_PROFILER_ENABLE_PER_KERNEL=true";
+
+  auto& profiler = libkineto::api().activityProfiler();
+  profiler.prepareTrace(types_cupti_prof, profiler_config);
+
+  // Good to warm up after prepareTrace to get cupti initialization to settle
+  warmup();
+
+  profiler.startTrace();
+  basicMemcpyToDevice();
+  compute();
+  basicMemcpyFromDevice();
+
+  auto trace = profiler.stopTrace();
+  LOG(INFO) << "Stopped and processed trace. Got " << trace->activities()->size() << " activities.";
+  trace->save(kFileName);
+  return 0;
+}
+

--- a/libkineto/sample_programs/kineto_playground.cu
+++ b/libkineto/sample_programs/kineto_playground.cu
@@ -22,39 +22,62 @@ void warmup(void) {
   cudaFree(mem); 
 }
 
-void basicMemcpyMemset(void) {
-  size_t size = (1 << 8) * sizeof(float);
-  float *hostMemSrc, *deviceMem, *hostMemDst;
+float *hA, *dA, *hOut;
+int num = 50'000;
+
+void basicMemcpyToDevice(void) {
+  size_t size = num * sizeof(float);
   cudaError_t err;
 
-  hostMemSrc = (float*)malloc(size);
-  hostMemDst = (float*)malloc(size);
-  err = cudaMalloc(&deviceMem, size);
+  hA = (float*)malloc(size);
+  hOut = (float*)malloc(size);
+  err = cudaMalloc(&dA, size);
   if (err != cudaSuccess) {
     printf("cudaMalloc failed during %s", __func__);
     return;
   }
 
-  memset(hostMemSrc, 1, size);
-  cudaMemcpy(deviceMem, hostMemSrc, size, cudaMemcpyHostToDevice);
+  memset(hA, 1, size);
+  err = cudaMemcpy(dA, hA, size, cudaMemcpyHostToDevice);
+  if (err != cudaSuccess) {
+    printf("cudaMemcpy failed during %s", __func__);
+    return;
+  }
+}
+
+void basicMemcpyFromDevice(void) {
+
+  size_t size = num * sizeof(float);
+  cudaError_t err;
+
+  err = cudaMemcpy(hOut, dA, size, cudaMemcpyDeviceToHost);
   if (err != cudaSuccess) {
     printf("cudaMemcpy failed during %s", __func__);
     return;
   }
 
-  cudaMemcpy(hostMemDst, deviceMem, size, cudaMemcpyDeviceToHost);
-  if (err != cudaSuccess) {
-    printf("cudaMemcpy failed during %s", __func__);
-    return;
-  }
+  free(hA);
+  free(hOut);
+  cudaFree(dA);
+}
 
-  free(hostMemSrc);
-  free(hostMemDst);
-  cudaFree(deviceMem);
+__global__ void square(float* A, int N) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < N) {
+    A[i] *= A[i];
+  }
 }
 
 void playground(void) {
   // Add your experimental CUDA implementation here. 
 }
 
+void compute(void) {
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (num + threadsPerBlock - 1) / threadsPerBlock;
+  for (int i = 0; i < 10; i++) {
+    square<<<blocksPerGrid, threadsPerBlock>>> (dA, num);
+  }
 }
+
+} // namespace kineto

--- a/libkineto/sample_programs/kineto_playground.cuh
+++ b/libkineto/sample_programs/kineto_playground.cuh
@@ -10,9 +10,15 @@ namespace kineto {
 void warmup(void);
 
 // Basic usage of cudaMemcpy and cudaMemset
-void basicMemcpyMemset(void);
+void basicMemcpyToDevice(void);
+
+// Basic usage of cudaMemcpy from device to host
+void basicMemcpyFromDevice(void);
 
 // Your experimental code goes in here!
 void playground(void);
+
+// Run a simple elementwise kernel
+void compute(void);
 
 }

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -4,7 +4,10 @@
 
 #include <cupti.h>
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "ITraceActivity.h"
+#include "GenericTraceActivity.h"
 #include "CuptiActivityPlatform.h"
 #include "ThreadUtil.h"
 #include "cupti_strings.h"

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -550,7 +550,7 @@ void CuptiActivityProfiler::configure(
 void CuptiActivityProfiler::startTraceInternal(const time_point<system_clock>& now) {
   captureWindowStartTime_ = libkineto::timeSinceEpoch(now);
   VLOG(0) << "Warmup -> CollectTrace";
-  for (auto& session: sessions_){
+  for (auto& session : sessions_){
     LOG(INFO) << "Starting child profiler session";
     session->start();
   }
@@ -587,7 +587,7 @@ void CuptiActivityProfiler::stopTraceInternal(const time_point<system_clock>& no
         static_cast<std::underlying_type<RunloopState>::type>(
             currentRunloopState_.load());
   }
-  for (auto& session: sessions_){
+  for (auto& session : sessions_){
     LOG(INFO) << "Stopping child profiler session";
     session->stop();
   }
@@ -804,6 +804,11 @@ void CuptiActivityProfiler::finalizeTrace(const Config& config, ActivityLogger& 
   }
 
   gpuUserEventMap_.logEvents(&logger);
+
+  for (auto& session : sessions_){
+    auto trace_buffer = session->getTraceBuffer();
+    traceBuffers_->cpu.push_back(std::move(trace_buffer));
+  }
 
 #if !USE_GOOGLE_LOG
   // Save logs from LoggerCollector objects into Trace metadata.

--- a/libkineto/src/CuptiRangeProfiler.cpp
+++ b/libkineto/src/CuptiRangeProfiler.cpp
@@ -1,0 +1,299 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <Logger.h>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <unistd.h>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "output_base.h"
+#include "CuptiRangeProfiler.h"
+#include "CuptiRangeProfilerConfig.h"
+#include "Demangle.h"
+
+namespace KINETO_NAMESPACE {
+
+const ActivityType kProfActivityType = ActivityType::CUDA_PROFILER_RANGE;
+const std::set<ActivityType> kSupportedActivities{kProfActivityType};
+
+const std::string kProfilerName{"CuptiRangeProfiler"};
+
+static ICuptiRBProfilerSessionFactory& getFactory() {
+  static CuptiRBProfilerSessionFactory factory_;
+  return factory_;
+}
+
+/* ----------------------------------------
+ * Implement CuptiRangeProfilerSession
+ * ----------------------------------------
+ */
+
+namespace {
+
+CuptiProfilerPrePostCallback cuptiProfilerPreRunCb;
+CuptiProfilerPrePostCallback cuptiProfilerPostRunCb;
+
+
+/* Following are aliases to a set of CUPTI metrics that can be
+ * used to derived measures like FLOPs etc.
+ */
+std::unordered_map<std::string, std::vector<std::string>> kDerivedMetrics = {
+  {"kineto__cuda_core_flops", {
+    "smsp__sass_thread_inst_executed_op_dadd_pred_on.sum",
+    "smsp__sass_thread_inst_executed_op_dfma_pred_on.sum",
+    "smsp__sass_thread_inst_executed_op_dmul_pred_on.sum",
+    "smsp__sass_thread_inst_executed_op_hadd_pred_on.sum",
+    "smsp__sass_thread_inst_executed_op_hfma_pred_on.sum",
+    "smsp__sass_thread_inst_executed_op_hmul_pred_on.sum",
+    "smsp__sass_thread_inst_executed_op_fadd_pred_on.sum",
+    "smsp__sass_thread_inst_executed_op_ffma_pred_on.sum",
+    "smsp__sass_thread_inst_executed_op_fmul_pred_on.sum"}},
+  {"kineto__tensor_core_insts", {
+    "sm__inst_executed_pipe_tensor.sum"}},
+};
+
+} // namespace;
+
+
+CuptiRangeProfilerSession::CuptiRangeProfilerSession(
+    const Config& config, ICuptiRBProfilerSessionFactory& factory) {
+
+  // CUPTI APIs can conflict with other monitoring systems like DCGM
+  // or NSight / NVProf. The pre and post run hooks enable users to
+  // potentially pause other tools like DCGM.
+  // By the way consider adding some delay while using dcgmpause() so
+  // the change takes effect inside the driver.
+  if (cuptiProfilerPreRunCb) {
+    cuptiProfilerPreRunCb();
+  }
+
+  const CuptiRangeProfilerConfig& cupti_config =
+    CuptiRangeProfilerConfig::get(config);
+
+  std::vector<std::string> cupti_metrics;
+  const auto& requested_metrics = cupti_config.activitiesCuptiMetrics();
+
+  for (const auto& metric : requested_metrics) {
+    auto it = kDerivedMetrics.find(metric);
+    if (it != kDerivedMetrics.end()) {
+      // add all the fundamental metrics
+      for (const auto& m : it->second) {
+        cupti_metrics.push_back(m);
+      }
+    } else {
+      cupti_metrics.push_back(metric);
+    }
+  }
+
+  // Capture metrics per kernel implies using auto-range mode
+  if (cupti_config.cuptiProfilerPerKernel()) {
+    rangeType_ = CUPTI_AutoRange;
+    replayType_ = CUPTI_KernelReplay;
+  }
+
+  LOG(INFO) << "Configuring " << cupti_metrics.size()
+            << " CUPTI metrics";
+
+  int max_ranges = cupti_config.cuptiProfilerMaxRanges();
+  for (const auto& m : cupti_metrics) {
+    LOG(INFO) << "\t" << m;
+  }
+
+  CuptiRangeProfilerOptions opts{
+    .metricNames = cupti_metrics,
+    .maxRanges = max_ranges,
+    .numNestingLevels = 1,
+    .cuContext = nullptr};
+
+  for (auto device_id : CuptiRBProfilerSession::getActiveDevices()) {
+    LOG(INFO) << "Init CUPTI range profiler on gpu = " << device_id
+              << " max ranges = " << max_ranges;
+    opts.deviceId = device_id;
+    profilers_.push_back(factory.make(opts));
+  }
+}
+
+void CuptiRangeProfilerSession::start() {
+  for (auto& profiler: profilers_) {
+    // user range or auto range
+    profiler->asyncStartAndEnable(rangeType_, replayType_);
+  }
+}
+
+void CuptiRangeProfilerSession::stop() {
+  for (auto& profiler: profilers_) {
+    profiler->disableAndStop();
+  }
+}
+
+void CuptiRangeProfilerSession::addRangeEvents(
+    const CuptiProfilerResult& result,
+    const CuptiRBProfilerSession* profiler) {
+  const auto& metricNames = result.metricNames;
+  auto& activities = traceBuffer_.activities;
+  bool use_kernel_names = false;
+  int num_kernels = 0;
+
+  if (rangeType_ == CUPTI_AutoRange) {
+    use_kernel_names = true;
+    num_kernels = profiler->getKernelNames().size();
+    if (num_kernels != result.rangeVals.size()) {
+      LOG(WARNING) << "Number of kernels tracked does not match the "
+                   << " number of ranges collected"
+                   << " kernel names size = " << num_kernels
+                   << " vs ranges = " << result.rangeVals.size();
+    }
+  }
+
+  // the actual times do not really matter here so
+  // we can just split the total span up per range
+  int64_t startTime = traceBuffer_.span.startTime,
+          duration = traceBuffer_.span.endTime - startTime,
+          interval = duration / result.rangeVals.size();
+
+  int ridx = 0;
+  for (const auto& measurement : result.rangeVals) {
+    bool use_kernel_as_range = use_kernel_names && (ridx < num_kernels);
+    activities.emplace_back(
+        traceBuffer_.span,
+        kProfActivityType,
+        use_kernel_as_range ?
+          demangle(profiler->getKernelNames()[ridx]) :
+          measurement.rangeName
+    );
+    auto& event = activities.back();
+    event.startTime = startTime + interval * ridx;
+    event.endTime = startTime + interval * (ridx + 1);
+    event.device = profiler->deviceId();
+
+    // add metadata per counter
+    for (int i = 0; i < metricNames.size(); i++) {
+      event.addMetadata(metricNames[i], measurement.values[i]);
+    }
+    ridx++;
+  }
+}
+
+void CuptiRangeProfilerSession::processTrace(ActivityLogger& logger) {
+  if (profilers_.size() == 0) {
+    LOG(WARNING) << "Nothing to report";
+    return;
+  }
+
+  traceBuffer_.span = profilers_[0]->getProfilerTraceSpan();
+  for (auto& profiler: profilers_) {
+    bool verbose = VLOG_IS_ON(1);
+    auto result = profiler->evaluateMetrics(verbose);
+
+    LOG(INFO) << "Profiler Range data on gpu = " << profiler->deviceId();
+    if (result.rangeVals.size() == 0) {
+      LOG(WARNING) << "Skipping profiler results on gpu = "
+                   << profiler->deviceId() << " as 0 ranges were found";
+      continue;
+    }
+    addRangeEvents(result, profiler.get());
+  }
+
+  for (const auto& event : traceBuffer_.activities) {
+    logger.handleGenericActivity(event);
+  }
+
+  LOG(INFO) << "CUPTI Range Profiler added " << traceBuffer_.activities.size()
+            << " events";
+
+  if (cuptiProfilerPostRunCb) {
+    cuptiProfilerPostRunCb();
+  }
+}
+
+std::vector<std::string> CuptiRangeProfilerSession::errors() {
+  return {};
+}
+
+/* ----------------------------------------
+ * Implement CuptiRangeProfiler
+ * ----------------------------------------
+ */
+CuptiRangeProfiler::CuptiRangeProfiler()
+  : CuptiRangeProfiler(getFactory()) {}
+
+CuptiRangeProfiler::CuptiRangeProfiler(ICuptiRBProfilerSessionFactory& factory)
+  : factory_(factory) {}
+
+void CuptiRangeProfiler::setPreRunCallback(
+    CuptiProfilerPrePostCallback fn) {
+  cuptiProfilerPreRunCb = fn;
+}
+
+void CuptiRangeProfiler::setPostRunCallback(
+    CuptiProfilerPrePostCallback fn) {
+  cuptiProfilerPostRunCb = fn;
+}
+
+const std::string& CuptiRangeProfiler::name() const {
+  return kProfilerName;
+}
+
+const std::set<ActivityType>& CuptiRangeProfiler::availableActivities()
+    const {
+  return kSupportedActivities;
+}
+
+// TODO remove activity_types from this interface in the future
+std::unique_ptr<IActivityProfilerSession> CuptiRangeProfiler::configure(
+    const std::set<ActivityType>& /*activity_types*/,
+    const Config& config) {
+  const auto& activity_types_ = config.selectedActivityTypes();
+  if (activity_types_.find(kProfActivityType) == activity_types_.end()) {
+    return nullptr;
+  }
+
+  if (activity_types_.size() > 1) {
+    LOG(WARNING) << kProfilerName << " cannot be run in combination with"
+                << " other cuda activity profilers, please configure"
+                << " only one activity type  : cuda_profiler_range";
+    return nullptr;
+  }
+
+  return std::make_unique<CuptiRangeProfilerSession>(config, factory_);
+}
+
+std::unique_ptr<IActivityProfilerSession>
+CuptiRangeProfiler::configure(
+    int64_t /*ts_ms*/,
+    int64_t /*duration_ms*/,
+    const std::set<ActivityType>& activity_types,
+    const Config& config) {
+  return configure(activity_types, config);
+};
+
+/* ----------------------------------------
+ * CuptiRangeProfilerInit :
+ *    a small wrapper class that ensure the activity profiler is created and
+ *  initialized.
+ * ----------------------------------------
+ */
+CuptiRangeProfilerInit::CuptiRangeProfilerInit() {
+  // register config
+  CuptiRangeProfilerConfig::registerFactory();
+
+#ifdef HAS_CUPTI
+  // TODO should this be revised to avoid overhead
+  CuptiRBProfilerSession::staticInit();
+#endif
+
+  // Register the activity profiler instance with libkineto api
+  api().registerProfilerFactory([&]() {
+    return std::make_unique<CuptiRangeProfiler>();
+  });
+}
+
+CuptiRangeProfilerInit::~CuptiRangeProfilerInit() {
+    CuptiRBProfilerSession::deInitCupti();
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiRangeProfiler.h
+++ b/libkineto/src/CuptiRangeProfiler.h
@@ -1,0 +1,108 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <functional>
+
+#include <libkineto.h>
+#include <IActivityProfiler.h>
+
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "CuptiRangeProfilerApi.h"
+
+/* CuptiRangeProfiler :
+ *   This profiler object provides an interface to run the CUPTI
+ *   Range Based Profiler API.
+ */
+
+namespace KINETO_NAMESPACE {
+
+using CuptiProfilerPrePostCallback = std::function<void(void)>;
+
+/* Activity Profiler session encapsulates the CUPTI Range based Profiler
+ * API object
+ */
+class CuptiRangeProfilerSession : public IActivityProfilerSession {
+ public:
+  explicit CuptiRangeProfilerSession(
+      const Config& config,
+      ICuptiRBProfilerSessionFactory& factory);
+
+  ~CuptiRangeProfilerSession() override {};
+
+  // start profiling
+  void start() override;
+
+  // stop profiling
+  void stop() override;
+
+  // process trace events with logger
+  void processTrace(libkineto::ActivityLogger& logger) override;
+
+  std::unique_ptr<CpuTraceBuffer> getTraceBuffer() override {
+    return std::make_unique<CpuTraceBuffer>(std::move(traceBuffer_));
+  }
+
+  // returns errors with this trace
+  std::vector<std::string> errors() override;
+
+ private:
+  void addRangeEvents(
+      const CuptiProfilerResult& result,
+      const CuptiRBProfilerSession* profiler);
+
+  CUpti_ProfilerRange rangeType_ = CUPTI_UserRange;
+  CUpti_ProfilerReplayMode replayType_ = CUPTI_UserReplay;
+
+  CpuTraceBuffer traceBuffer_;
+  std::vector<
+    std::unique_ptr<CuptiRBProfilerSession>> profilers_;
+};
+
+
+/* This is a wrapper class that refers to the underlying
+ * CuptiRangeProfiler. Using a wrapper libkineto can manage the ownership
+ * of this object independent of the CuptiRangeProfiler itself.
+ */
+class CuptiRangeProfiler : public libkineto::IActivityProfiler {
+ public:
+  explicit CuptiRangeProfiler();
+
+  explicit CuptiRangeProfiler(ICuptiRBProfilerSessionFactory& factory);
+
+  ~CuptiRangeProfiler() override {}
+
+  // name of profiler
+  const std::string& name() const override;
+
+  // returns activity types this profiler supports
+  const std::set<ActivityType>& availableActivities() const override;
+
+  // sets up the tracing session and provides control to the
+  // the activity profiler session object.
+  std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      const std::set<libkineto::ActivityType>& activity_types,
+      const Config& config) override;
+
+  // asynchronous version of the above with future timestamp and duration.
+  std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      int64_t ts_ms,
+      int64_t duration_ms,
+      const std::set<libkineto::ActivityType>& activity_types,
+      const Config& config) override;
+
+  // hooks to enable configuring the environment before and after the
+  // profiling sesssion.
+  static void setPreRunCallback(CuptiProfilerPrePostCallback fn);
+  static void setPostRunCallback(CuptiProfilerPrePostCallback fn);
+ private:
+  ICuptiRBProfilerSessionFactory& factory_;
+};
+
+struct CuptiRangeProfilerInit {
+  CuptiRangeProfilerInit();
+  ~CuptiRangeProfilerInit();
+};
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -3,11 +3,14 @@
 #include <memory>
 #include <mutex>
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "ActivityProfilerProxy.h"
 #include "Config.h"
 #ifdef HAS_CUPTI
 #include "CuptiCallbackApi.h"
 #include "CuptiActivityApi.h"
+#include "CuptiRangeProfiler.h"
 #include "EventProfilerController.h"
 #endif
 #include "cupti_call.h"
@@ -65,6 +68,8 @@ static void stopProfiler(
   std::lock_guard<std::mutex> lock(initMutex);
   EventProfilerController::stop(ctx);
 }
+
+static CuptiRangeProfilerInit rangeProfilerInit;
 #endif // HAS_CUPTI
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -535,7 +535,7 @@ TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
   int64_t duration_us = 1000;
   auto start_time = time_point<system_clock>(microseconds(start_time_us));
 
-  std::vector<GenericTraceActivity> test_activities{3, ev};
+  std::deque<GenericTraceActivity> test_activities{3, ev};
   test_activities[0].startTime = start_time_us;
   test_activities[0].endTime = start_time_us + 5000;
   test_activities[0].activityName = "SubGraph A execution";

--- a/libkineto/test/CuptiProfilerApiTest.cu
+++ b/libkineto/test/CuptiProfilerApiTest.cu
@@ -158,8 +158,14 @@ bool runTestWithAutoRange(
 
   // create a CUPTI range based profiling profiler
   //  this configures the counter data as well
-  CuptiRBProfilerSession profiler(
-      metricNames, deviceNum, 2, 1, async ? nullptr : cuContext);
+  CuptiRangeProfilerOptions opts{
+    .metricNames = metricNames,
+    .deviceId = deviceNum,
+    .maxRanges = 2,
+    .numNestingLevels = 1,
+    .cuContext = async ? nullptr : cuContext
+  };
+  CuptiRBProfilerSession profiler(opts);
 
   CUpti_ProfilerRange profilerRange = CUPTI_AutoRange;
   CUpti_ProfilerReplayMode profilerReplayMode = CUPTI_KernelReplay;
@@ -211,8 +217,14 @@ bool runTestWithUserRange(
 
   // create a CUPTI range based profiling profiler
   //  this configures the counter data as well
-  CuptiRBProfilerSession profiler(
-      metricNames, deviceNum, numRanges, 1, async ? nullptr : cuContext);
+  CuptiRangeProfilerOptions opts{
+    .metricNames = metricNames,
+    .deviceId = deviceNum,
+    .maxRanges = numRanges,
+    .numNestingLevels = 1,
+    .cuContext = async ? nullptr : cuContext
+  };
+  CuptiRBProfilerSession profiler(opts);
 
   CUpti_ProfilerRange profilerRange = CUPTI_UserRange;
   CUpti_ProfilerReplayMode profilerReplayMode = CUPTI_UserReplay;

--- a/libkineto/test/CuptiRangeProfilerTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerTest.cpp
@@ -1,0 +1,303 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include <array>
+#include <set>
+
+#ifdef __linux__
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#endif
+
+#include "include/libkineto.h"
+#include "include/Config.h"
+#include "src/ActivityTrace.h"
+#include "src/CuptiRangeProfilerConfig.h"
+#include "src/CuptiRangeProfiler.h"
+#include "src/output_base.h"
+#include "src/output_json.h"
+#include "src/output_membuf.h"
+#include "src/Logger.h"
+
+#include "test/CuptiRangeProfilerTestUtil.h"
+
+using namespace KINETO_NAMESPACE;
+
+#if HAS_CUPTI_RANGE_PROFILER
+
+std::unordered_map<int, CuptiProfilerResult>&
+MockCuptiRBProfilerSession::getResults() {
+  static std::unordered_map<int, CuptiProfilerResult> results;
+  return results;
+}
+
+static std::vector<std::string> kCtx0Kernels = {
+  "foo", "bar", "baz"};
+static std::vector<std::string> kCtx1Kernels = {
+  "mercury", "venus", "earth"};
+
+static auto getActivityTypes() {
+  static std::set activity_types_{libkineto::ActivityType::CUDA_PROFILER_RANGE};
+  return activity_types_;
+}
+
+static ICuptiRBProfilerSessionFactory& getFactory() {
+  static MockCuptiRBProfilerSessionFactory factory_;
+  return factory_;
+}
+
+// Create mock CUPTI profiler events and simuulate context
+// creation and kernel launches
+class CuptiRangeProfilerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::vector<std::string> log_modules(
+        {"CuptiRangeProfilerApi.cpp", "CuptiRangeProfiler.cpp"});
+    SET_LOG_VERBOSITY_LEVEL(1, log_modules);
+
+    // this is bad but the pointer is never accessed
+    ctx0_ = reinterpret_cast<CUcontext>(10);
+    ctx1_ = reinterpret_cast<CUcontext>(11);
+
+    simulateCudaContextCreate(ctx0_, 0 /*device_id*/);
+    simulateCudaContextCreate(ctx1_, 1 /*device_id*/);
+
+    results_[0] = CuptiProfilerResult{};
+    results_[1] = CuptiProfilerResult{};
+
+    // use MockCuptiRBProfilerSession to mock CUPTI Profiler interface
+    profiler_ = std::make_unique<CuptiRangeProfiler>(getFactory());
+
+    // used for logging to a file
+    loggerFactory.addProtocol("file", [](const std::string& url) {
+        return std::unique_ptr<ActivityLogger>(new ChromeTraceLogger(url));
+    });
+  }
+
+  void TearDown() override {
+    simulateCudaContextDestroy(ctx0_, 0 /*device_id*/);
+    simulateCudaContextDestroy(ctx1_, 1 /*device_id*/);
+  }
+
+  void setupConfig(const std::vector<std::string>& metrics, bool per_kernel) {
+    std::string config_str = fmt::format("ACTIVITIES_WARMUP_PERIOD_SECS=0\n "
+      "CUPTI_PROFILER_METRICS={}\n "
+      "CUPTI_PROFILER_ENABLE_PER_KERNEL={}",
+      fmt::join(metrics, ","),
+      (per_kernel ? "true" : "false"));
+
+    cfg_ = std::make_unique<Config>();
+    cfg_->parse(config_str);
+    cfg_->setClientDefaults();
+    cfg_->setSelectedActivityTypes(getActivityTypes());
+
+    // setup profiler results
+    results_[0].metricNames = metrics;
+    results_[1].metricNames = metrics;
+    for (int i = 0; i < metrics.size(); i++) {
+      measurements_.push_back(0.1 * i);
+    }
+  }
+
+  int simulateWorkload() {
+    for (const auto& k : kCtx0Kernels) {
+      simulateKernelLaunch(ctx0_, k);
+    }
+    for (const auto& k : kCtx1Kernels) {
+      simulateKernelLaunch(ctx1_, k);
+    }
+    return kCtx0Kernels.size() + kCtx1Kernels.size();
+  }
+
+  void setupResultsUserRange() {
+    // sets up mock results returned by Mock CUPTI interface
+    results_[0].rangeVals.emplace_back(
+        CuptiRangeMeasurement{"__profile__", measurements_});
+    results_[1].rangeVals.emplace_back(
+        CuptiRangeMeasurement{"__profile__", measurements_});
+  }
+
+  void setupResultsAutoRange() {
+    // sets up mock results returned by Mock CUPTI interface
+    for (const auto& k : kCtx0Kernels) {
+      results_[0].rangeVals.emplace_back(
+        CuptiRangeMeasurement{k, measurements_});
+    }
+    for (const auto& k : kCtx1Kernels) {
+      results_[1].rangeVals.emplace_back(
+        CuptiRangeMeasurement{k, measurements_});
+    }
+  }
+
+  std::unique_ptr<Config> cfg_;
+  std::unique_ptr<CuptiRangeProfiler> profiler_;
+  ActivityLoggerFactory loggerFactory;
+
+  std::vector<double> measurements_;
+  std::unordered_map<int, CuptiProfilerResult>& results_
+    = MockCuptiRBProfilerSession::getResults();
+
+  CUcontext ctx0_, ctx1_;
+};
+
+void checkMetrics(
+    const std::vector<std::string>& metrics,
+    const std::string& metadataJson) {
+  for (const auto& m : metrics) {
+    EXPECT_NE(metadataJson.find(m), std::string::npos)
+      << "Could not find metdata on metric " << m
+      << "\n metadata json = '" << metadataJson << "'";
+  }
+}
+
+void saveTrace(ActivityTrace& /*trace*/) {
+  // TODO seems to be hitting a memory bug run with ASAN
+#if 0
+//#ifdef __linux__
+  char filename[] = "/tmp/libkineto_testXXXXXX.json";
+  mkstemps(filename, 5);
+  trace.save(filename);
+  // Check that the expected file was written and that it has some content
+  int fd = open(filename, O_RDONLY);
+  if (!fd) {
+    perror(filename);
+  }
+  EXPECT_TRUE(fd);
+  // Should expect at least 100 bytes
+  struct stat buf{};
+  fstat(fd, &buf);
+  EXPECT_GT(buf.st_size, 100);
+#endif
+}
+
+TEST_F(CuptiRangeProfilerTest, BasicTest) {
+
+  EXPECT_NE(profiler_->name().size(), 0);
+  EXPECT_EQ(profiler_->availableActivities(), getActivityTypes());
+
+  std::set<ActivityType> incorrect_act_types{
+    ActivityType::CUDA_RUNTIME, ActivityType::CONCURRENT_KERNEL};
+
+  cfg_ = std::make_unique<Config>();
+  cfg_->setClientDefaults();
+  cfg_->setSelectedActivityTypes({});
+  EXPECT_EQ(
+      profiler_->configure(incorrect_act_types, *cfg_).get(), nullptr)
+    << "Profiler config should fail for wrong activity type";
+
+  incorrect_act_types.insert(ActivityType::CUDA_PROFILER_RANGE);
+
+  cfg_ = std::make_unique<Config>();
+  cfg_->setClientDefaults();
+  cfg_->setSelectedActivityTypes(incorrect_act_types);
+
+  EXPECT_EQ(
+      profiler_->configure(incorrect_act_types, *cfg_).get(), nullptr)
+    << "Profiler config should fail if the activity types is not exclusively"
+    << " CUDA_PROFILER_RANGE";
+}
+
+TEST_F(CuptiRangeProfilerTest, UserRangeTest) {
+
+  std::vector<std::string> metrics{
+    "smsp__sass_thread_inst_executed_op_dadd_pred_on.sum",
+    "sm__inst_executed_pipe_tensor.sum",
+  };
+
+  setupConfig(metrics, false /*per_kernel*/);
+
+  auto session = profiler_->configure(getActivityTypes(), *cfg_);
+  ASSERT_NE(session, nullptr) << "CUPTI Profiler configuration failed";
+
+  session->start();
+  simulateWorkload();
+  session->stop();
+
+  setupResultsUserRange();
+
+  // Have the profiler process them
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  session->processTrace(*logger);
+
+  // Just a wrapper to iterate events
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  EXPECT_EQ(trace.activities()->size(), 2);
+  auto activities = *trace.activities();
+
+  // check if we have all counter values encoded
+  for (auto& actvity : activities) {
+    checkMetrics(metrics, actvity->metadataJson());
+    EXPECT_EQ(actvity->type(), ActivityType::CUDA_PROFILER_RANGE);
+  }
+  EXPECT_EQ(activities[0]->deviceId(), 0);
+  EXPECT_EQ(activities[1]->deviceId(), 1);
+
+  saveTrace(trace);
+}
+
+TEST_F(CuptiRangeProfilerTest, AutoRangeTest) {
+
+  std::vector<std::string> metrics{
+    "smsp__sass_thread_inst_executed_op_dadd_pred_on.sum",
+    "sm__inst_executed_pipe_tensor.sum",
+  };
+  int kernel_count = 0;
+
+  setupConfig(metrics, true /*per_kernel*/);
+
+  auto session = profiler_->configure(getActivityTypes(), *cfg_);
+  ASSERT_NE(session, nullptr) << "CUPTI Profiler configuration failed";
+
+  session->start();
+  kernel_count = simulateWorkload();
+  session->stop();
+
+  setupResultsAutoRange();
+
+  // Have the profiler process them
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  session->processTrace(*logger);
+
+  // Just a wrapper to iterate events
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  EXPECT_EQ(trace.activities()->size(), kernel_count);
+  auto activities = *trace.activities();
+
+  // check if we have all counter values encoded
+  for (auto& actvity : activities) {
+    checkMetrics(metrics, actvity->metadataJson());
+    EXPECT_EQ(actvity->type(), ActivityType::CUDA_PROFILER_RANGE);
+  }
+
+  // check if kernel names are captured
+  for (int i = 0; i < kCtx0Kernels.size(); i++) {
+    EXPECT_EQ(activities[i]->deviceId(), 0);
+    EXPECT_EQ(activities[i]->name(), kCtx0Kernels[i]);
+  }
+
+  const size_t offset = kCtx0Kernels.size();
+  for (int i = 0; i < kCtx1Kernels.size(); i++) {
+    EXPECT_EQ(activities[i + offset]->deviceId(), 1);
+    EXPECT_EQ(activities[i + offset]->name(), kCtx1Kernels[i]);
+  }
+
+  // check transfer of ownership
+  auto traceBuffer = session->getTraceBuffer();
+  ASSERT_NE(traceBuffer, nullptr);
+  EXPECT_EQ(traceBuffer->activities.size(), kernel_count);
+
+  EXPECT_NE(traceBuffer->span.startTime, 0);
+  EXPECT_NE(traceBuffer->span.endTime, 0);
+  EXPECT_GT(traceBuffer->span.endTime, traceBuffer->span.startTime);
+
+  saveTrace(trace);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  CuptiRangeProfilerConfig::registerFactory();
+  return RUN_ALL_TESTS();
+}
+
+#endif // HAS_CUPTI_RANGE_PROFILER

--- a/libkineto/test/MockActivitySubProfiler.cpp
+++ b/libkineto/test/MockActivitySubProfiler.cpp
@@ -4,6 +4,7 @@
 #include <set>
 #include <vector>
 
+#include "output_base.h"
 #include "test/MockActivitySubProfiler.h"
 
 namespace libkineto {
@@ -12,7 +13,7 @@ const std::set<ActivityType> supported_activities {ActivityType::CPU_OP};
 const std::string profile_name{"MockProfiler"};
 
 void MockProfilerSession::processTrace(ActivityLogger& logger) {
-  for (const auto& activity: activities()) {
+  for (const auto& activity: test_activities_) {
     activity.log(logger);
   }
 }
@@ -26,7 +27,7 @@ const std::set<ActivityType>& MockActivityProfiler::availableActivities() const 
 }
 
 MockActivityProfiler::MockActivityProfiler(
-    std::vector<GenericTraceActivity>& activities) :
+    std::deque<GenericTraceActivity>& activities) :
   test_activities_(activities) {};
 
 std::unique_ptr<IActivityProfilerSession> MockActivityProfiler::configure(
@@ -45,5 +46,10 @@ std::unique_ptr<IActivityProfilerSession> MockActivityProfiler::configure(
   return configure(activity_types, config);
 };
 
+std::unique_ptr<CpuTraceBuffer> MockProfilerSession::getTraceBuffer() {
+  auto buf = std::make_unique<CpuTraceBuffer>();
+  buf->activities.swap(test_activities_);
+  return buf;
+}
 } // namespace libkineto
 

--- a/libkineto/test/MockActivitySubProfiler.h
+++ b/libkineto/test/MockActivitySubProfiler.h
@@ -4,9 +4,10 @@
 
 #include <memory>
 #include <set>
-#include <vector>
+#include <deque>
 
 #include "include/IActivityProfiler.h"
+#include "output_base.h"
 
 namespace libkineto {
 
@@ -25,31 +26,29 @@ class MockProfilerSession: public IActivityProfilerSession {
       status_ = TraceStatus::PROCESSING;
     }
 
-    std::vector<GenericTraceActivity>& activities() override {
-      return test_activities_;
-    }
-
     std::vector<std::string> errors() override {
       return {};
     }
 
     void processTrace(ActivityLogger& logger) override;
 
-    void set_test_activities(std::vector<GenericTraceActivity>&& acs) {
+    void set_test_activities(std::deque<GenericTraceActivity>&& acs) {
       test_activities_ = std::move(acs);
     }
+
+    std::unique_ptr<CpuTraceBuffer> getTraceBuffer() override;
 
     int start_count = 0;
     int stop_count = 0;
   private:
-    std::vector<GenericTraceActivity> test_activities_;
+    std::deque<GenericTraceActivity> test_activities_;
 };
 
 
 class MockActivityProfiler: public IActivityProfiler {
 
  public:
-  explicit MockActivityProfiler(std::vector<GenericTraceActivity>& activities);
+  explicit MockActivityProfiler(std::deque<GenericTraceActivity>& activities);
 
   const std::string& name() const override;
 
@@ -66,7 +65,7 @@ class MockActivityProfiler: public IActivityProfiler {
       const Config& config) override;
 
  private:
-  std::vector<GenericTraceActivity> test_activities_;
+  std::deque<GenericTraceActivity> test_activities_;
 };
 
 } // namespace libkineto


### PR DESCRIPTION
Summary:
# Summary

The CUPTI Range Profiler allows Kineto to leverage CUPTI Range Profiler API. This feature can be used
 to read performance counters, dynamic instruction counts etc.
To use it set the activity type to : = `{ ActivityType::CUDA_PROFILER_RANGE }` and use profiler config options below:
```
CUPTI_PROFILER_METRICS :  a comma separated list of metrics to measure
 Please see : https://docs.nvidia.com/cupti/Cupti/r_main.html#r_profiler
 (two special metrics kineto__cuda_core_flops and kineto__tensor_core_insts are also available to enable FLOPs measurement)

CUPTI_PROFILER_ENABLE_PER_KERNEL= true or false
  If true each metric is measured for individual kernels in the measurement region

CUPTI_PROFILER_MAX_RANGES = N
 Optional : specify maximum number of ranges. This is the upper bound on number of kernels or user ranges the profiler can measure
Once we hit the maximum data is not collected for newer kernels.
```

## Motivation
Among others this can be used to measure FLOPs count, Dram read/writes in pytorch. It serves as an alternative to NSight Compute when
you want to automate collection of a metrics or you know the range you are interested in.

## Details
Adds a Profiler module based on CUPTI Range profiler

This module will
a. Correctly configure CUPTI Range Profiler across multiple active cuda contexts
b. Evaluate the counter metrics using CUPTI Range Profiler
c. The counter values are then added into the trace as metadata

Reviewed By: aaronenyeshi

Differential Revision: D34191615

