### PR TITLE
Fix potential Roctracer thread safety issue

### DIFF
--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -272,7 +272,7 @@ void RoctracerActivityApi::api_callback(uint32_t domain, uint32_t cid, const voi
 
     // Pack callbacks into row structures
 
-    static timespec timestamp;	// FIXME verify thread safety
+    thread_local timespec timestamp;
 
     if (data->phase == ACTIVITY_API_PHASE_ENTER) {
       clock_gettime(CLOCK_MONOTONIC, &timestamp);  // record proper clock
@@ -281,6 +281,7 @@ void RoctracerActivityApi::api_callback(uint32_t domain, uint32_t cid, const voi
       timespec endTime;
       timespec startTime { timestamp };
       clock_gettime(CLOCK_MONOTONIC, &endTime);  // record proper clock
+      std::unique_lock<std::mutex> lock(dis->mutex_);
 
       switch (cid) {
         case HIP_API_ID_hipLaunchKernel:

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -160,6 +160,7 @@ class RoctracerActivityApi {
   std::deque<copyRow> copyRows_;
   std::deque<mallocRow> mallocRows_;
   std::map<activity_correlation_id_t, GenericTraceActivity> kernelLaunches_;
+  std::mutex mutex_;
 #endif
 
   int maxGpuBufferCount_{0};


### PR DESCRIPTION
I found some evidence the api callback function is not being serialized by libroctracer as was initially expected.
Protected the data structures.