### PR TITLE
Add methods to bridge the transition to std::unique_ptr<GenericTraceActivity>

### DIFF
--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -37,6 +37,19 @@ class Config;
 class ConfigLoader;
 
 struct CpuTraceBuffer {
+  template <class... Args>
+  void emplace_activity(Args&&... args) {
+    activities.emplace_back(std::forward<Args>(args)...);
+  }
+
+  static GenericTraceActivity& toRef(GenericTraceActivity& ref) {
+    return ref;
+  }
+
+  static const GenericTraceActivity& toRef(const GenericTraceActivity& ref) {
+    return ref;
+  }
+
   TraceSpan span{0, 0, "none"};
   int gpuOpCount;
   std::deque<GenericTraceActivity> activities;


### PR DESCRIPTION
Summary:
The goal is to replace:
```
struct CpuTraceBuffer {
  TraceSpan span{0, 0, "none"};
  int gpuOpCount;
  std::deque<GenericTraceActivity> activities;
};
```
with
```
struct CpuTraceBuffer {
  TraceSpan span{0, 0, "none"};
  int gpuOpCount;
  std::deque<std::unique_ptr<GenericTraceActivity>> activities;
};
```
This will add a lot of safety to Kineto (which currently uses a lot of raw pointers to elements in containers) and allow clients to keep track of which event is which even if `activities` is reordered.

However, this is a breaking change and will break clients who are  expecting the old behavior. To bridge the change, this PR introduces two methods to CpuTraceBuffer: An emplace method which can be changed to call std::make_unique, and a toRef method which will dereference the pointer when applicable. Once all callers use these methods, we can change `activities` without fear.

Reviewed By: aaronenyeshi

Differential Revision: D36679292

