### PR TITLE
fix : only initialize range profiler when libkineto_init() is called

### DIFF
--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -69,7 +69,7 @@ static void stopProfiler(
   EventProfilerController::stop(ctx);
 }
 
-static CuptiRangeProfilerInit rangeProfilerInit;
+static std::unique_ptr<CuptiRangeProfilerInit> rangeProfilerInit;
 #endif // HAS_CUPTI
 
 } // namespace KINETO_NAMESPACE
@@ -114,6 +114,11 @@ bool libkineto_init(bool cpuOnly, bool logOnError) {
         LOG(INFO) << "If you see CUPTI_ERROR_INSUFFICIENT_PRIVILEGES, refer to "
                   << "https://developer.nvidia.com/nvidia-development-tools-solutions-err-nvgpuctrperm-cupti";
       }
+    }
+
+    // initialize CUPTI Range Profiler API
+    if (success) {
+      rangeProfilerInit = std::make_unique<CuptiRangeProfilerInit>();
     }
   }
 


### PR DESCRIPTION
Summary:
We should not be statically initializing CUPTI Profiler interface. The current code also sets up some CUPTI callbacks.
External tools like Nsight system may want to utilize CUPTI and this prevents it. The range profiler module should get out of the way in this case.

Solution is to initialize CUPTI Range Profiler inside libkineto_init() functions. The init() can be guarded to avoid colliding with Nsight systems/compute.

Reviewed By: aaronenyeshi

Differential Revision: D35238581

