### PR TITLE
Support logging stages for sync APIs such as PyTorch Profiler in Auto-Trace

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -265,8 +265,15 @@ void ActivityProfilerController::prepareTrace(const Config& config) {
   profiler_->configure(config, now);
 }
 
+void ActivityProfilerController::startTrace() {
+  UST_LOGGER_MARK_COMPLETED(kWarmUpStage);
+  profiler_->startTrace(std::chrono::system_clock::now());
+}
+
 std::unique_ptr<ActivityTraceInterface> ActivityProfilerController::stopTrace() {
   profiler_->stopTrace(std::chrono::system_clock::now());
+  UST_LOGGER_MARK_COMPLETED(kCollectionStage);
+
   auto logger = std::make_unique<MemoryTraceLogger>(profiler_->config());
   profiler_->processTrace(*logger);
   profiler_->reset();

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -32,19 +32,15 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
       const std::string& protocol,
       ActivityLoggerFactory::FactoryFunc factory);
 
+  // These API are used for On-Demand Tracing.
   bool canAcceptConfig() override;
   void acceptConfig(const Config& config) override;
-
   void scheduleTrace(const Config& config);
 
+  // These API are used for Synchronous Tracing.
   void prepareTrace(const Config& config);
-
-  void startTrace() {
-    profiler_->startTrace(std::chrono::system_clock::now());
-  }
-
+  void startTrace();
   void step();
-
   std::unique_ptr<ActivityTraceInterface> stopTrace();
 
   bool isActive() {

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -759,7 +759,6 @@ const time_point<system_clock> CuptiActivityProfiler::performRunLoopStep(
       // for quickly handling trace request via synchronous API
       std::lock_guard<std::mutex> guard(mutex_);
       processTraceInternal(*logger_);
-      UST_LOGGER_MARK_COMPLETED(kPostProcessingStage);
       resetInternal();
       VLOG(0) << "ProcessTrace -> WaitForRequest";
       break;

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -357,9 +357,7 @@ void ChromeTraceLogger::handleLink(
   // clang-format on
 }
 
-void ChromeTraceLogger::finalizeTrace(
-    const Config& /*unused*/,
-    std::unique_ptr<ActivityBuffers> /*unused*/,
+void ChromeTraceLogger::finalizeTraceInternal(
     int64_t endTime,
     std::unordered_map<std::string, std::vector<std::string>>& metadata) {
   if (!traceOf_) {
@@ -410,4 +408,12 @@ void ChromeTraceLogger::finalizeTrace(
   traceOf_.close();
 }
 
+void ChromeTraceLogger::finalizeTrace(
+    const Config& /*unused*/,
+    std::unique_ptr<ActivityBuffers> /*unused*/,
+    int64_t endTime,
+    std::unordered_map<std::string, std::vector<std::string>>& metadata) {
+  ChromeTraceLogger::finalizeTraceInternal(endTime, metadata);
+  UST_LOGGER_MARK_COMPLETED(kPostProcessingStage);
+}
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -52,6 +52,11 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
     return fileName_;
   }
 
+ protected:
+  void finalizeTraceInternal(
+  int64_t endTime,
+  std::unordered_map<std::string, std::vector<std::string>>& metadata);
+
  private:
 
   // Create a flow event (arrow)


### PR DESCRIPTION
Summary: Add stages to applications using synchronous API calls when profiling.

Differential Revision: D36294768

Pulled By: aaronenyeshi

