### PR TITLE
Fix Copyright header for files in open source kineto project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ BSD License
 
 For Kineto software
 
-Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
 
 All contributions by Microsoft:
 Copyright (c) Microsoft Corporation. (The Azure AI Platform team)

--- a/README.md
+++ b/README.md
@@ -35,4 +35,3 @@ If you plan to contribute new features, please first open an issue and discuss t
 
 ## License
 Kineto has a BSD-style license, as found in the [LICENSE](LICENSE) file.
-

--- a/libkineto/include/AbstractConfig.h
+++ b/libkineto/include/AbstractConfig.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/include/ActivityProfilerInterface.h
+++ b/libkineto/include/ActivityProfilerInterface.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/include/ActivityTraceInterface.h
+++ b/libkineto/include/ActivityTraceInterface.h
@@ -1,9 +1,11 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace libkineto {
 

--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/include/ClientInterface.h
+++ b/libkineto/include/ClientInterface.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/include/IActivityProfiler.h
+++ b/libkineto/include/IActivityProfiler.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/include/ILoggerObserver.h
+++ b/libkineto/include/ILoggerObserver.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/include/ITraceActivity.h
+++ b/libkineto/include/ITraceActivity.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/include/ThreadUtil.h
+++ b/libkineto/include/ThreadUtil.h
@@ -1,3 +1,6 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
+
 #pragma once
 
 #include <cstdint>

--- a/libkineto/include/TraceSpan.h
+++ b/libkineto/include/TraceSpan.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 // Mediator for initialization and profiler control
 

--- a/libkineto/include/time_since_epoch.h
+++ b/libkineto/include/time_since_epoch.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.

--- a/libkineto/sample_programs/kineto_cupti_profiler.cpp
+++ b/libkineto/sample_programs/kineto_cupti_profiler.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -49,4 +50,3 @@ int main() {
   trace->save(kFileName);
   return 0;
 }
-

--- a/libkineto/sample_programs/kineto_playground.cpp
+++ b/libkineto/sample_programs/kineto_playground.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,4 +36,3 @@ int main() {
   trace->save(kFileName);
   return 0;
 }
-

--- a/libkineto/sample_programs/kineto_playground.cu
+++ b/libkineto/sample_programs/kineto_playground.cu
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <stdio.h>
 
@@ -19,7 +20,7 @@ void warmup(void) {
     return;
   }
 
-  cudaFree(mem); 
+  cudaFree(mem);
 }
 
 float *hA, *dA, *hOut;
