### PR TITLE
Supporting adding addtional string metadata

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -41,10 +41,15 @@ std::string& ChromeTraceLogger::sanitizeStrForJSON(std::string& value) {
 }
 
 void ChromeTraceLogger::metadataToJSON(
-    const std::unordered_map<std::string, std::string>& metadata) {
+    const std::unordered_map<std::string, std::string>& metadata, bool quote) {
   for (const auto& kv : metadata) {
-    traceOf_ << fmt::format(R"JSON(
+    if (quote) {
+      traceOf_ << fmt::format(R"JSON(
+  "{}": "{}",)JSON", kv.first, kv.second);
+    } else {
+      traceOf_ << fmt::format(R"JSON(
   "{}": {},)JSON", kv.first, kv.second);
+    }
   }
 }
 
@@ -60,7 +65,7 @@ void ChromeTraceLogger::handleTraceStart(
   ],)JSON", devicePropertiesJson());
 #endif
 
-  metadataToJSON(metadata);
+  metadataToJSON(metadata, true /*quote*/);
   traceOf_ << R"JSON(
   "traceEvents": [)JSON";
 }

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -75,7 +75,9 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
 
   void handleGenericLink(const ITraceActivity& activity);
 
-  void metadataToJSON(const std::unordered_map<std::string, std::string>& metadata);
+  void metadataToJSON(
+      const std::unordered_map<std::string, std::string>& metadata,
+      bool quote = false);
 
   std::string& sanitizeStrForJSON(std::string& value);
 


### PR DESCRIPTION
Summary: Update chromtrace to support string metadata

Reviewed By: aaronenyeshi

Differential Revision: D36420466

