### PR TITLE
Consolidate Iteration Based and Timestamp Based logic in ActivityProfilerController

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -84,6 +84,65 @@ void ActivityProfilerController::acceptConfig(const Config& config) {
   }
 }
 
+bool ActivityProfilerController::shouldActivateTimestampConfig(
+    const std::chrono::time_point<std::chrono::system_clock>& now) {
+  if (asyncRequestConfig_->hasProfileStartIteration()) {
+    return false;
+  }
+  // Note on now + kProfilerIntervalMsecs
+  // Profiler interval does not align perfectly up to startTime - warmup.
+  // Waiting until the next tick won't allow sufficient time for the profiler to warm up.
+  // So check if we are very close to the warmup time and trigger warmup.
+  if (now + kProfilerIntervalMsecs
+      >= (asyncRequestConfig_->requestTimestamp() - asyncRequestConfig_->activitiesWarmupDuration())) {
+    LOG(INFO) << "Received on-demand activity trace request by "
+              << " profile timestamp = "
+              << asyncRequestConfig_->requestTimestamp().time_since_epoch().count();
+    return true;
+  }
+  return false;
+}
+
+bool ActivityProfilerController::shouldActivateIterationConfig(
+    int64_t currentIter) {
+  if (!asyncRequestConfig_->hasProfileStartIteration()) {
+    return false;
+  }
+  auto rootIter = asyncRequestConfig_->startIterationIncludingWarmup();
+  // Keep waiting, it is not time to start yet.
+  if (currentIter < rootIter) {
+    return false;
+  }
+
+  LOG(INFO) << "Received on-demand activity trace request by "
+                " profile start iteration = "
+            << asyncRequestConfig_->profileStartIteration()
+            << ", current iteration = " << currentIter;
+  // Re-calculate the start iter if requested iteration is in the past.
+  if (currentIter > rootIter) {
+    auto newProfileStart = currentIter +
+        asyncRequestConfig_->activitiesWarmupIterations();
+    // Use Start Iteration Round Up if it is present.
+    if (asyncRequestConfig_->profileStartIterationRoundUp() > 0) {
+      // round up to nearest multiple
+      auto divisor = asyncRequestConfig_->profileStartIterationRoundUp();
+      auto rem = newProfileStart % divisor;
+      newProfileStart += ((rem == 0) ? 0 : divisor - rem);
+      LOG(INFO) << "Rounding up profiler start iteration to : " << newProfileStart;
+      asyncRequestConfig_->setProfileStartIteration(newProfileStart);
+      if (currentIter != asyncRequestConfig_->startIterationIncludingWarmup()) {
+        // Ex. Current 9, start 8, warmup 5, roundup 100. Resolves new start to 100,
+        // with warmup starting at 95. So don't start now.
+        return false;
+      }
+    } else {
+      LOG(INFO) << "Start iteration updated to : " << newProfileStart;
+      asyncRequestConfig_->setProfileStartIteration(newProfileStart);
+    }
+  }
+  return true;
+}
+
 void ActivityProfilerController::profilerLoop() {
   setThreadName("Kineto Activity Profiler");
   VLOG(0) << "Entering activity profiler loop";
@@ -100,19 +159,12 @@ void ActivityProfilerController::profilerLoop() {
       now = system_clock::now();
     }
 
-    if (!profiler_->isActive()) {
+    // Perform Double-checked locking to reduce overhead of taking lock.
+    if (asyncRequestConfig_ && !profiler_->isActive()) {
       std::lock_guard<std::mutex> lock(asyncConfigLock_);
-      if (asyncRequestConfig_ && !asyncRequestConfig_->hasProfileStartIteration()) {
-        // Note on now + kProfilerIntervalMsecs
-        // Profiler interval does not align perfectly upto startTime - warmup. Waiting until the next tick
-        // won't allow sufficient time for the profiler to warm up. So check if we are very close to the warmup time and trigger warmup
-        if (now + kProfilerIntervalMsecs
-            >= (asyncRequestConfig_->requestTimestamp() - asyncRequestConfig_->activitiesWarmupDuration())) {
-          LOG(INFO) << "Received on-demand activity trace request by "
-                    << " profile timestamp = "
-                    << asyncRequestConfig_->requestTimestamp().time_since_epoch().count();
-          activateConfig(now);
-        }
+      if (asyncRequestConfig_ && !profiler_->isActive() &&
+          shouldActivateTimestampConfig(now)) {
+        activateConfig(now);
       }
     }
 
@@ -132,29 +184,17 @@ void ActivityProfilerController::profilerLoop() {
 }
 
 void ActivityProfilerController::step() {
+  // Do not remove this copy to currentIter. Otherwise count is not guaranteed.
   int64_t currentIter = ++iterationCount_;
   VLOG(0) << "Step called , iteration  = " << currentIter;
 
-  // optimization to not take the lock unless necessary
+  // Perform Double-checked locking to reduce overhead of taking lock.
   if (asyncRequestConfig_ && !profiler_->isActive()) {
     std::lock_guard<std::mutex> lock(asyncConfigLock_);
-    auto startIter = asyncRequestConfig_->startIterationIncludingWarmup();
-
-    if (asyncRequestConfig_->hasProfileStartIteration()
-        && currentIter >= startIter) {
-      LOG(INFO) << "Received on-demand activity trace request by profile"
-                << " start iteration = "
-                << asyncRequestConfig_->profileStartIteration()
-                << " current iteration = " << currentIter;
-
-      if (currentIter > startIter) {
-        // adjust the start iteration if it is in the past
-        auto newProfileStart = currentIter +
-          asyncRequestConfig_->activitiesWarmupIterations();
-        LOG(INFO) << "Start iteration updated to " << newProfileStart;
-        asyncRequestConfig_->setProfileStartIteration(newProfileStart);
-      }
-      activateConfig(system_clock::now());
+    auto now = system_clock::now();
+    if (asyncRequestConfig_ && !profiler_->isActive() &&
+        shouldActivateIterationConfig(currentIter)) {
+      activateConfig(now);
     }
   }
 
@@ -165,6 +205,7 @@ void ActivityProfilerController::step() {
   }
 }
 
+// This function should only be called when holding the configLock_.
 void ActivityProfilerController::activateConfig(
     std::chrono::time_point<std::chrono::system_clock> now) {
   logger_ = makeLogger(*asyncRequestConfig_);
@@ -186,24 +227,17 @@ void ActivityProfilerController::scheduleTrace(const Config& config) {
     return;
   }
 
-  {
+  bool newConfigScheduled = false;
+  if (!asyncRequestConfig_) {
     std::lock_guard<std::mutex> lock(asyncConfigLock_);
-    asyncRequestConfig_ = config.clone();
-
-    auto startIter = asyncRequestConfig_->startIterationIncludingWarmup();
-
-    if (asyncRequestConfig_->hasProfileStartIteration()
-        && (currentIter > startIter)
-        && asyncRequestConfig_->profileStartIterationRoundUp() > 0) {
-      auto newProfileStart
-        = currentIter + asyncRequestConfig_->activitiesWarmupIterations();
-      // round up to nearest multiple
-      auto divisor = asyncRequestConfig_->profileStartIterationRoundUp();
-      auto rem = newProfileStart % divisor;
-      newProfileStart += ((rem == 0) ? 0 : divisor - rem);
-      LOG(INFO) << "Rounding up profiler start iteration to : " << newProfileStart;
-      asyncRequestConfig_->setProfileStartIteration(newProfileStart);
+    if (!asyncRequestConfig_) {
+      asyncRequestConfig_ = config.clone();
+      newConfigScheduled = true;
     }
+  }
+  if (!newConfigScheduled) {
+    LOG(WARNING) << "Ignored request - another profile request is pending.";
+    return;
   }
 
   // start a profilerLoop() thread to handle request

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -68,6 +68,9 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   void addMetadata(const std::string& key, const std::string& value);
 
  private:
+  bool shouldActivateIterationConfig(int64_t currentIter);
+  bool shouldActivateTimestampConfig(
+      const std::chrono::time_point<std::chrono::system_clock>& now);
   void profilerLoop();
   void activateConfig(std::chrono::time_point<std::chrono::system_clock> now);
 


### PR DESCRIPTION
Summary:
Update the ActivityProfilerController with the following changes:
1. Only allow Iteration Based Request to be triggered by step(), and Timestamp Based Request to be triggered by profilerLoop().
2. Move logic to activating Config into two functions, shouldActivateIterationConfig and shouldActivateTimestampConfig.
3. For Iteration Based Config, perform re-calculation of profiler start iteration during the step boundary rather than scheduleTrace.
4. During scheduleTrace, if an asyncRequestConfig_ already exists, don't overwrite it, ignore incoming requests with warnings.
5. Used double checked locking to avoid locking when asyncRequestConfig_ is nullptr or profiler is active.

Reviewed By: briancoutinho

Differential Revision: D35123429

Pulled By: aaronenyeshi