@@ -69,7 +70,7 @@ __global__ void square(float* A, int N) {
 }
 
 void playground(void) {
-  // Add your experimental CUDA implementation here. 
+  // Add your experimental CUDA implementation here.
 }
 
 void compute(void) {

--- a/libkineto/sample_programs/kineto_playground.cuh
+++ b/libkineto/sample_programs/kineto_playground.cuh
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/sample_programs/kineto_stress_test.cpp
+++ b/libkineto/sample_programs/kineto_stress_test.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/libkineto/sample_programs/random_ops_stress_test.cu
+++ b/libkineto/sample_programs/random_ops_stress_test.cu
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <stdio.h>
 #include <unistd.h>

--- a/libkineto/sample_programs/random_ops_stress_test.cuh
+++ b/libkineto/sample_programs/random_ops_stress_test.cuh
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/AbstractConfig.cpp
+++ b/libkineto/src/AbstractConfig.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "AbstractConfig.h"
 

--- a/libkineto/src/ActivityBuffers.h
+++ b/libkineto/src/ActivityBuffers.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/ActivityLoggerFactory.h
+++ b/libkineto/src/ActivityLoggerFactory.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "ActivityProfilerController.h"
 

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "ActivityProfilerProxy.h"
 

--- a/libkineto/src/ActivityProfilerProxy.h
+++ b/libkineto/src/ActivityProfilerProxy.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/ActivityTrace.h
+++ b/libkineto/src/ActivityTrace.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "ActivityType.h"
 

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "Config.h"
 

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "ConfigLoader.h"
 

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CudaDeviceProperties.cpp
+++ b/libkineto/src/CudaDeviceProperties.cpp
@@ -1,9 +1,5 @@
-/*
- * Copyright (c) Kineto Contributors
- * All rights reserved.
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree.
- */
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "CudaDeviceProperties.h"
 

--- a/libkineto/src/CudaDeviceProperties.h
+++ b/libkineto/src/CudaDeviceProperties.h
@@ -1,9 +1,5 @@
-/*
- * Copyright (c) Kineto Contributors
- * All rights reserved.
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree.
- */
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiActivity.tpp
+++ b/libkineto/src/CuptiActivity.tpp
@@ -1,9 +1,5 @@
- /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree.
- */
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "CuptiActivity.h"
 

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "CuptiActivityApi.h"
 

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiActivityBuffer.h
+++ b/libkineto/src/CuptiActivityBuffer.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiActivityPlatform.cpp
+++ b/libkineto/src/CuptiActivityPlatform.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
+
 #include <chrono>
 
 namespace chrono = std::chrono;

--- a/libkineto/src/CuptiActivityPlatform.h
+++ b/libkineto/src/CuptiActivityPlatform.h
@@ -1,3 +1,6 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
+
 #pragma once
 
 #include <cstdint>

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "CuptiActivityProfiler.h"
 

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 
@@ -405,7 +406,7 @@ class CuptiActivityProfiler {
   std::vector<std::unique_ptr<IActivityProfilerSession>> sessions_;
 
   // Number of memory overhead events encountered during the session
-  uint32_t resourceOverheadCount_; 
+  uint32_t resourceOverheadCount_;
 
   // LoggerCollector to collect all LOGs during the trace
 #if !USE_GOOGLE_LOG

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "CuptiCallbackApi.h"
 

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiCallbackApiMock.h
+++ b/libkineto/src/CuptiCallbackApiMock.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiEventApi.cpp
+++ b/libkineto/src/CuptiEventApi.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "CuptiEventApi.h"
 

--- a/libkineto/src/CuptiEventApi.h
+++ b/libkineto/src/CuptiEventApi.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiMetricApi.cpp
+++ b/libkineto/src/CuptiMetricApi.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "CuptiMetricApi.h"
 

--- a/libkineto/src/CuptiMetricApi.h
+++ b/libkineto/src/CuptiMetricApi.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiNvPerfMetric.cpp
+++ b/libkineto/src/CuptiNvPerfMetric.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #ifdef HAS_CUPTI
 #include <cuda_runtime_api.h>

--- a/libkineto/src/CuptiNvPerfMetric.h
+++ b/libkineto/src/CuptiNvPerfMetric.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiRangeProfiler.cpp
+++ b/libkineto/src/CuptiRangeProfiler.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <Logger.h>
 #include <functional>

--- a/libkineto/src/CuptiRangeProfiler.h
+++ b/libkineto/src/CuptiRangeProfiler.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiRangeProfilerApi.cpp
+++ b/libkineto/src/CuptiRangeProfilerApi.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/libkineto/src/CuptiRangeProfilerApi.h
+++ b/libkineto/src/CuptiRangeProfilerApi.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/CuptiRangeProfilerConfig.cpp
+++ b/libkineto/src/CuptiRangeProfilerConfig.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <CuptiRangeProfilerConfig.h>
 #include <Logger.h>

--- a/libkineto/src/CuptiRangeProfilerConfig.h
+++ b/libkineto/src/CuptiRangeProfilerConfig.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/DaemonConfigLoader.h
+++ b/libkineto/src/DaemonConfigLoader.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/Demangle.cpp
+++ b/libkineto/src/Demangle.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "Demangle.h"
 

--- a/libkineto/src/Demangle.h
+++ b/libkineto/src/Demangle.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/EventProfiler.cpp
+++ b/libkineto/src/EventProfiler.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "EventProfiler.h"
 

--- a/libkineto/src/EventProfiler.h
+++ b/libkineto/src/EventProfiler.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/EventProfilerController.cpp
+++ b/libkineto/src/EventProfilerController.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "EventProfilerController.h"
 

--- a/libkineto/src/EventProfilerController.h
+++ b/libkineto/src/EventProfilerController.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/GenericTraceActivity.cpp
+++ b/libkineto/src/GenericTraceActivity.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "GenericTraceActivity.h"
 #include "output_base.h"

--- a/libkineto/src/ILoggerObserver.cpp
+++ b/libkineto/src/ILoggerObserver.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/LoggerCollector.h
+++ b/libkineto/src/LoggerCollector.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "RoctracerActivityApi.h"
 

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 
@@ -170,4 +171,3 @@ class RoctracerActivityApi {
 };
 
 } // namespace KINETO_NAMESPACE
-

--- a/libkineto/src/RoctracerActivityBuffer.h
+++ b/libkineto/src/RoctracerActivityBuffer.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/SampleListener.h
+++ b/libkineto/src/SampleListener.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/ScopeExit.h
+++ b/libkineto/src/ScopeExit.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/ThreadUtil.cpp
+++ b/libkineto/src/ThreadUtil.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
+
 #include "ThreadUtil.h"
 
 #ifndef _MSC_VER

--- a/libkineto/src/WeakSymbols.cpp
+++ b/libkineto/src/WeakSymbols.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
+
 #include <stdexcept>
 
 #ifndef _MSC_VER

--- a/libkineto/src/cuda_call.h
+++ b/libkineto/src/cuda_call.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/cupti_call.h
+++ b/libkineto/src/cupti_call.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/cupti_strings.cpp
+++ b/libkineto/src/cupti_strings.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "cupti_strings.h"
 

--- a/libkineto/src/cupti_strings.h
+++ b/libkineto/src/cupti_strings.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <memory>
 #include <mutex>

--- a/libkineto/src/libkineto_api.cpp
+++ b/libkineto/src/libkineto_api.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "libkineto.h"
 

--- a/libkineto/src/output_base.h
+++ b/libkineto/src/output_base.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/output_csv.cpp
+++ b/libkineto/src/output_csv.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "output_csv.h"
 

--- a/libkineto/src/output_csv.h
+++ b/libkineto/src/output_csv.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 #include "SampleListener.h"

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "output_json.h"
 

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "include/Config.h"
 

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <fmt/format.h>
 #include <gmock/gmock.h>

--- a/libkineto/test/CuptiProfilerApiTest.cu
+++ b/libkineto/test/CuptiProfilerApiTest.cu
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <string>
 #include <fmt/format.h>

--- a/libkineto/test/CuptiRangeProfilerApiTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerApiTest.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <gtest/gtest.h>
 #include <array>

--- a/libkineto/test/CuptiRangeProfilerConfigTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerConfigTest.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "include/Config.h"
 #include "src/CuptiRangeProfilerConfig.h"

--- a/libkineto/test/CuptiRangeProfilerTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerTest.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <gtest/gtest.h>
 #include <array>

--- a/libkineto/test/CuptiRangeProfilerTestUtil.h
+++ b/libkineto/test/CuptiRangeProfilerTestUtil.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <stdlib.h>
 #include <unordered_map>

--- a/libkineto/test/CuptiStringsTest.cpp
+++ b/libkineto/test/CuptiStringsTest.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <gtest/gtest.h>
 

--- a/libkineto/test/EventProfilerTest.cpp
+++ b/libkineto/test/EventProfilerTest.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "src/EventProfiler.h"
 

--- a/libkineto/test/LoggerObserverTest.cpp
+++ b/libkineto/test/LoggerObserverTest.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <gtest/gtest.h>
 #include <memory>

--- a/libkineto/test/MockActivitySubProfiler.cpp
+++ b/libkineto/test/MockActivitySubProfiler.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include <memory>
 #include <set>

--- a/libkineto/test/MockActivitySubProfiler.h
+++ b/libkineto/test/MockActivitySubProfiler.h
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #pragma once
 

--- a/libkineto/test/PidInfoTest.cpp
+++ b/libkineto/test/PidInfoTest.cpp
@@ -1,4 +1,5 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// All rights reserved.
 
 #include "include/ThreadUtil.h"
 


### PR DESCRIPTION
Summary:
OSS Kineto files are failing Copyright header check. A snippet of the requirements include:
- Every project specific source file must contain a doc block with an appropriate copyright header.
- A copyright header clearly indicates that the code is owned by Facebook. Every open source file must start with a comment containing "Meta Platforms, Inc. and affiliates"

Reviewed By: briancoutinho

Differential Revision: D37386057

Pulled By: aaronenyeshi

