### PR TITLE
Remove duplicate image in tb_plugin README.md

### DIFF
--- a/tb_plugin/README.md
+++ b/tb_plugin/README.md
@@ -287,8 +287,6 @@ We describe each of these views below.
     "Kernel Properties + Op Name" will group kernels by combination of kernel name, launching operator name,
     grid, block, registers per thread, and shared memory.
 
-    ![Alt text](./docs/images/trace_view.PNG)
-
     * Operator: The name of PyTorch operator which launches this kernel.
 
     * Grid: Grid size of this kernel.


### PR DESCRIPTION
I removed this image (marked by X) because it appears twice, once in the wrong section. 
<img width="618" alt="image" src="https://user-images.githubusercontent.com/1737560/162360535-93b92527-ab32-495d-987b-878e9e8649bd.png">

I hope this helps!