### PR TITLE
Change output_membuffer to copy and own GenericTraceActivity objects

### DIFF
--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -68,8 +68,10 @@ class ActivityLogger {
 
   virtual void handleTraceSpan(const TraceSpan& span) = 0;
 
-  virtual void handleGenericActivity(
+  virtual void handleActivity(
       const libkineto::ITraceActivity& activity) = 0;
+  virtual void handleGenericActivity(
+      const libkineto::GenericTraceActivity& activity) = 0;
 
 #ifdef HAS_CUPTI
   virtual void handleGpuActivity(

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -280,7 +280,7 @@ void ChromeTraceLogger::handleGenericInstantEvent(
       op.timestamp(), op.metadataJson());
 }
 
-void ChromeTraceLogger::handleGenericActivity(
+void ChromeTraceLogger::handleActivity(
     const libkineto::ITraceActivity& op) {
   if (!traceOf_) {
     return;
@@ -321,6 +321,11 @@ void ChromeTraceLogger::handleGenericActivity(
     handleGenericLink(op);
   }
 }
+
+void ChromeTraceLogger::handleGenericActivity(
+    const libkineto::GenericTraceActivity& op) {
+        handleActivity(op);
+    }
 
 void ChromeTraceLogger::handleGenericLink(const ITraceActivity& act) {
   static struct {

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -39,7 +39,8 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
 
   void handleTraceSpan(const TraceSpan& span) override;
 
-  void handleGenericActivity(const ITraceActivity& activity) override;
+  void handleActivity(const ITraceActivity& activity) override;
+  void handleGenericActivity(const GenericTraceActivity& activity) override;
 
 #ifdef HAS_CUPTI
   void handleGpuActivity(const GpuActivity<CUpti_ActivityKernel4>& activity) override;

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -47,19 +47,22 @@ class MemoryTraceLogger : public ActivityLogger {
     // Handled separately
   }
 
-  // Just add the pointer to the list - ownership of the underlying
-  // objects must be transferred in ActivityBuffers via finalizeTrace
-  void handleGenericActivity(const ITraceActivity& activity) override {
-    activities_.push_back(&activity);
-  }
-
-#ifdef HAS_CUPTI
   template<class T>
   void addActivityWrapper(const T& act) {
     wrappers_.push_back(std::make_unique<T>(act));
     activities_.push_back(wrappers_.back().get());
   }
 
+  // Just add the pointer to the list - ownership of the underlying
+  // objects must be transferred in ActivityBuffers via finalizeTrace
+  void handleActivity(const ITraceActivity& activity) override {
+    activities_.push_back(&activity);
+  }
+  void handleGenericActivity(const GenericTraceActivity& activity) override {
+    addActivityWrapper(activity);
+  }
+
+#ifdef HAS_CUPTI
   void handleGpuActivity(const GpuActivity<CUpti_ActivityKernel4>& activity) override {
     addActivityWrapper(activity);
   }


### PR DESCRIPTION
This is a fix for a break at https://github.com/pytorch/kineto/pull/464
This change was adding pointers to temporaries (stack addresses) to the list of output events.  Specifically it was taking a const &, assuming it was referring to a heap object, deciding it owned it now, and ignoring any life-cycle concerns.

This change mirrors the handling used for GpuActivity.
1) change ActivityLogger::handleGenericActivity() to actually take a GenericTraceActivity instead of the abstract base.
2) concrete GenericTraceActivity can now be used with make_unique<>.
3) use MemoryTraceLogger::addActivityWrapper (as GpuActivity does), which copies the object and maintains lifecycle via wrappers_
4) CLEANUP: added a ActivityLogger::handleActivity(cont ITraceActivity) in case someone actually wants to log an abstract base event (at their peril)
