### PR TITLE
remove noisy warning on CUPTI range profiler init

### DIFF
--- a/libkineto/src/CuptiRangeProfiler.cpp
+++ b/libkineto/src/CuptiRangeProfiler.cpp
@@ -273,7 +273,7 @@ CuptiRangeProfiler::configure(
 
 /* ----------------------------------------
  * CuptiRangeProfilerInit :
- *    a small wrapper class that ensure the activity profiler is created and
+ *    a small wrapper class that ensure the range profiler is created and
  *  initialized.
  * ----------------------------------------
  */
@@ -283,8 +283,12 @@ CuptiRangeProfilerInit::CuptiRangeProfilerInit() {
 
 #ifdef HAS_CUPTI
   // TODO should this be revised to avoid overhead
-  CuptiRBProfilerSession::staticInit();
+  success = CuptiRBProfilerSession::staticInit();
 #endif
+
+  if (!success) {
+    return;
+  }
 
   // Register the activity profiler instance with libkineto api
   api().registerProfilerFactory([&]() {
@@ -293,7 +297,9 @@ CuptiRangeProfilerInit::CuptiRangeProfilerInit() {
 }
 
 CuptiRangeProfilerInit::~CuptiRangeProfilerInit() {
+  if (success) {
     CuptiRBProfilerSession::deInitCupti();
+  }
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiRangeProfiler.h
+++ b/libkineto/src/CuptiRangeProfiler.h
@@ -103,6 +103,8 @@ class CuptiRangeProfiler : public libkineto::IActivityProfiler {
 struct CuptiRangeProfilerInit {
   CuptiRangeProfilerInit();
   ~CuptiRangeProfilerInit();
+
+  bool success = false;
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiRangeProfilerApi.h
+++ b/libkineto/src/CuptiRangeProfilerApi.h
@@ -145,11 +145,11 @@ class CuptiRBProfilerSession {
 
   static std::set<uint32_t> getActiveDevices();
 
-  static void initCupti();
+  static bool initCupti();
 
   static void deInitCupti();
 
-  static void staticInit();
+  static bool staticInit();
 
   static void setCounterAvailabilityImage(std::vector<uint8_t> img) {
     counterAvailabilityImage() = img;


### PR DESCRIPTION
Summary: Removes noisy errors during initialization in case CUPTI library is not present in the runtime environment.

Differential Revision: D35030051

