### PR TITLE
fix JSON output

### DIFF
--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -105,7 +105,7 @@ int RoctracerActivityApi::processActivities(
     a.flow.type = kLinkAsyncCpuGpu;
     a.flow.start = true;
 
-    a.addMetadata("ptr", item.ptr);
+    a.addMetadataQuoted("ptr", fmt::format("{}", item.ptr));
     if (item.cid == HIP_API_ID_hipMalloc) {
       a.addMetadata("size", item.size);
     }
@@ -128,12 +128,12 @@ int RoctracerActivityApi::processActivities(
     a.flow.type = kLinkAsyncCpuGpu;
     a.flow.start = true;
 
-    a.addMetadata("src", item.src);
-    a.addMetadata("dst", item.dst);
+    a.addMetadataQuoted("src", fmt::format("{}", item.src));
+    a.addMetadataQuoted("dst", fmt::format("{}", item.dst));
     a.addMetadata("size", item.size);
     a.addMetadata("kind", item.kind);
     if ((item.cid == HIP_API_ID_hipMemcpyAsync) || (item.cid == HIP_API_ID_hipMemcpyWithStream)) {
-      a.addMetadata("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
+      a.addMetadataQuoted("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
     }
 
     logger.handleGenericActivity(a);
@@ -166,7 +166,7 @@ int RoctracerActivityApi::processActivities(
     a.addMetadata("grid dim", fmt::format("[{}, {}, {}]", item.gridX, item.gridY, item.gridZ));
     a.addMetadata("block dim", fmt::format("[{}, {}, {}]", item.workgroupX, item.workgroupY, item.workgroupZ));
     a.addMetadata("shared size", item.groupSegmentSize);
-    a.addMetadata("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
+    a.addMetadataQuoted("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
 
     // Stash launches to tie to the async ops
     kernelLaunches_[a.id] = a;


### PR DESCRIPTION
Summary:
This patch fixes JSON format by quoting hex pointer values.

For example,
```
# Wrong since a hex value (for example 0x7f162bc09600) is not a number in JSON
  {
    "ph": "X", "cat": "cuda_runtime", "name": "hipMemcpyWithStream", "pid": 1468712, "tid": 1468712,
    "ts": 1655165458323941, "dur": 32,
    "args": {
      "External id": 30,
      "src": 0x7f162bc09600, "dst": 0x7f1c47af8c40, "size": 8, "kind": 2, "stream": 0x0
    }
  },
```
->
```
# Correct since hex values are quoted.
  {
    "ph": "X", "cat": "cuda_runtime", "name": "hipMemcpyWithStream", "pid": 1468712, "tid": 1468712,
    "ts": 1655165458323941, "dur": 32,
    "args": {
      "External id": 30,
      "src": "0x7f162bc09600", "dst": "0x7f1c47af8c40", "size": 8, "kind": 2, "stream": "0x0"
    }
  },
```
I could not find "ptr" in the log, but I believe "ptr" takes a hex value.

Differential Revision: D37128234

