### PR TITLE
Refactor 5/n: Simplify activity logger step 3/3

### DIFF
--- a/libkineto/src/CudaDeviceProperties.h
+++ b/libkineto/src/CudaDeviceProperties.h
@@ -10,11 +10,16 @@
 #include <stdint.h>
 #include <string>
 
+#include <cupti.h>
+
 namespace KINETO_NAMESPACE {
 
 int smCount(uint32_t deviceId);
+float blocksPerSm(const CUpti_ActivityKernel4& kernel);
+float warpsPerSm(const CUpti_ActivityKernel4& kernel);
 
 // Return estimated achieved occupancy for a kernel
+float kernelOccupancy(const CUpti_ActivityKernel4& kernel);
 float kernelOccupancy(
     uint32_t deviceId,
     uint16_t registersPerThread,

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -9,6 +9,7 @@
 #include "ITraceActivity.h"
 #include "GenericTraceActivity.h"
 #include "CuptiActivityPlatform.h"
+#include "GenericTraceActivity.h"
 #include "ThreadUtil.h"
 #include "cupti_strings.h"
 

--- a/libkineto/src/CuptiActivity.tpp
+++ b/libkineto/src/CuptiActivity.tpp
@@ -9,6 +9,7 @@
 
 #include <fmt/format.h>
 
+#include "CudaDeviceProperties.h"
 #include "Demangle.h"
 #include "output_base.h"
 
@@ -26,7 +27,45 @@ inline ActivityType GpuActivity<CUpti_ActivityKernel4>::type() const {
   return ActivityType::CONCURRENT_KERNEL;
 }
 
-static inline std::string memcpyName(uint8_t kind, uint8_t src, uint8_t dst) {
+template<class T>
+inline void GpuActivity<T>::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+}
+
+constexpr int64_t us(int64_t timestamp) {
+  // It's important that this conversion is the same here and in the CPU trace.
+  // No rounding!
+  return timestamp / 1000;
+}
+
+template<>
+inline const std::string GpuActivity<CUpti_ActivityKernel4>::metadataJson() const {
+  const CUpti_ActivityKernel4& kernel = raw();
+  // clang-format off
+  return fmt::format(R"JSON(
+      "queued": {}, "device": {}, "context": {},
+      "stream": {}, "correlation": {},
+      "registers per thread": {},
+      "shared memory": {},
+      "blocks per SM": {},
+      "warps per SM": {},
+      "grid": [{}, {}, {}],
+      "block": [{}, {}, {}],
+      "est. achieved occupancy %": {})JSON",
+      us(kernel.queued), kernel.deviceId, kernel.contextId,
+      kernel.streamId, kernel.correlationId,
+      kernel.registersPerThread,
+      kernel.staticSharedMemory + kernel.dynamicSharedMemory,
+      blocksPerSm(kernel),
+      warpsPerSm(kernel),
+      kernel.gridX, kernel.gridY, kernel.gridZ,
+      kernel.blockX, kernel.blockY, kernel.blockZ,
+      (int) (0.5 + kernelOccupancy(kernel) * 100.0));
+  // clang-format on
+}
+
+
+inline std::string memcpyName(uint8_t kind, uint8_t src, uint8_t dst) {
   return fmt::format(
       "Memcpy {} ({} -> {})",
       memcpyKindString((CUpti_ActivityMemcpyKind)kind),
@@ -44,6 +83,25 @@ inline const std::string GpuActivity<CUpti_ActivityMemcpy>::name() const {
   return memcpyName(raw().copyKind, raw().srcKind, raw().dstKind);
 }
 
+inline std::string bandwidth(uint64_t bytes, uint64_t duration) {
+  return duration == 0 ? "\"N/A\"" : fmt::format("{}", bytes * 1.0 / duration);
+}
+
+template<>
+inline const std::string GpuActivity<CUpti_ActivityMemcpy>::metadataJson() const {
+  const CUpti_ActivityMemcpy& memcpy = raw();
+  // clang-format off
+  return fmt::format(R"JSON(
+      "device": {}, "context": {},
+      "stream": {}, "correlation": {},
+      "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
+      memcpy.deviceId, memcpy.contextId,
+      memcpy.streamId, memcpy.correlationId,
+      memcpy.bytes, bandwidth(memcpy.bytes, memcpy.end - memcpy.start));
+  // clang-format on
+}
+
+
 template<>
 inline ActivityType GpuActivity<CUpti_ActivityMemcpy2>::type() const {
   return ActivityType::GPU_MEMCPY;
@@ -52,6 +110,22 @@ inline ActivityType GpuActivity<CUpti_ActivityMemcpy2>::type() const {
 template<>
 inline const std::string GpuActivity<CUpti_ActivityMemcpy2>::name() const {
   return memcpyName(raw().copyKind, raw().srcKind, raw().dstKind);
+}
+
+template<>
+inline const std::string GpuActivity<CUpti_ActivityMemcpy2>::metadataJson() const {
+  const CUpti_ActivityMemcpy2& memcpy = raw();
+  // clang-format off
+  return fmt::format(R"JSON(
+      "fromDevice": {}, "inDevice": {}, "toDevice": {},
+      "fromContext": {}, "inContext": {}, "toContext": {},
+      "stream": {}, "correlation": {},
+      "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
+      memcpy.srcDeviceId, memcpy.deviceId, memcpy.dstDeviceId,
+      memcpy.srcContextId, memcpy.contextId, memcpy.dstContextId,
+      memcpy.streamId, memcpy.correlationId,
+      memcpy.bytes, bandwidth(memcpy.bytes, memcpy.end - memcpy.start));
+  // clang-format on
 }
 
 template<>
@@ -64,6 +138,20 @@ inline const std::string GpuActivity<CUpti_ActivityMemset>::name() const {
 template<>
 inline ActivityType GpuActivity<CUpti_ActivityMemset>::type() const {
   return ActivityType::GPU_MEMSET;
+}
+
+template<>
+inline const std::string GpuActivity<CUpti_ActivityMemset>::metadataJson() const {
+  const CUpti_ActivityMemset& memset = raw();
+  // clang-format off
+  return fmt::format(R"JSON(
+      "device": {}, "context": {},
+      "stream": {}, "correlation": {},
+      "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
+      memset.deviceId, memset.contextId,
+      memset.streamId, memset.correlationId,
+      memset.bytes, bandwidth(memset.bytes, memset.end - memset.start));
+  // clang-format on
 }
 
 inline void RuntimeActivity::log(ActivityLogger& logger) const {
@@ -82,11 +170,6 @@ inline const std::string OverheadActivity::metadataJson() const {
   return "";
 }
 
-template<class T>
-inline void GpuActivity<T>::log(ActivityLogger& logger) const {
-  logger.handleGpuActivity(*this);
-}
-
 inline bool RuntimeActivity::flowStart() const {
   return activity_.cbid == CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000 ||
       (activity_.cbid >= CUPTI_RUNTIME_TRACE_CBID_cudaMemcpy_v3020 &&
@@ -98,8 +181,7 @@ inline bool RuntimeActivity::flowStart() const {
 }
 
 inline const std::string RuntimeActivity::metadataJson() const {
-  return fmt::format(R"JSON(
-      "cbid": {}, "correlation": {})JSON",
+  return fmt::format(R"JSON("cbid": {}, "correlation": {})JSON",
       activity_.cbid, activity_.correlationId);
 }
 

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -40,7 +40,6 @@ class CuptiActivityApi {
 
   static CuptiActivityApi& singleton();
 
-  virtual int smCount();
   static void pushCorrelationID(int id, CorrelationFlowType type);
   static void popCorrelationID(CorrelationFlowType type);
 

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -18,6 +18,12 @@
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+
+#ifdef HAS_CUPTI
+#include <cupti.h>
+#include "CuptiActivity.h"
+#endif // HAS_CUPTI
+
 #include "ThreadUtil.h"
 #include "TraceSpan.h"
 #include "libkineto.h"

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -8,10 +8,6 @@
 #include <thread>
 #include <unordered_map>
 
-#ifdef HAS_CUPTI
-#include <cupti.h>
-#include "CuptiActivity.h"
-#endif // HAS_CUPTI
 #include "ActivityBuffers.h"
 #include "GenericTraceActivity.h"
 #include "ThreadUtil.h"
@@ -19,8 +15,6 @@
 
 namespace KINETO_NAMESPACE {
   class Config;
-  class GpuKernelActivity;
-  struct RuntimeActivity;
 }
 
 namespace libkineto {
@@ -72,17 +66,6 @@ class ActivityLogger {
       const libkineto::ITraceActivity& activity) = 0;
   virtual void handleGenericActivity(
       const libkineto::GenericTraceActivity& activity) = 0;
-
-#ifdef HAS_CUPTI
-  virtual void handleGpuActivity(
-      const GpuActivity<CUpti_ActivityKernel4>& activity) = 0;
-  virtual void handleGpuActivity(
-      const GpuActivity<CUpti_ActivityMemcpy>& activity) = 0;
-  virtual void handleGpuActivity(
-      const GpuActivity<CUpti_ActivityMemcpy2>& activity) = 0;
-  virtual void handleGpuActivity(
-      const GpuActivity<CUpti_ActivityMemset>& activity) = 0;
-#endif // HAS_CUPTI
 
   virtual void handleTraceStart(
       const std::unordered_map<std::string, std::string>& metadata) = 0;

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -9,9 +9,6 @@
 
 #include "Config.h"
 #ifdef HAS_CUPTI
-#include "CuptiActivity.h"
-#include "CuptiActivity.tpp"
-#include "CuptiActivityApi.h"
 #include "CudaDeviceProperties.h"
 #endif // HAS_CUPTI
 #include "Demangle.h"
@@ -85,12 +82,6 @@ ChromeTraceLogger::ChromeTraceLogger(const std::string& traceFileName) {
   fileName_ = traceFileName.empty() ? defaultFileName() : traceFileName;
   traceOf_.clear(std::ios_base::badbit);
   openTraceFile();
-}
-
-static int64_t us(int64_t timestamp) {
-  // It's important that this conversion is the same here and in the CPU trace.
-  // No rounding!
-  return timestamp / 1000;
 }
 
 void ChromeTraceLogger::handleDeviceInfo(
@@ -241,26 +232,6 @@ void ChromeTraceLogger::addIterationMarker(const TraceSpan& span) {
   // clang-format on
 }
 
-static std::string traceActivityJson(const ITraceActivity& activity) {
-  // clang-format off
-  int64_t ts = activity.timestamp();
-  int64_t duration = activity.duration();
-  if (activity.type() ==  ActivityType::GPU_USER_ANNOTATION) {
-    // The GPU user annotations start at the same time as the
-    // first associated GPU activity. Since they appear later
-    // in the trace file, this causes a visualization issue in Chrome.
-    // Make it start one us earlier.
-    ts--;
-    duration++; // Still need it to end at the orginal point
-  }
-  return fmt::format(R"JSON(
-    "name": "{}", "pid": {}, "tid": {},
-    "ts": {}, "dur": {})JSON",
-      activity.name(), activity.deviceId(), activity.resourceId(),
-      ts, duration);
-  // clang-format on
-}
-
 void ChromeTraceLogger::handleGenericInstantEvent(
     const libkineto::ITraceActivity& op) {
   if (!traceOf_) {
@@ -269,14 +240,14 @@ void ChromeTraceLogger::handleGenericInstantEvent(
 
   traceOf_ << fmt::format(R"JSON(
   {{
-    "ph": "i", "s": "t", "name": "{}",
+    "ph": "i", "cat": "{}", "s": "t", "name": "{}",
     "pid": {}, "tid": {},
     "ts": {},
     "args": {{
       {}
     }}
   }},)JSON",
-      op.name(), op.deviceId(), op.resourceId(),
+      toString(op.type()), op.name(), op.deviceId(), op.resourceId(),
       op.timestamp(), op.metadataJson());
 }
 
@@ -291,6 +262,16 @@ void ChromeTraceLogger::handleActivity(
     return;
   }
 
+  int64_t ts = op.timestamp();
+  int64_t duration = op.duration();
+  if (op.type() ==  ActivityType::GPU_USER_ANNOTATION) {
+    // The GPU user annotations start at the same time as the
+    // first associated GPU op. Since they appear later
+    // in the trace file, this causes a visualization issue in Chrome.
+    // Make it start one us earlier.
+    ts--;
+    duration++; // Still need it to end at the orginal point
+  }
   const std::string op_metadata = op.metadataJson();
   std::string separator = "";
   if (op_metadata.find_first_not_of(" \t\n") != std::string::npos) {
@@ -303,16 +284,20 @@ void ChromeTraceLogger::handleActivity(
         op.traceSpan()->name,
         op.traceSpan()->iteration);
   }
+  int device = op.deviceId();
+  int resource = op.resourceId();
 
   // clang-format off
   traceOf_ << fmt::format(R"JSON(
   {{
-    "ph": "X", "cat": "{}", {},
+    "ph": "X", "cat": "{}", "name": "{}", "pid": {}, "tid": {},
+    "ts": {}, "dur": {},
     "args": {{{}
       "External id": {}{}{}
     }}
   }},)JSON",
-          toString(op.type()), traceActivityJson(op),
+          toString(op.type()), op.name(), device, resource,
+          ts, duration,
           // args
           span,
           op.correlationId(), separator, op_metadata);
@@ -371,161 +356,6 @@ void ChromeTraceLogger::handleLink(
       type, id, e.deviceId(), e.resourceId(), e.timestamp(), cat, name);
   // clang-format on
 }
-
-#ifdef HAS_CUPTI
-// GPU side kernel activity
-void ChromeTraceLogger::handleGpuActivity(
-    const GpuActivity<CUpti_ActivityKernel4>& activity) {
-  if (!traceOf_) {
-    return;
-  }
-  const CUpti_ActivityKernel4* kernel = &activity.raw();
-  constexpr int threads_per_warp = 32;
-  float blocks_per_sm = -1.0;
-  float warps_per_sm = -1.0;
-  int sm_count = smCount(kernel->deviceId);
-  if (sm_count) {
-    blocks_per_sm =
-        (kernel->gridX * kernel->gridY * kernel->gridZ) / (float) sm_count;
-    warps_per_sm =
-        blocks_per_sm * (kernel->blockX * kernel->blockY * kernel->blockZ)
-        / threads_per_warp;
-  }
-
-  // Calculate occupancy
-  float occupancy = KINETO_NAMESPACE::kernelOccupancy(
-      kernel->deviceId,
-      kernel->registersPerThread,
-      kernel->staticSharedMemory,
-      kernel->dynamicSharedMemory,
-      kernel->blockX,
-      kernel->blockY,
-      kernel->blockZ,
-      blocks_per_sm);
-
-  // clang-format off
-  traceOf_ << fmt::format(R"JSON(
-  {{
-    "ph": "X", "cat": "Kernel", {},
-    "args": {{
-      "queued": {}, "device": {}, "context": {},
-      "stream": {}, "correlation": {},
-      "registers per thread": {},
-      "shared memory": {},
-      "blocks per SM": {},
-      "warps per SM": {},
-      "grid": [{}, {}, {}],
-      "block": [{}, {}, {}],
-      "est. achieved occupancy %": {}
-    }}
-  }},)JSON",
-      traceActivityJson(activity),
-      // args
-      us(kernel->queued), kernel->deviceId, kernel->contextId,
-      kernel->streamId, kernel->correlationId,
-      kernel->registersPerThread,
-      kernel->staticSharedMemory + kernel->dynamicSharedMemory,
-      blocks_per_sm,
-      warps_per_sm,
-      kernel->gridX, kernel->gridY, kernel->gridZ,
-      kernel->blockX, kernel->blockY, kernel->blockZ,
-      (int) (0.5 + occupancy * 100.0));
-  // clang-format on
-
-  auto to_id = activity.correlationId();
-  handleLink(kFlowEnd, activity, to_id, "async_cpu_to_gpu", "async_gpu");
-}
-
-static std::string bandwidth(uint64_t bytes, uint64_t duration) {
-  return duration == 0 ? "\"N/A\"" : fmt::format("{}", bytes * 1.0 / duration);
-}
-
-// GPU side memcpy activity
-void ChromeTraceLogger::handleGpuActivity(
-    const GpuActivity<CUpti_ActivityMemcpy>& activity) {
-  if (!traceOf_) {
-    return;
-  }
-  const CUpti_ActivityMemcpy& memcpy = activity.raw();
-  VLOG(2) << memcpy.correlationId << ": MEMCPY";
-  // clang-format off
-  traceOf_ << fmt::format(R"JSON(
-  {{
-    "ph": "X", "cat": "Memcpy", {},
-    "args": {{
-      "device": {}, "context": {},
-      "stream": {}, "correlation": {},
-      "bytes": {}, "memory bandwidth (GB/s)": {}
-    }}
-  }},)JSON",
-      traceActivityJson(activity),
-      // args
-      memcpy.deviceId, memcpy.contextId,
-      memcpy.streamId, memcpy.correlationId,
-      memcpy.bytes, bandwidth(memcpy.bytes, memcpy.end - memcpy.start));
-  // clang-format on
-
-  int64_t to_id = activity.correlationId();
-  handleLink(kFlowEnd, activity, to_id, "async_cpu_to_gpu", "async_gpu");
-}
-
-// GPU side memcpy activity
-void ChromeTraceLogger::handleGpuActivity(
-    const GpuActivity<CUpti_ActivityMemcpy2>& activity) {
-  if (!traceOf_) {
-    return;
-  }
-  const CUpti_ActivityMemcpy2& memcpy = activity.raw();
-  // clang-format off
-  traceOf_ << fmt::format(R"JSON(
-  {{
-    "ph": "X", "cat": "Memcpy", {},
-    "args": {{
-      "fromDevice": {}, "inDevice": {}, "toDevice": {},
-      "fromContext": {}, "inContext": {}, "toContext": {},
-      "stream": {}, "correlation": {},
-      "bytes": {}, "memory bandwidth (GB/s)": {}
-    }}
-  }},)JSON",
-      traceActivityJson(activity),
-      // args
-      memcpy.srcDeviceId, memcpy.deviceId, memcpy.dstDeviceId,
-      memcpy.srcContextId, memcpy.contextId, memcpy.dstContextId,
-      memcpy.streamId, memcpy.correlationId,
-      memcpy.bytes, bandwidth(memcpy.bytes, memcpy.end - memcpy.start));
-  // clang-format on
-
-  int64_t to_id = activity.correlationId();
-  handleLink(kFlowEnd, activity, to_id, "async_cpu_to_gpu", "async_gpu");
-}
-
-void ChromeTraceLogger::handleGpuActivity(
-    const GpuActivity<CUpti_ActivityMemset>& activity) {
-  if (!traceOf_) {
-    return;
-  }
-  const CUpti_ActivityMemset& memset = activity.raw();
-  // clang-format off
-  traceOf_ << fmt::format(R"JSON(
-  {{
-    "ph": "X", "cat": "Memset", {},
-    "args": {{
-      "device": {}, "context": {},
-      "stream": {}, "correlation": {},
-      "bytes": {}, "memory bandwidth (GB/s)": {}
-    }}
-  }},)JSON",
-      traceActivityJson(activity),
-      // args
-      memset.deviceId, memset.contextId,
-      memset.streamId, memset.correlationId,
-      memset.bytes, bandwidth(memset.bytes, memset.end - memset.start));
-  // clang-format on
-
-  int64_t to_id = activity.correlationId();
-  handleLink(kFlowEnd, activity, to_id, "async_cpu_to_gpu", "async_gpu");
-}
-#endif // HAS_CUPTI
 
 void ChromeTraceLogger::finalizeTrace(
     const Config& /*unused*/,

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -42,13 +42,6 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   void handleActivity(const ITraceActivity& activity) override;
   void handleGenericActivity(const GenericTraceActivity& activity) override;
 
-#ifdef HAS_CUPTI
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityKernel4>& activity) override;
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemcpy>& activity) override;
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemcpy2>& activity) override;
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemset>& activity) override;
-#endif // HAS_CUPTI
-
   void handleTraceStart(
       const std::unordered_map<std::string, std::string>& metadata) override;
 

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -7,16 +7,8 @@
 #include <unordered_map>
 #include <vector>
 
-#ifdef HAS_CUPTI
-#include <cupti.h>
-#endif
-
 #include "Config.h"
 #include "GenericTraceActivity.h"
-#ifdef HAS_CUPTI
-#include "CuptiActivity.h"
-#include "CuptiActivity.tpp"
-#endif // HAS_CUPTI
 #include "output_base.h"
 
 namespace KINETO_NAMESPACE {
@@ -61,21 +53,6 @@ class MemoryTraceLogger : public ActivityLogger {
   void handleGenericActivity(const GenericTraceActivity& activity) override {
     addActivityWrapper(activity);
   }
-
-#ifdef HAS_CUPTI
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityKernel4>& activity) override {
-    addActivityWrapper(activity);
-  }
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemcpy>& activity) override {
-    addActivityWrapper(activity);
-  }
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemcpy2>& activity) override {
-    addActivityWrapper(activity);
-  }
-  void handleGpuActivity(const GpuActivity<CUpti_ActivityMemset>& activity) override {
-    addActivityWrapper(activity);
-  }
-#endif // HAS_CUPTI
 
   void handleTraceStart(
       const std::unordered_map<std::string, std::string>& metadata) override {

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -127,10 +127,6 @@ struct MockCuptiActivityBuffer {
 // Mock parts of the CuptiActivityApi
 class MockCuptiActivities : public CuptiActivityApi {
  public:
-  virtual int smCount() override {
-    return 10;
-  }
-
   virtual const std::pair<int, int> processActivities(
       CuptiActivityBufferMap&, /*unused*/
       std::function<void(const CUpti_Activity*)> handler) override {


### PR DESCRIPTION
Summary:
Re-opening Gisle's refactor diffs, and landing them.

Remove all CUPTI-specific code from the trace loggers by using handleGenericActivity for all CUPTI activities.

Differential Revision: D31665030

Pulled By: aaronenyeshi

