### PR TITLE
Ensure both on-demand and auto-trace signals post proc to UST

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -301,11 +301,12 @@ void ActivityProfilerController::startTrace() {
 std::unique_ptr<ActivityTraceInterface> ActivityProfilerController::stopTrace() {
   profiler_->stopTrace(std::chrono::system_clock::now());
   UST_LOGGER_MARK_COMPLETED(kCollectionStage);
+  // Note: kPostProcessingStage marked in the destructor of ActivityTrace.
 
   auto logger = std::make_unique<MemoryTraceLogger>(profiler_->config());
   profiler_->processTrace(*logger);
   profiler_->reset();
-  return std::make_unique<ActivityTrace>(std::move(logger), loggerFactory());
+  return std::make_unique<ActivityTrace>(std::move(logger), loggerFactory(), true);
 }
 
 void ActivityProfilerController::addMetadata(

--- a/libkineto/src/ActivityTrace.cpp
+++ b/libkineto/src/ActivityTrace.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "ActivityTrace.h"
+
+#include <kineto/libkineto/src/Logger.h>
+
+namespace libkineto {
+
+ActivityTrace::~ActivityTrace() {
+  // Allow any loggers to finish saving (or not), before marking complete.
+  // This allows us to track post process sample, and save any urls.
+  if(pushToUST) {
+    UST_LOGGER_MARK_COMPLETED(kPostProcessingStage);
+  }
+}
+
+const std::vector<const ITraceActivity*>* ActivityTrace::activities() {
+  return memLogger_->traceActivities();
+};
+
+void ActivityTrace::save(const std::string& url) {
+  std::string prefix;
+  // if no protocol is specified, default to file
+  if (url.find("://") == url.npos) {
+    prefix = "file://";
+  }
+  memLogger_->log(*loggerFactory_.makeLogger(prefix + url));
+};
+
+
+} // namespace libkineto

--- a/libkineto/src/ActivityTrace.h
+++ b/libkineto/src/ActivityTrace.h
@@ -19,23 +19,15 @@ class ActivityTrace : public ActivityTraceInterface {
  public:
   ActivityTrace(
       std::unique_ptr<MemoryTraceLogger> tmpLogger,
-      const ActivityLoggerFactory& factory)
+      const ActivityLoggerFactory& factory,
+      bool shouldPushToUST = false)
     : memLogger_(std::move(tmpLogger)),
-      loggerFactory_(factory) {
+      loggerFactory_(factory),
+      pushToUST(shouldPushToUST) {
   }
-
-  const std::vector<const ITraceActivity*>* activities() override {
-    return memLogger_->traceActivities();
-  };
-
-  void save(const std::string& url) override {
-    std::string prefix;
-    // if no protocol is specified, default to file
-    if (url.find("://") == url.npos) {
-      prefix = "file://";
-    }
-    memLogger_->log(*loggerFactory_.makeLogger(prefix + url));
-  };
+  ~ActivityTrace() override;
+  const std::vector<const ITraceActivity*>* activities() override;
+  void save(const std::string& url) override;
 
  private:
   // Activities are logged into a buffer
@@ -43,6 +35,8 @@ class ActivityTrace : public ActivityTraceInterface {
 
   // Alternative logger used by save() if protocol prefix is specified
   const ActivityLoggerFactory& loggerFactory_;
+
+  bool pushToUST;
 };
 
 } // namespace libkineto

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -789,7 +789,6 @@ const time_point<system_clock> CuptiActivityProfiler::performRunLoopStep(
         std::lock_guard<std::mutex> guard(mutex_);
         stopTraceInternal(now);
         VLOG_IF(0, collection_done) << "Reached profile end time";
-
         UST_LOGGER_MARK_COMPLETED(kCollectionStage);
       } else if (derivedConfig_->isProfilingByIteration()) {
         // nothing to do here
@@ -813,6 +812,7 @@ const time_point<system_clock> CuptiActivityProfiler::performRunLoopStep(
       // for quickly handling trace request via synchronous API
       std::lock_guard<std::mutex> guard(mutex_);
       processTraceInternal(*logger_);
+      UST_LOGGER_MARK_COMPLETED(kPostProcessingStage);
       resetInternal();
       VLOG(0) << "ProcessTrace -> WaitForRequest";
       break;

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -360,7 +360,9 @@ void ChromeTraceLogger::handleLink(
   // clang-format on
 }
 
-void ChromeTraceLogger::finalizeTraceInternal(
+void ChromeTraceLogger::finalizeTrace(
+    const Config& /*unused*/,
+    std::unique_ptr<ActivityBuffers> /*unused*/,
     int64_t endTime,
     std::unordered_map<std::string, std::vector<std::string>>& metadata) {
   if (!traceOf_) {
@@ -411,12 +413,4 @@ void ChromeTraceLogger::finalizeTraceInternal(
   traceOf_.close();
 }
 
-void ChromeTraceLogger::finalizeTrace(
-    const Config& /*unused*/,
-    std::unique_ptr<ActivityBuffers> /*unused*/,
-    int64_t endTime,
-    std::unordered_map<std::string, std::vector<std::string>>& metadata) {
-  ChromeTraceLogger::finalizeTraceInternal(endTime, metadata);
-  UST_LOGGER_MARK_COMPLETED(kPostProcessingStage);
-}
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -55,11 +55,6 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
     return fileName_;
   }
 
- protected:
-  void finalizeTraceInternal(
-  int64_t endTime,
-  std::unordered_map<std::string, std::vector<std::string>>& metadata);
-
  private:
 
   // Create a flow event (arrow)


### PR DESCRIPTION
Summary:
There are two cases to handle:
  1) ActivityProfilerController API used by PyTorch Profiler and Auto-Trace
  2) CuptiActivityProfiler's RunLoop used by On-Demand tracing.

This patch ensures both will call the UST_LOGGER_MARK_COMPLETED API with the 3 stages: WarmUp, Collection, and PostProcessing.

Differential Revision: D37693168

Pulled By: aaronenyeshi

