### PR TITLE
Fix missing profileEndTime_ due to cleanup

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -463,7 +463,7 @@ void CuptiActivityProfiler::configure(
     profileStartIter_ = config_->profileStartIteration();
     profileEndIter_ = profileStartIter_ + config_->activitiesRunIterations();
   } else {
-
+    profileEndTime_ = profileStartTime_ + config_->activitiesDuration();
     profileStartIter_ = -1;
     profileEndIter_ = (std::numeric_limits<decltype(profileEndIter_)>::max)();
 


### PR DESCRIPTION
Summary: Add back the profileEndTime_ which was deleted from RunloopState::CollectTrace in recent cleanup. This will be replaced in later diffs.

Reviewed By: chaekit

Differential Revision: D35583199

Pulled By: aaronenyeshi

