### PR TITLE
Update HAS_CUPTI_RANGE_PROFILER to CUDA 11+ for CUPTI Range Profiler APIs and remove init-statement in seletion statement

### DIFF
--- a/libkineto/src/CuptiRangeProfilerApi.cpp
+++ b/libkineto/src/CuptiRangeProfilerApi.cpp
@@ -22,15 +22,15 @@
 #include "CuptiCallbackApiMock.h"
 #include "CuptiRangeProfilerApi.h"
 
-#if HAS_CUPTI_PROFILER
+#if HAS_CUPTI_RANGE_PROFILER
 #include <cupti.h>
 #include <nvperf_host.h>
 #include "cupti_call.h"
-#endif // HAS_CUPTI_PROFILER
+#endif // HAS_CUPTI_RANGE_PROFILER
 
 namespace KINETO_NAMESPACE {
 
-#if HAS_CUPTI_PROFILER
+#if HAS_CUPTI_RANGE_PROFILER
 constexpr char kRootUserRangeName[] = "__profile__";
 constexpr int kCallbacksCountToFlush = 500;
 
@@ -171,7 +171,8 @@ void __trackCudaKernelLaunch(
           << " context ptr = " << ctx;
 
   uint32_t device_id = 0;
-  if (auto it = ctx_to_dev.find(ctx); it == ctx_to_dev.end()) {
+  auto it = ctx_to_dev.find(ctx);
+  if (it == ctx_to_dev.end()) {
     // Warning here could be too noisy
     VLOG(0) << " Could not find corresponding device to ctx = " << ctx;
     return;
@@ -730,20 +731,20 @@ std::vector<uint8_t>& CuptiRBProfilerSession::counterAvailabilityImage() {
   static std::vector<uint8_t> _vec;
   return _vec;
 }
-#endif // HAS_CUPTI_PROFILER
+#endif // HAS_CUPTI_RANGE_PROFILER
 
 namespace testing {
 
 void trackCudaCtx(CUcontext ctx, uint32_t device_id, CUpti_CallbackId cbid) {
-#if HAS_CUPTI_PROFILER
+#if HAS_CUPTI_RANGE_PROFILER
   __trackCudaCtx(ctx, device_id, cbid);
-#endif // HAS_CUPTI_PROFILER
+#endif // HAS_CUPTI_RANGE_PROFILER
 }
 
 void trackCudaKernelLaunch(CUcontext ctx, const char* kernelName) {
-#if HAS_CUPTI_PROFILER
+#if HAS_CUPTI_RANGE_PROFILER
   __trackCudaKernelLaunch(ctx, kernelName);
-#endif // HAS_CUPTI_PROFILER
+#endif // HAS_CUPTI_RANGE_PROFILER
 }
 
 } // namespace testing

--- a/libkineto/src/CuptiRangeProfilerApi.h
+++ b/libkineto/src/CuptiRangeProfilerApi.h
@@ -5,12 +5,13 @@
 #ifdef HAS_CUPTI
 #include <cuda.h>
 #include <cuda_runtime_api.h>
-#if defined(CUDART_VERSION) && CUDART_VERSION >= 10000 && CUDART_VERSION < 11040 && CUDA_VERSION >= 10010
-#define HAS_CUPTI_PROFILER 1
-#endif // CUDART_VERSION > 10.00 and < 11.04 && CUDA_VERSION >= 10.10
+// Using CUDA 11 and above due to usage of API: cuptiProfilerGetCounterAvailability.
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 10000 && CUDART_VERSION < 11040 && CUDA_VERSION >= 11000
+#define HAS_CUPTI_RANGE_PROFILER 1
+#endif // CUDART_VERSION > 10.00 and < 11.04 && CUDA_VERSION >= 11.00
 #endif // HAS_CUPTI
 
-#if HAS_CUPTI_PROFILER
+#if HAS_CUPTI_RANGE_PROFILER
 #include <cupti.h>
 #include <cupti_profiler_target.h>
 #include <cupti_target.h>
@@ -26,7 +27,7 @@ using CUpti_ProfilerReplayMode = enum
   CUPTI_KernelReplay,
   CUPTI_UserReplay,
 };
-#endif // HAS_CUPTI_PROFILER
+#endif // HAS_CUPTI_RANGE_PROFILER
 
 #include <chrono>
 #include <mutex>
@@ -197,7 +198,7 @@ class CuptiRBProfilerSession {
 
   static std::vector<uint8_t>& counterAvailabilityImage();
 
-#if HAS_CUPTI_PROFILER
+#if HAS_CUPTI_RANGE_PROFILER
   CUpti_Profiler_BeginPass_Params beginPassParams_;
   CUpti_Profiler_EndPass_Params endPassParams_;
 #endif

--- a/libkineto/test/CuptiProfilerApiTest.cu
+++ b/libkineto/test/CuptiProfilerApiTest.cu
@@ -149,7 +149,7 @@ void VectorAddSubtract() {
   cleanUp(h_A, h_B, h_C, h_D, d_A, d_B, d_C, d_D);
 }
 
-#if HAS_CUPTI_PROFILER
+#if HAS_CUPTI_RANGE_PROFILER
 bool runTestWithAutoRange(
     int deviceNum,
     const std::vector<std::string>& metricNames,
@@ -272,7 +272,7 @@ bool runTestWithUserRange(
   }
   return true;
 }
-#endif // HAS_CUPTI_PROFILER
+#endif // HAS_CUPTI_RANGE_PROFILER
 
 int main(int argc, char* argv[]) {
 
@@ -314,7 +314,7 @@ int main(int argc, char* argv[]) {
     LOG(ERROR) << "CUPTI Profiler is not supported  with compute capability < 7.0";
     return -2;
   }
-  
+
   CuptiRBProfilerSession::staticInit();
 
   // metrics to profile
@@ -329,7 +329,7 @@ int main(int argc, char* argv[]) {
 
   VectorAddSubtract();
 
-#if HAS_CUPTI_PROFILER
+#if HAS_CUPTI_RANGE_PROFILER
   CuptiRBProfilerSession::staticInit();
 
   if (!runTestWithUserRange(deviceNum, metricNames, cuContext, false)) {
@@ -345,7 +345,7 @@ int main(int argc, char* argv[]) {
   CuptiRBProfilerSession::deInitCupti();
 #else
   LOG(WARNING) << "CuptiRBProfilerSession is not supported.";
-#endif // HAS_CUPTI_PROFILER
+#endif // HAS_CUPTI_RANGE_PROFILER
   DRIVER_API_CALL(cuCtxDestroy(cuContext));
 
 


### PR DESCRIPTION
Summary:
The CuptiRangeProfilerAPI is using APIs from CUPTI in CUDA 11 such as CUpti_Profiler_GetCounterAvailability_Params and cuptiProfilerGetCounterAvailability. These are not available in CUDA 10.2 which caused PyTorch CI to crash.

Also, move the init statement outside of the if statement, which is a C++17 feature, but PyTorch uses C++14.

Differential Revision: D34690168

Pulled By: aaronenyeshi

