### PR TITLE
Don't wrap GenericTraceActivities in CuptiRangeProfiler and CuptiActivityProfiler

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <vector>
 #include <limits>
 
@@ -240,7 +241,13 @@ void CuptiActivityProfiler::processCpuTrace(
   for (auto const& act : cpuTrace.activities) {
     VLOG(2) << act->correlationId() << ": OP " << act->activityName;
     if (derivedConfig_->profileActivityTypes().count(act->type())) {
-      act->log(logger);
+      static_assert(
+          std::is_same<
+              std::remove_reference<decltype(act)>::type,
+              const std::unique_ptr<GenericTraceActivity>>::value,
+          "handleActivity is unsafe and relies on the caller to maintain not "
+          "only lifetime but also address stability.");
+      logger.handleActivity(*act);
     }
     clientActivityTraceMap_[act->correlationId()] = &span_pair;
     activityMap_[act->correlationId()] = act.get();

--- a/libkineto/src/CuptiRangeProfiler.cpp
+++ b/libkineto/src/CuptiRangeProfiler.cpp
@@ -3,6 +3,7 @@
 #include <Logger.h>
 #include <functional>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -200,7 +201,13 @@ void CuptiRangeProfilerSession::processTrace(ActivityLogger& logger) {
   }
 
   for (const auto& event : traceBuffer_.activities) {
-    logger.handleGenericActivity(*event);
+    static_assert(
+        std::is_same<
+            std::remove_reference<decltype(event)>::type,
+            const std::unique_ptr<GenericTraceActivity>>::value,
+        "handleActivity is unsafe and relies on the caller to maintain not "
+        "only lifetime but also address stability.");
+    logger.handleActivity(*event);
   }
 
   LOG(INFO) << "CUPTI Range Profiler added " << traceBuffer_.activities.size()


### PR DESCRIPTION
Summary:
Now that CpuTraceBuffer stores its activities as unique_ptr we can safely use the unsafe `handleActivity` method without having to worry about the internal storage details of the container.

@mwootton Is there an analogous change that we need to make for RocTracer?

To give some context: I agree with the assessment in https://github.com/pytorch/kineto/pull/553 that lifetime and ownership is not robustly handled in Kineto's internals. From the PyTorch profiler's perspective we want to be able to give Kineto an event and later be able to keep track of which events we provided and which events Kineto added. There isn't a concept of an ID in kineto events so instead I elected to use the address and just make the address stable.

Differential Revision: D37406957

