### PR TITLE
fix : add default activity types list for configs

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -7,7 +7,10 @@
 
 namespace libkineto {
 
+// Note : All activity types are not enabled by default. Please add them
+// at correct position in the enum
 enum class ActivityType {
+    // Activity types enabled by default
     CPU_OP = 0, // cpu side ops
     USER_ANNOTATION,
     GPU_USER_ANNOTATION,
@@ -16,12 +19,16 @@ enum class ActivityType {
     CONCURRENT_KERNEL, // on-device kernels
     EXTERNAL_CORRELATION,
     CUDA_RUNTIME, // host side cuda runtime events
-    CUDA_PROFILER_RANGE, // CUPTI Profiler range for performance metrics
-    GLOW_RUNTIME, // host side glow runtime events
     CPU_INSTANT_EVENT, // host side point-like events
     PYTHON_FUNCTION,
+
+    // Optional Activity types
+    GLOW_RUNTIME, // host side glow runtime events
+    CUDA_PROFILER_RANGE, // CUPTI Profiler range for performance metrics
     OVERHEAD, // CUPTI induced overhead events sampled from its overhead API.
-    ENUM_COUNT // This is to add buffer and not used for any profiling logic. Add your new type before it.
+
+    ENUM_COUNT, // This is to add buffer and not used for any profiling logic. Add your new type before it.
+    OPTIONAL_ACTIVITY_TYPE_START = GLOW_RUNTIME,
 };
 
 const char* toString(ActivityType t);
@@ -29,6 +36,8 @@ ActivityType toActivityType(const std::string& str);
 
 // Return an array of all activity types except COUNT
 constexpr int activityTypeCount = (int)ActivityType::ENUM_COUNT;
+constexpr int defaultActivityTypeCount = (int)ActivityType::OPTIONAL_ACTIVITY_TYPE_START;
 const std::array<ActivityType, activityTypeCount> activityTypes();
+const std::array<ActivityType, defaultActivityTypeCount> defaultActivityTypes();
 
 } // namespace libkineto

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -335,12 +335,8 @@ class Config : public AbstractConfig {
   // Sets the default activity types to be traced
   void selectDefaultActivityTypes() {
     // If the user has not specified an activity list, add all types
-    for (ActivityType t : activityTypes()) {
-      // Do no enable this by default
-      // TODO: introduce optional types
-      if (t != ActivityType::OVERHEAD) {
-        selectedActivityTypes_.insert(t);
-      }
+    for (ActivityType t : defaultActivityTypes()) {
+      selectedActivityTypes_.insert(t);
     }
   }
 

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -20,10 +20,10 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
     {"kernel", ActivityType::CONCURRENT_KERNEL},
     {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
     {"cuda_runtime", ActivityType::CUDA_RUNTIME},
-    {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
-    {"glow_runtime", ActivityType::GLOW_RUNTIME},
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
     {"python_function", ActivityType::PYTHON_FUNCTION},
+    {"glow_runtime", ActivityType::GLOW_RUNTIME},
+    {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
     {"overhead", ActivityType::OVERHEAD},
     {"ENUM_COUNT", ActivityType::ENUM_COUNT}
 }};
@@ -54,5 +54,14 @@ const std::array<ActivityType, activityTypeCount> activityTypes() {
   }
   return res;
 }
+
+const std::array<ActivityType, defaultActivityTypeCount> defaultActivityTypes() {
+  std::array<ActivityType, defaultActivityTypeCount> res;
+  for (int i = 0; i < defaultActivityTypeCount; i++) {
+    res[i] = map[i].type;
+  }
+  return res;
+}
+
 
 } // namespace libkineto

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -417,11 +417,9 @@ void CuptiActivityProfiler::handleCuptiActivity(const CUpti_Activity* record, Ac
 
 void CuptiActivityProfiler::configureChildProfilers() {
   // If child profilers are enabled create profiler sessions
+  int64_t start_time_ms = duration_cast<milliseconds>(
+      profileStartTime_.time_since_epoch()).count();
   for (auto& profiler: profilers_) {
-    int64_t start_time_ms = duration_cast<milliseconds>(
-        profileStartTime_.time_since_epoch()).count();
-    LOG(INFO) << "Running child profiler " << profiler->name() << " for "
-            << config_->activitiesDuration().count() << " ms";
     auto session = profiler->configure(
         start_time_ms,
         config_->activitiesDuration().count(),
@@ -429,6 +427,8 @@ void CuptiActivityProfiler::configureChildProfilers() {
         *config_
     );
     if (session) {
+      LOG(INFO) << "Running child profiler " << profiler->name() << " for "
+                << config_->activitiesDuration().count() << " ms";
       sessions_.push_back(std::move(session));
     }
   }

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -67,10 +67,9 @@ TEST(ParseTest, Format) {
 TEST(ParseTest, DefaultActivityTypes) {
   Config cfg;
   cfg.validate(std::chrono::system_clock::now());
-  auto all_activities = activityTypes();
-  // TODO: introduce optional activities
+  auto default_activities = defaultActivityTypes();
   EXPECT_EQ(cfg.selectedActivityTypes(),
-    std::set<ActivityType>(all_activities.begin(), all_activities.end() - 1));
+    std::set<ActivityType>(default_activities.begin(), default_activities.end()));
 }
 
 TEST(ParseTest, ActivityTypes) {
@@ -89,9 +88,7 @@ TEST(ParseTest, ActivityTypes) {
                             ActivityType::GPU_MEMSET,
                             ActivityType::CONCURRENT_KERNEL,
                             ActivityType::EXTERNAL_CORRELATION,
-                            ActivityType::GLOW_RUNTIME,
-                            ActivityType::CUDA_RUNTIME,
-                            ActivityType::CUDA_PROFILER_RANGE}));
+                            ActivityType::CUDA_RUNTIME}));
 
   Config cfg2;
   EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES=gpu_memcpy,gpu_MeMsEt,kernel"));


### PR DESCRIPTION
Summary:
Currently the default activity list includes all activity types. This can be an issue if we want optional or experimental activity types.
This changes updates the Activity type enum to have a default and an optional section.
* Adds a `defaultActivityTypes()` function as well.
* Fix child profiler message so we know if it actually was initialized.

Reviewed By: aaronenyeshi

Differential Revision: D35218132

