### PR TITLE
Set flow end for kernel ops

### DIFF
--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -238,6 +238,7 @@ int RoctracerActivityApi::processActivities(
         a.activityName = std::string(name);
         a.flow.id = record->correlation_id;
         a.flow.type = kLinkAsyncCpuGpu;
+        a.flow.start = false;
 
         auto it = kernelNames_.find(record->correlation_id);
         if (it != kernelNames_.end()) {


### PR DESCRIPTION
Explicitly set the flow end on kernel ops from roctracer.  This was taking the default value.