### PR TITLE
Call CUPTI range profiler init at a later point

### DIFF
--- a/libkineto/src/CuptiRangeProfiler.cpp
+++ b/libkineto/src/CuptiRangeProfiler.cpp
@@ -283,7 +283,6 @@ CuptiRangeProfilerInit::CuptiRangeProfilerInit() {
   CuptiRangeProfilerConfig::registerFactory();
 
 #ifdef HAS_CUPTI
-  // TODO should this be revised to avoid overhead
   success = CuptiRBProfilerSession::staticInit();
 #endif
 


### PR DESCRIPTION
Summary: Delay CUPTI range profiler init to avoid loading libnvperf_host.so

Differential Revision: D35826397

