### PR TITLE
Update CUPTI Range Profiler to support CUDA 11.4 and above

### DIFF
--- a/libkineto/src/CuptiRangeProfilerApi.h
+++ b/libkineto/src/CuptiRangeProfilerApi.h
@@ -6,9 +6,9 @@
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 // Using CUDA 11 and above due to usage of API: cuptiProfilerGetCounterAvailability.
-#if defined(USE_CUPTI_RANGE_PROFILER) && defined(CUDART_VERSION) && CUDART_VERSION >= 10000 && CUDART_VERSION < 11040 && CUDA_VERSION >= 11000
+#if defined(USE_CUPTI_RANGE_PROFILER) && defined(CUDART_VERSION) && CUDART_VERSION >= 10000 && CUDA_VERSION >= 11000
 #define HAS_CUPTI_RANGE_PROFILER 1
-#endif // CUDART_VERSION > 10.00 and < 11.04 && CUDA_VERSION >= 11.00
+#endif // CUDART_VERSION > 10.00 and CUDA_VERSION >= 11.00
 #endif // HAS_CUPTI
 
 #if HAS_CUPTI_RANGE_PROFILER


### PR DESCRIPTION
Summary:
In CUDA 11.4 one of the structs and call signatures in nvperf_cuda_host.h have changed. This patch adds support for CUDA >= 11.4
The header is used to configure the CUPTI Range profiler via NV Perfworks API

See https://gitlab.com/nvidia/headers/cuda-individual/cupti/-/blob/main/nvperf_cuda_host.h

Facebook
With switch from platform009 to platform010 there is change to CUDA 11.4 where the structure changes.
So far in this feature is disabled for this CUDA version

Differential Revision: D35504691

