### PR TITLE
Make ActivityProfiler Config const and create DerivedConfigState

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -184,12 +184,6 @@ class Config : public AbstractConfig {
     return activitiesRunIterations_;
   }
 
-  std::chrono::milliseconds activitiesDurationDefault() const;
-
-  void setActivitiesDuration(std::chrono::milliseconds duration) {
-    activitiesDuration_ = duration;
-  }
-
   int activitiesMaxGpuBufferSize() const {
     return activitiesMaxGpuBufferSize_;
   }
@@ -212,7 +206,8 @@ class Config : public AbstractConfig {
     if (requestTimestamp_.time_since_epoch().count() == 0) {
       return requestTimestamp_;
     }
-    // TODO(T94634890): Deperecate requestTimestamp
+
+    // TODO(T94634890): Deprecate requestTimestamp
     return requestTimestamp_ + maxRequestAge() + activitiesWarmupDuration();
   }
 
@@ -409,9 +404,10 @@ class Config : public AbstractConfig {
   std::chrono::time_point<std::chrono::system_clock>
       activitiesOnDemandTimestamp_;
 
-  // Synchronized start timestamp
+  // ActivityProfilers are triggered by either:
+  // Synchronized start timestamps
   std::chrono::time_point<std::chrono::system_clock> profileStartTime_;
-  // or start iteration
+  // Or start iterations.
   int profileStartIteration_;
   int profileStartIterationRoundUp_;
 

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -73,6 +73,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
 
   std::unique_ptr<Config> asyncRequestConfig_;
   std::mutex asyncConfigLock_;
+
   std::unique_ptr<CuptiActivityProfiler> profiler_;
   std::unique_ptr<ActivityLogger> logger_;
   std::thread* profilerThread_{nullptr};

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -368,10 +368,6 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   return true;
 }
 
-std::chrono::milliseconds Config::activitiesDurationDefault() const {
-  return kDefaultActivitiesProfileDurationMSecs;
-};
-
 void Config::updateActivityProfilerRequestReceivedTime() {
   activitiesOnDemandTimestamp_ = system_clock::now();
 }

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -64,8 +64,7 @@ CuptiActivityProfiler::CuptiActivityProfiler(CuptiActivityApi& cupti, bool cpuOn
       flushOverhead_{0, 0},
       setupOverhead_{0, 0},
       cpuOnly_{cpuOnly},
-      currentRunloopState_{RunloopState::WaitForRequest},
-      stopCollection_{false} {}
+      currentRunloopState_{RunloopState::WaitForRequest} {}
 
 void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
   LOG(INFO) << "Processing " << traceBuffers_->cpu.size() << " CPU buffers";
@@ -556,9 +555,7 @@ void CuptiActivityProfiler::startTraceInternal(const time_point<system_clock>& n
 }
 
 void CuptiActivityProfiler::stopTraceInternal(const time_point<system_clock>& now) {
-  if (captureWindowEndTime_ == 0) {
-    captureWindowEndTime_ = libkineto::timeSinceEpoch(now);
-  }
+  captureWindowEndTime_ = libkineto::timeSinceEpoch(now);
 #if defined(HAS_CUPTI) || defined(HAS_ROCTRACER)
   if (!cpuOnly_) {
     time_point<system_clock> timestamp;
@@ -691,20 +688,10 @@ const time_point<system_clock> CuptiActivityProfiler::performRunLoopStep(
 
     case RunloopState::CollectTrace:
       VLOG(1) << "State: CollectTrace";
-      // captureWindowStartTime_ can be set by external threads,
-      // so recompute end time.
-      // FIXME: Is this a good idea for synced start?
-      if (profileStartIter_ < 0) {
-        std::lock_guard<std::mutex> guard(mutex_);
-        profileEndTime_ = time_point<system_clock>(
-                              microseconds(captureWindowStartTime_)) +
-            config_->activitiesDuration();
-      }
-
       collection_done = isCollectionDone(now, currentIter);
 
       // TODO revisit stopCollection_ is not used right now
-      if (collection_done || stopCollection_.exchange(false)
+      if (collection_done
 #if defined(HAS_CUPTI) || defined(HAS_ROCTRACER)
           || cupti_.stopCollection
 #endif // HAS_CUPTI || HAS_ROCTRACER

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -335,19 +335,15 @@ class CuptiActivityProfiler {
   // Runloop phase
   std::atomic<RunloopState> currentRunloopState_{RunloopState::WaitForRequest};
 
-  // Keep track of the start time of the first net in the current trace.
-  // This is only relevant to Caffe2 as PyTorch does not have nets.
+  // Keep track of the start time and end time for the trace collected.
+  // External threads using startTrace need to manually stopTrace. Part of the mock tests.
   // All CUDA events before this time will be removed
-  // Can be written by external threads during collection.
   int64_t captureWindowStartTime_{0};
   // Similarly, all CUDA API events after the last net event will be removed
   int64_t captureWindowEndTime_{0};
 
   // span name -> iteration count
   std::map<std::string, int> iterationCountMap_;
-  // Flag used to stop tracing from external api callback.
-  // Needs to be atomic since it's set from a different thread.
-  std::atomic_bool stopCollection_{false};
 
   // Buffers where trace data is stored
   std::unique_ptr<ActivityBuffers> traceBuffers_;


### PR DESCRIPTION
Summary: The Config given to ActivityProfiler should be considered request truth, and shouldn't be modified (made const here). Instead, use a struct DerivedConfigState that handles derived values of Start and End times / iterations.

Differential Revision: D35053324

Pulled By: aaronenyeshi

