### PR TITLE
Fix json quoting issue

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -41,15 +41,10 @@ std::string& ChromeTraceLogger::sanitizeStrForJSON(std::string& value) {
 }
 
 void ChromeTraceLogger::metadataToJSON(
-    const std::unordered_map<std::string, std::string>& metadata, bool quote) {
+    const std::unordered_map<std::string, std::string>& metadata) {
   for (const auto& kv : metadata) {
-    if (quote) {
-      traceOf_ << fmt::format(R"JSON(
-  "{}": "{}",)JSON", kv.first, kv.second);
-    } else {
-      traceOf_ << fmt::format(R"JSON(
+    traceOf_ << fmt::format(R"JSON(
   "{}": {},)JSON", kv.first, kv.second);
-    }
   }
 }
 
@@ -65,7 +60,7 @@ void ChromeTraceLogger::handleTraceStart(
   ],)JSON", devicePropertiesJson());
 #endif
 
-  metadataToJSON(metadata, true /*quote*/);
+  metadataToJSON(metadata);
   traceOf_ << R"JSON(
   "traceEvents": [)JSON";
 }

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -76,8 +76,7 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   void handleGenericLink(const ITraceActivity& activity);
 
   void metadataToJSON(
-      const std::unordered_map<std::string, std::string>& metadata,
-      bool quote = false);
+      const std::unordered_map<std::string, std::string>& metadata);
 
   std::string& sanitizeStrForJSON(std::string& value);
 


### PR DESCRIPTION
Summary:
Fixes an issue introduced in https://github.com/pytorch/kineto/pull/601
We should not be assuming the json data value is string but in general could be any generic json blurb.
We will add the quotes while logging to the metadata string itself.

Reviewed By: robieta

Differential Revision: D36612241

