### PR TITLE
Add HPU Activity Type

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -22,6 +22,7 @@ enum class ActivityType {
     CPU_INSTANT_EVENT, // host side point-like events
     PYTHON_FUNCTION,
     OVERHEAD, // CUPTI induced overhead events sampled from its overhead API.
+    HPU_OP,
 
     // Optional Activity types
     GLOW_RUNTIME, // host side glow runtime events

--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -22,11 +22,11 @@ enum class ActivityType {
     CPU_INSTANT_EVENT, // host side point-like events
     PYTHON_FUNCTION,
     OVERHEAD, // CUPTI induced overhead events sampled from its overhead API.
-    HPU_OP,
 
     // Optional Activity types
     GLOW_RUNTIME, // host side glow runtime events
     CUDA_PROFILER_RANGE, // CUPTI Profiler range for performance metrics
+    HPU_OP,  //HPU host side runtime event
 
     ENUM_COUNT, // This is to add buffer and not used for any profiling logic. Add your new type before it.
     OPTIONAL_ACTIVITY_TYPE_START = GLOW_RUNTIME,

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -23,9 +23,9 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
     {"python_function", ActivityType::PYTHON_FUNCTION},
     {"overhead", ActivityType::OVERHEAD},
-    {"hpu_op", ActivityType::HPU_OP},
     {"glow_runtime", ActivityType::GLOW_RUNTIME},
     {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
+    {"hpu_op", ActivityType::HPU_OP},
     {"ENUM_COUNT", ActivityType::ENUM_COUNT}
 }};
 

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -11,8 +11,8 @@ struct ActivityTypeName {
   ActivityType type;
 };
 
-static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
-    {"cpu_op", ActivityType::CPU_OP},
+static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{
+    {{"cpu_op", ActivityType::CPU_OP},
     {"user_annotation", ActivityType::USER_ANNOTATION},
     {"gpu_user_annotation", ActivityType::GPU_USER_ANNOTATION},
     {"gpu_memcpy", ActivityType::GPU_MEMCPY},
@@ -23,6 +23,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
     {"python_function", ActivityType::PYTHON_FUNCTION},
     {"overhead", ActivityType::OVERHEAD},
+    {"hpu_op", ActivityType::HPU_OP},
     {"glow_runtime", ActivityType::GLOW_RUNTIME},
     {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
     {"ENUM_COUNT", ActivityType::ENUM_COUNT}

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -186,9 +186,6 @@ void ChromeTraceLogger::handleTraceSpan(const TraceSpan& span) {
   if (!traceOf_) {
     return;
   }
-  if (span.startTime == 0 && span.endTime == 0 && span.iteration == -1) {
-    return;
-  }
 
   // clang-format off
   traceOf_ << fmt::format(R"JSON(

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -186,6 +186,9 @@ void ChromeTraceLogger::handleTraceSpan(const TraceSpan& span) {
   if (!traceOf_) {
     return;
   }
+  if (span.startTime == 0 && span.endTime == 0 && span.iteration == -1) {
+    return;
+  }
 
   // clang-format off
   traceOf_ << fmt::format(R"JSON(


### PR DESCRIPTION
Summary: This change is part of Habana Device enablement in PyTorch.
Allows user to select HPU as profiling activity.