### PR TITLE
Allow external pytorch libraries to see kineto

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -78,8 +78,7 @@ add_dependencies(kineto_base libkineto_defs.bzl)
 set_target_properties(kineto_base kineto_api PROPERTIES
       CXX_STANDARD 14
       CXX_STANDARD_REQUIRED YES
-      CXX_EXTENSIONS NO
-      CXX_VISIBILITY_PRESET hidden)
+      CXX_EXTENSIONS NO)
 
 set(KINETO_COMPILE_OPTIONS "-DKINETO_NAMESPACE=libkineto")
 list(APPEND KINETO_COMPILE_OPTIONS "-DFMT_HEADER_ONLY")


### PR DESCRIPTION
Summary: External activity profilers needs access to libkineto::api() to register.
kineto_api uses hidden CXX_VISIBILITY_PRESET. This blocks using
libkineto::api() symbol in scenario where kineto is linked statically
to pytorch (default case) and the external profiler is inside pytorch plugin.