### PR TITLE
Reset config state on remote Configs

### DIFF
--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -277,6 +277,7 @@ void ConfigLoader::updateConfigThread() {
       onDemandConfig = config_->clone();
       configureFromSignal(now, *onDemandConfig);
     } else if (now > next_on_demand_load_time) {
+      onDemandConfig = std::make_unique<Config>();
       configureFromDaemon(now, *onDemandConfig);
       next_on_demand_load_time = now + onDemandConfigUpdateIntervalSecs_;
     }


### PR DESCRIPTION
Summary:
On demand configs will have options that need to be set from scratch. the Config has logic to set default options etc.
We need to reset the entire state so on-demand configs get parsed correctly.

This was causing a bug where if PROFILE_START_TIME is not present, instead of setting default, the 2nd Config onwards would get stale start times.

Differential Revision: D34661638

