### PR TITLE
Add back deviceProperties to trace metadata

### DIFF
--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -8,9 +8,6 @@
 #include <thread>
 #include <unordered_map>
 
-#ifdef HAS_CUPTI
-#include <cupti.h>
-#endif
 #include "GenericTraceActivity.h"
 #include "output_base.h"
 


### PR DESCRIPTION
Summary: OSS: Remove include cupti.h from output_json.h which is not needed by this directly anymore. Will be included in CudaDeviceProperties.h when needed.

Reviewed By: chaekit

Differential Revision: D35628993

Pulled By: aaronenyeshi

