### PR TITLE
Improve PROFILE_START_TIME = 0 or absent for Config

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -208,7 +208,10 @@ class Config : public AbstractConfig {
     if  (profileStartTime_.time_since_epoch().count()) {
       return profileStartTime_;
     }
-
+    // If no one requested timestamp, return 0.
+    if (requestTimestamp_.time_since_epoch().count() == 0) {
+      return requestTimestamp_;
+    }
     // TODO(T94634890): Deperecate requestTimestamp
     return requestTimestamp_ + maxRequestAge() + activitiesWarmupDuration();
   }

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -246,6 +246,11 @@ static time_point<system_clock> handleRequestTimestamp(int64_t ms) {
 }
 
 static time_point<system_clock> handleProfileStartTime(int64_t start_time_ms) {
+  // If 0, return 0, so that AbstractConfig::parse can fix the timestamp later.
+  if (start_time_ms == 0) {
+    return time_point<system_clock>(milliseconds(0));
+  }
+
   auto t = time_point<system_clock>(milliseconds(start_time_ms));
   // This should check that ProfileStartTime is in the future with
   // enough time for warm-up.

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -318,6 +318,11 @@ TEST(ParseTest, ProfileStartTime) {
       duration_cast<milliseconds>(now.time_since_epoch()).count();
   EXPECT_TRUE(cfg.parse(fmt::format("PROFILE_START_TIME = {}", tgood_ms)));
 
+  // Pass given PROFILE_START_TIME = 0, a timestamp is assigned.
+  tgood_ms = 0;
+  EXPECT_TRUE(cfg.parse(fmt::format("PROFILE_START_TIME = {}", tgood_ms)));
+
+  // Fail given PROFILE_START_TIME older than kMaxRequestAge from now.
   int64_t tbad_ms =
       duration_cast<milliseconds>((now - seconds(15)).time_since_epoch())
           .count();


### PR DESCRIPTION
Summary:
Perform these changes:
- Remove request_timestamp from dyno for gputrace, instead use profile_start_time
- Fix Config to actually return 0 when requestTimestamp is 0 or absent, the AbstractConfig::parse function will actually assign a value for this case.
- Add test checks for PROFILE_START_TIME=0 and absent PROFILE_START_TIME for ensure a start timestamp is assigned.

Reviewed By: chaekit

Differential Revision: D35296356

Pulled By: aaronenyeshi

