### PR TITLE
Add python stack tracing option on on-demand flow

### DIFF
--- a/libkineto/include/ClientInterface.h
+++ b/libkineto/include/ClientInterface.h
@@ -12,7 +12,7 @@ class ClientInterface {
   virtual ~ClientInterface() {}
   virtual void init() = 0;
   virtual void warmup(bool setupOpInputsCollection) = 0;
-  virtual void start() = 0;
+  virtual void start(bool withStack) = 0;
   virtual void stop() = 0;
 };
 

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -177,6 +177,10 @@ class Config : public AbstractConfig {
     return enableOpInputsCollection_;
   }
 
+  bool isPythonStackTraceEnabled() const {
+    return enablePythonStackTrace_;
+  }
+
   // Trace for this long
   std::chrono::milliseconds activitiesDuration() const {
     return activitiesDuration_;
@@ -389,6 +393,9 @@ class Config : public AbstractConfig {
   // Client Interface
   // Enable inputs collection when tracing ops
   bool enableOpInputsCollection_{true};
+
+  // Enable Python Stack Tracing
+  bool enablePythonStackTrace_{false};
 
   // Profile for specified iterations and duration
   std::chrono::milliseconds activitiesDuration_;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -66,6 +66,7 @@ constexpr char kActivitiesMaxGpuBufferSizeKey[] =
 
 // Client Interface
 constexpr char kClientInterfaceEnableOpInputsCollection[] = "CLIENT_INTERFACE_ENABLE_OP_INPUTS_COLLECTION";
+constexpr char kPythonStackTrace[] = "PYTHON_STACK_TRACE";
 
 constexpr char kActivitiesWarmupIterationsKey[] = "ACTIVITIES_WARMUP_ITERATIONS";
 constexpr char kActivitiesIterationsKey[] = "ACTIVITIES_ITERATIONS";
@@ -347,6 +348,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   // Client Interface
   else if (!name.compare(kClientInterfaceEnableOpInputsCollection)) {
     enableOpInputsCollection_ = toBool(val);
+  } else if (!name.compare(kPythonStackTrace)) {
+    enablePythonStackTrace_ = toBool(val);
   }
 
   // Common

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -58,6 +58,7 @@ ConfigDerivedState::ConfigDerivedState(const Config& config) {
     profileEndIter_ = (std::numeric_limits<decltype(profileEndIter_)>::max)();
     profileEndTime_ = profileStartTime_ + config.activitiesDuration();
   }
+  profileWithStack_ = config.isPythonStackTraceEnabled();
 }
 
 bool ConfigDerivedState::canStart(
@@ -750,7 +751,7 @@ const time_point<system_clock> CuptiActivityProfiler::performRunLoopStep(
         }
         startTrace(now);
         if (libkineto::api().client()) {
-          libkineto::api().client()->start();
+          libkineto::api().client()->start(derivedConfig_->profileWithPythonStack());
         }
         if (nextWakeupTime > derivedConfig_->profileEndTime()) {
           new_wakeup_time = derivedConfig_->profileEndTime();

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -83,6 +83,7 @@ struct ConfigDerivedState final {
   int64_t profileStartIteration() const { return profileStartIter_; }
   int64_t profileEndIteration() const { return profileEndIter_; }
   bool isProfilingByIteration() const { return profilingByIter_; }
+  bool profileWithPythonStack() const { return profileWithStack_; }
 
  private:
   std::set<ActivityType> profileActivityTypes_;
@@ -94,6 +95,7 @@ struct ConfigDerivedState final {
   int64_t profileStartIter_ {-1};
   int64_t profileEndIter_ {-1};
   bool profilingByIter_ {false};
+  bool profileWithStack_ {false};
 };
 
 class CuptiActivityProfiler {


### PR DESCRIPTION
Summary:
Changes:
1. add an option in Config; can use 'PYTHON_STACK_TRACE=true' option (via .conf)
2. deliver PYTHON_STACK_TRACE value to kineto_client_interface start()
3. abstract class also changed.

Differential Revision: D37410204

