### PR TITLE
Use lowercase for EventTypeMap keys and checks in TB Plugin

### DIFF
--- a/tb_plugin/torch_tb_profiler/profiler/trace.py
+++ b/tb_plugin/torch_tb_profiler/profiler/trace.py
@@ -33,17 +33,17 @@ class EventTypes(object):
 
 
 EventTypeMap = {
-    'Trace': EventTypes.TRACE,
+    'trace': EventTypes.TRACE,
     'cpu_op': EventTypes.OPERATOR,
-    'Operator': EventTypes.OPERATOR,
-    'Runtime': EventTypes.RUNTIME,
-    'Kernel': EventTypes.KERNEL,
-    'Memcpy': EventTypes.MEMCPY,
+    'operator': EventTypes.OPERATOR,
+    'runtime': EventTypes.RUNTIME,
+    'kernel': EventTypes.KERNEL,
+    'memcpy': EventTypes.MEMCPY,
     'gpu_memcpy': EventTypes.MEMCPY,
-    'Memset': EventTypes.MEMSET,
+    'memset': EventTypes.MEMSET,
     'gpu_memset': EventTypes.MEMSET,
-    'Python': EventTypes.PYTHON,
-    'Memory': EventTypes.MEMORY,
+    'python': EventTypes.PYTHON,
+    'memory': EventTypes.MEMORY,
     'python_function': EventTypes.PYTHON_FUNCTION
 }
 
@@ -180,7 +180,7 @@ def create_event(event, is_pytorch_lightning) -> Optional[BaseEvent]:
 
 def create_trace_event(event, is_pytorch_lightning) -> Optional[BaseEvent]:
     category = event.get('cat')
-    event_type = EventTypeMap.get(category)
+    event_type = EventTypeMap.get(category.lower())
     if event_type == EventTypes.OPERATOR:
         name = event.get('name')
         if name and name.startswith('ProfilerStep#'):


### PR DESCRIPTION
Recently there was a patch that changed the trace format. It was previously Kernel, Memcpy, and Memset, but these were changed to kernel, gpu_memcpy and gpu_memset (following https://github.com/pytorch/kineto/blob/cdfa44f8d8f2f2b5c6f2efa83322977551e05d92/libkineto/src/ActivityType.cpp#L20). There are also a few new fields added, offending diff: https://github.com/pytorch/kineto/commit/1679e50eebaf47d7d02903ae2069faee0a5d2db6 . To support kernel, we will lowercase all the EventTypeMap keys and the check.
