### PR TITLE
Disable test_profiler_api_without_gpu in TB CI

### DIFF
--- a/tb_plugin/test/test_compare_with_autograd.py
+++ b/tb_plugin/test/test_compare_with_autograd.py
@@ -275,6 +275,7 @@ class TestCompareWithAutogradResult(unittest.TestCase):
             get_train_func(use_gpu)(13, p)
         self.compare_results(log_dir, profilers_dict, use_gpu, record_shapes, with_stack)
 
+    @pytest.mark.skip(reason='This type of test should be in PyTorch CI')
     def test_profiler_api_without_gpu(self):
         self.base_profiler_api(False, True, True, False)
 


### PR DESCRIPTION
As discussed with Taylor in https://github.com/pytorch/kineto/pull/631, test_profiler_api_without_gpu should be disabled in TB_Plugin_CI, and if we want this to exist, it should exist in PyTorch CI.