### PR TITLE
filter out out-of-window overhead activities

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -335,9 +335,11 @@ void CuptiActivityProfiler::handleOverheadActivity(
     const CUpti_ActivityOverhead* activity,
     ActivityLogger* logger) {
   VLOG(2) << ": CUPTI_ACTIVITY_KIND_OVERHEAD" << " overheadKind=" << activity->overheadKind;
-
   const auto& overhead_activity =
       traceBuffers_->addActivityWrapper(OverheadActivity(activity, nullptr));
+  if (outOfRange(overhead_activity)) {
+    return;
+  }
   overhead_activity.log(*logger);
 }
 


### PR DESCRIPTION
Summary:
Initial version of overhead tracking did not filter out pre/post window activities to understand the full picture of overheads that can happen before/after tracing window.

so far excessive overhead has been captured during the window, meaning its sufficient to understand overheads without capturing more than tracing window.
because we are considering turning this on by default, we should filter out to tidy up the traces in prod

Reviewed By: aaronenyeshi

Differential Revision: D35820401

