### PR TITLE
Refactor Roctracer support.  Add external correlation id support.

### DIFF
--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -64,7 +64,7 @@ class GenericTraceActivity : public ITraceActivity {
   }
 
   const ITraceActivity* linkedActivity() const override {
-    return nullptr;
+    return linked;
   }
 
   int flowType() const override {
@@ -122,6 +122,7 @@ class GenericTraceActivity : public ITraceActivity {
     uint32_t type : 4;
     uint32_t start : 1;
   } flow;
+  const ITraceActivity* linked{nullptr};
 
  private:
   const TraceSpan* traceSpan_;

--- a/libkineto/include/ThreadUtil.h
+++ b/libkineto/include/ThreadUtil.h
@@ -28,3 +28,7 @@ std::string processName(int32_t pid);
 std::vector<std::pair<int32_t, std::string>> pidCommandPairsOfAncestors();
 
 } // namespace libkineto
+
+#ifdef HAS_ROCTRACER
+using namespace libkineto;
+#endif

--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -32,6 +32,7 @@ def get_libkineto_cupti_srcs(with_api = True):
 def get_libkineto_roctracer_srcs(with_api = True):
     return [
         "src/RoctracerActivityApi.cpp",
+        "src/RoctracerLogger.cpp",
     ] + (get_libkineto_cpu_only_srcs(with_api))
 
 def get_libkineto_cpu_only_srcs(with_api = True):

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -13,6 +13,9 @@
 #include "CuptiActivityApi.h"
 #include "Logger.h"
 #include <chrono>
+#ifdef HAS_ROCTRACER
+#include "RoctracerActivityApi.h"
+#endif
 
 namespace KINETO_NAMESPACE {
 
@@ -86,11 +89,20 @@ bool ActivityProfilerProxy::isActive() {
 void ActivityProfilerProxy::pushCorrelationId(uint64_t id) {
   CuptiActivityApi::pushCorrelationID(id,
     CuptiActivityApi::CorrelationFlowType::Default);
+#ifdef HAS_ROCTRACER
+  // FIXME: bad design here
+  RoctracerActivityApi::pushCorrelationID(id,
+    RoctracerActivityApi::CorrelationFlowType::Default);
+#endif
 }
 
 void ActivityProfilerProxy::popCorrelationId() {
   CuptiActivityApi::popCorrelationID(
     CuptiActivityApi::CorrelationFlowType::Default);
+#ifdef HAS_ROCTRACER
+  RoctracerActivityApi::popCorrelationID(
+    RoctracerActivityApi::CorrelationFlowType::Default);
+#endif
 }
 
 void ActivityProfilerProxy::pushUserCorrelationId(uint64_t id) {

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -218,7 +218,9 @@ void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
 #ifdef HAS_ROCTRACER
   if (!cpuOnly_) {
     VLOG(0) << "Retrieving GPU activity buffers";
-    const int count = cupti_.processActivities(logger);
+    const int count = cupti_.processActivities(
+        logger,
+        std::bind(&CuptiActivityProfiler::cpuActivity, this, std::placeholders::_1));
     LOG(INFO) << "Processed " << count << " GPU records";
     LOGGER_OBSERVER_ADD_EVENT_COUNT(count);
   }
@@ -547,6 +549,11 @@ void CuptiActivityProfiler::handleCuptiActivity(
   }
 }
 #endif // HAS_CUPTI
+
+const ITraceActivity* CuptiActivityProfiler::cpuActivity(int32_t correlationId) {
+    const auto& it2 = activityMap_.find(correlationId);
+    return (it2 != activityMap_.end()) ? it2->second : nullptr;
+}
 
 void CuptiActivityProfiler::configureChildProfilers() {
   // If child profilers are enabled create profiler sessions

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -296,6 +296,8 @@ class CuptiActivityProfiler {
       int32_t correlationId,
       const std::unordered_map<int64_t, int64_t>& correlationMap);
 
+  const ITraceActivity* cpuActivity(int32_t correlationId);
+
 #ifdef HAS_CUPTI
   // Process generic CUPTI activity
   void handleCuptiActivity(const CUpti_Activity* record, ActivityLogger* logger);

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -6,12 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "RoctracerActivityApi.h"
-
 #include <cstring>
 #include <chrono>
 #include <time.h>
 
+#include "RoctracerActivityApi.h"
+#include "RoctracerLogger.h"
 #include "Demangle.h"
 #include "output_base.h"
 #include "ThreadUtil.h"
@@ -33,8 +33,8 @@ RoctracerActivityApi& RoctracerActivityApi::singleton() {
   return instance;
 }
 
-RoctracerActivityApi::RoctracerActivityApi() {
-  gpuTraceBuffers_ = std::make_unique<std::list<RoctracerActivityBuffer>>();
+RoctracerActivityApi::RoctracerActivityApi()
+: d(&RoctracerLogger::singleton()) {
 }
 
 RoctracerActivityApi::~RoctracerActivityApi() {
@@ -44,24 +44,25 @@ RoctracerActivityApi::~RoctracerActivityApi() {
 
 void RoctracerActivityApi::pushCorrelationID(int id, CorrelationFlowType type) {
 #ifdef HAS_ROCTRACER
-  if (!singleton().externalCorrelationEnabled_) {
+  if (!singleton().d->externalCorrelationEnabled_) {
     return;
   }
-  // placeholder
+  singleton().d->pushCorrelationID(id, static_cast<RoctracerLogger::CorrelationDomain>(type));
 #endif
 }
 
 void RoctracerActivityApi::popCorrelationID(CorrelationFlowType type) {
 #ifdef HAS_ROCTRACER
-  if (!singleton().externalCorrelationEnabled_) {
+  if (!singleton().d->externalCorrelationEnabled_) {
     return;
   }
-  // placeholder
+  singleton().d->popCorrelationID(static_cast<RoctracerLogger::CorrelationDomain>(type));
 #endif
 }
 
 void RoctracerActivityApi::setMaxBufferSize(int size) {
-  maxGpuBufferCount_ = 1 + size / kBufSize;
+  // FIXME: implement?
+  //maxGpuBufferCount_ = 1 + size / kBufSize;
 }
 
 int RoctracerActivityApi::processActivities(
@@ -80,7 +81,7 @@ int RoctracerActivityApi::processActivities(
 
   // Basic Api calls
 
-  for (auto &item : rows_) {
+  for (auto &item : d->rows_) {
     GenericTraceActivity a;
     a.startTime = (item.begin + toffset) / 1000;
     a.endTime = (item.end + toffset) / 1000;
@@ -98,7 +99,7 @@ int RoctracerActivityApi::processActivities(
   }
 
   // Malloc/Free calls
-  for (auto &item : mallocRows_) {
+  for (auto &item : d->mallocRows_) {
     GenericTraceActivity a;
     a.startTime = (item.begin + toffset) / 1000;
     a.endTime = (item.end + toffset) / 1000;
@@ -121,7 +122,7 @@ int RoctracerActivityApi::processActivities(
   }
 
   // HipMemcpy calls
-  for (auto &item : copyRows_) {
+  for (auto &item : d->copyRows_) {
     GenericTraceActivity a;
     a.startTime = (item.begin + toffset) / 1000;
     a.endTime = (item.end + toffset) / 1000;
@@ -148,7 +149,7 @@ int RoctracerActivityApi::processActivities(
 
   // Kernel Launch Api calls
 
-  for (auto &item : kernelRows_) {
+  for (auto &item : d->kernelRows_) {
     GenericTraceActivity a;
     a.startTime = (item.begin + toffset) / 1000;
     a.endTime = (item.end + toffset) / 1000;
@@ -201,13 +202,13 @@ int RoctracerActivityApi::processActivities(
 
   // Async Ops
 
-  for (auto& buffer : *gpuTraceBuffers_) {
-    const roctracer_record_t* record = (const roctracer_record_t*)(buffer.data);
-    const roctracer_record_t* end_record = (const roctracer_record_t*)(buffer.data + buffer.validSize);
+  for (auto& buffer : *d->gpuTraceBuffers_) {
+    const roctracer_record_t* record = (const roctracer_record_t*)(buffer.data_);
+    const roctracer_record_t* end_record = (const roctracer_record_t*)(buffer.data_ + buffer.validSize_);
     GenericTraceActivity a;
 
     while (record < end_record) {
-      if ((record->domain == ACTIVITY_DOMAIN_HIP_API) && (loggedIds_.contains(record->op))) {
+      if (record->domain == ACTIVITY_DOMAIN_HIP_API) {
         const char *name = roctracer_op_string(record->domain, record->op, record->kind);
         a.device = record->process_id;
         a.resource = record->thread_id;
@@ -262,316 +263,34 @@ int RoctracerActivityApi::processActivities(
 }
 
 void RoctracerActivityApi::clearActivities() {
-  gpuTraceBuffers_->clear();
-  rows_.clear();
-  kernelRows_.clear();
-  copyRows_.clear();
-  mallocRows_.clear();
-  kernelLaunches_.clear();
+  d->clearLogs();
 }
 
-void RoctracerActivityApi::api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg)
-{
-  RoctracerActivityApi *dis = &singleton();
-
-  if (domain == ACTIVITY_DOMAIN_HIP_API && dis->loggedIds_.contains(cid)) {
-    const hip_api_data_t* data = (const hip_api_data_t*)(callback_data);
-
-    // Pack callbacks into row structures
-
-    thread_local timespec timestamp;
-
-    if (data->phase == ACTIVITY_API_PHASE_ENTER) {
-      clock_gettime(CLOCK_MONOTONIC, &timestamp);  // record proper clock
-    }
-    else { // (data->phase == ACTIVITY_API_PHASE_EXIT)
-      timespec endTime;
-      timespec startTime { timestamp };
-      clock_gettime(CLOCK_MONOTONIC, &endTime);  // record proper clock
-      std::unique_lock<std::mutex> lock(dis->mutex_);
-
-      switch (cid) {
-        case HIP_API_ID_hipLaunchKernel:
-        case HIP_API_ID_hipExtLaunchKernel:
-        case HIP_API_ID_hipLaunchCooperativeKernel:     // Should work here
-          {
-          auto &args = data->args.hipLaunchKernel;
-          dis->kernelRows_.emplace_back(data->correlation_id,
-                              domain,
-                              cid,
-                              processId(),
-                              systemThreadId(),
-                              timespec_to_ns(startTime),
-                              timespec_to_ns(endTime),
-                              args.function_address,
-                              nullptr,
-                              args.numBlocks.x,
-                              args.numBlocks.y,
-                              args.numBlocks.z,
-                              args.dimBlocks.x,
-                              args.dimBlocks.y,
-                              args.dimBlocks.z,
-                              args.sharedMemBytes,
-                              args.stream
-                            );
-          }
-          break;
-        case HIP_API_ID_hipHccModuleLaunchKernel:
-        case HIP_API_ID_hipModuleLaunchKernel:
-        case HIP_API_ID_hipExtModuleLaunchKernel:
-          {
-          auto &args = data->args.hipModuleLaunchKernel;
-          dis->kernelRows_.emplace_back(data->correlation_id,
-                              domain,
-                              cid,
-                              processId(),
-                              systemThreadId(),
-                              timespec_to_ns(startTime),
-                              timespec_to_ns(endTime),
-                              nullptr,
-                              args.f,
-                              args.gridDimX,
-                              args.gridDimY,
-                              args.gridDimZ,
-                              args.blockDimX,
-                              args.blockDimY,
-                              args.blockDimZ,
-                              args.sharedMemBytes,
-                              args.stream
-                            );
-          }
-          break;
-        case HIP_API_ID_hipLaunchCooperativeKernelMultiDevice:
-        case HIP_API_ID_hipExtLaunchMultiKernelMultiDevice:
-#if 0
-          {
-            auto &args = data->args.hipLaunchCooperativeKernelMultiDevice.launchParamsList__val;
-            dis->kernelRows_.emplace_back(data->correlation_id,
-                              domain,
-                              cid,
-                              processId(),
-                              systemThreadId(),
-                              timespec_to_ns(startTime),
-                              timespec_to_ns(endTime),
-                              args.function_address,
-                              nullptr,
-                              args.numBlocks.x,
-                              args.numBlocks.y,
-                              args.numBlocks.z,
-                              args.dimBlocks.x,
-                              args.dimBlocks.y,
-                              args.dimBlocks.z,
-                              args.sharedMemBytes,
-                              args.stream
-                            );
-          }
-#endif
-          break;
-        case HIP_API_ID_hipMalloc:
-            dis->mallocRows_.emplace_back(data->correlation_id,
-                              domain,
-                              cid,
-                              processId(),
-                              systemThreadId(),
-                              timespec_to_ns(startTime),
-                              timespec_to_ns(endTime),
-                              data->args.hipMalloc.ptr__val,
-                              data->args.hipMalloc.size
-                              );
-          break;
-        case HIP_API_ID_hipFree:
-            dis->mallocRows_.emplace_back(data->correlation_id,
-                              domain,
-                              cid,
-                              processId(),
-                              systemThreadId(),
-                              timespec_to_ns(startTime),
-                              timespec_to_ns(endTime),
-                              data->args.hipFree.ptr,
-                              0
-                              );
-          break;
-        case HIP_API_ID_hipMemcpy:
-          {
-            auto &args = data->args.hipMemcpy;
-            dis->copyRows_.emplace_back(data->correlation_id,
-                              domain,
-                              cid,
-                              processId(),
-                              systemThreadId(),
-                              timespec_to_ns(startTime),
-                              timespec_to_ns(endTime),
-                              args.src,
-                              args.dst,
-                              args.sizeBytes,
-                              args.kind,
-                              static_cast<hipStream_t>(0)  // use placeholder?
-                              );
-          }
-          break;
-        case HIP_API_ID_hipMemcpyAsync:
-        case HIP_API_ID_hipMemcpyWithStream:
-          {
-            auto &args = data->args.hipMemcpyAsync;
-            dis->copyRows_.emplace_back(data->correlation_id,
-                              domain,
-                              cid,
-                              processId(),
-                              systemThreadId(),
-                              timespec_to_ns(startTime),
-                              timespec_to_ns(endTime),
-                              args.src,
-                              args.dst,
-                              args.sizeBytes,
-                              args.kind,
-                              args.stream
-                              );
-          }
-          break;
-        default:
-          dis->rows_.emplace_back(data->correlation_id,
-                              domain,
-                              cid,
-                              processId(),
-                              systemThreadId(),
-                              timespec_to_ns(startTime),
-                              timespec_to_ns(endTime)
-                              );
-          break;
-      }
-    }
-  }
-}
-
-void RoctracerActivityApi::activity_callback(const char* begin, const char* end, void* arg)
-{
-  size_t size = end - begin;
-  uint8_t *buffer = (uint8_t*) malloc(size);
-  auto &gpuTraceBuffers = singleton().gpuTraceBuffers_;
-  memcpy(buffer, begin, size);
-  gpuTraceBuffers->emplace_back(buffer, size);
-}
 
 void RoctracerActivityApi::enableActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_ROCTRACER
-  if (!registered_) {
-    roctracer_set_properties(ACTIVITY_DOMAIN_HIP_API, nullptr);  // Magic encantation
-
-    // Set some api calls to ignore
-    loggedIds_.setInvertMode(true);  // Omit the specified api
-    loggedIds_.add("hipGetDevice");
-    loggedIds_.add("hipSetDevice");
-    loggedIds_.add("hipGetLastError");
-    loggedIds_.add("__hipPushCallConfiguration");
-    loggedIds_.add("__hipPopCallConfiguration");
-    loggedIds_.add("hipCtxSetCurrent");
-    loggedIds_.add("hipEventRecord");
-    loggedIds_.add("hipEventQuery");
-    loggedIds_.add("hipGetDeviceProperties");
-    loggedIds_.add("hipPeekAtLastError");
-    loggedIds_.add("hipModuleGetFunction");
-    loggedIds_.add("hipEventCreateWithFlags");
-
-    // Enable API callbacks
-    if (loggedIds_.invertMode() == true) {
-        // exclusion list - enable entire domain and turn off things in list
-        roctracer_enable_domain_callback(ACTIVITY_DOMAIN_HIP_API, api_callback, nullptr);
-        const std::unordered_map<uint32_t, uint32_t> &filter = loggedIds_.filterList();
-        for (auto it = filter.begin(); it != filter.end(); ++it) {
-            roctracer_disable_op_callback(ACTIVITY_DOMAIN_HIP_API, it->first);
-        }
-    }
-    else {
-        // inclusion list - only enable things in the list
-        const std::unordered_map<uint32_t, uint32_t> &filter = loggedIds_.filterList();
-        roctracer_disable_domain_callback(ACTIVITY_DOMAIN_HIP_API);
-        for (auto it = filter.begin(); it != filter.end(); ++it) {
-            roctracer_enable_op_callback(ACTIVITY_DOMAIN_HIP_API, it->first, api_callback, nullptr);
-        }
-    }
-    //roctracer_enable_domain_callback(ACTIVITY_DOMAIN_ROCTX, api_callback, nullptr);
-
-    // Allocate default tracing pool
-    roctracer_properties_t properties;
-    memset(&properties, 0, sizeof(roctracer_properties_t));
-    properties.buffer_size = 0x1000;
-    roctracer_open_pool(&properties);
-
-    // Enable async op collection
-    roctracer_properties_t hcc_cb_properties;
-    memset(&hcc_cb_properties, 0, sizeof(roctracer_properties_t));
-    hcc_cb_properties.buffer_size = 0x4000;
-    hcc_cb_properties.buffer_callback_fun = activity_callback;
-    roctracer_open_pool_expl(&hcc_cb_properties, &hccPool_);
-    roctracer_enable_domain_activity_expl(ACTIVITY_DOMAIN_HCC_OPS, hccPool_);
-
-    registered_ = true;
-  }
+  d->startLogging();
 
   for (const auto& activity : selected_activities) {
     if (activity == ActivityType::EXTERNAL_CORRELATION) {
-        externalCorrelationEnabled_ = true;
+        d->externalCorrelationEnabled_ = true;
     }
   }
-
-  roctracer_start();
 #endif
 }
 
 void RoctracerActivityApi::disableActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_ROCTRACER
-  roctracer_stop();
-  roctracer_flush_activity_expl(hccPool_);
+  d->stopLogging();
 
   for (const auto& activity : selected_activities) {
     if (activity == ActivityType::EXTERNAL_CORRELATION) {
-        externalCorrelationEnabled_ = false;
+        d->externalCorrelationEnabled_ = false;
     }
   }
 #endif
-}
-
-void RoctracerActivityApi::endTracing() {
-  if (registered_ == true) {
-    roctracer_disable_domain_callback(ACTIVITY_DOMAIN_HIP_API);
-    //roctracer_disable_domain_callback(ACTIVITY_DOMAIN_ROCTX);
-
-    roctracer_disable_domain_activity(ACTIVITY_DOMAIN_HCC_OPS);
-    roctracer_close_pool_expl(hccPool_);
-  }
-}
-
-
-ApiIdList::ApiIdList()
-: invert_(true)
-{
-}
-
-void ApiIdList::add(std::string apiName)
-{
-  uint32_t cid = 0;
-  if (roctracer_op_code(ACTIVITY_DOMAIN_HIP_API, apiName.c_str(), &cid, nullptr) == ROCTRACER_STATUS_SUCCESS) {
-    filter_[cid] = 1;
-  }
-}
-void ApiIdList::remove(std::string apiName)
-{
-  uint32_t cid = 0;
-  if (roctracer_op_code(ACTIVITY_DOMAIN_HIP_API, apiName.c_str(), &cid, nullptr) == ROCTRACER_STATUS_SUCCESS) {
-    filter_.erase(cid);
-  }
-}
-
-bool ApiIdList::loadUserPrefs()
-{
-  // placeholder
-  return false;
-}
-bool ApiIdList::contains(uint32_t apiId)
-{
-  return (filter_.find(apiId) != filter_.end()) ? !invert_ : invert_;  // XOR
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -39,7 +39,6 @@ RoctracerActivityApi::RoctracerActivityApi()
 
 RoctracerActivityApi::~RoctracerActivityApi() {
   disableActivities(std::set<ActivityType>());
-  d->endTracing();
 }
 
 void RoctracerActivityApi::pushCorrelationID(int id, CorrelationFlowType type) {

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -58,7 +58,8 @@ class RoctracerActivityApi {
     const std::set<ActivityType>& selected_activities);
   void clearActivities();
 
-  int processActivities(ActivityLogger& logger);
+  int processActivities(ActivityLogger& logger
+                        , std::function<const ITraceActivity*(int32_t)> linkedActivity);
 
   void setMaxBufferSize(int size);
 
@@ -66,7 +67,6 @@ class RoctracerActivityApi {
 
  private:
   bool registered_{false};
-  void endTracing();
 
   //Name cache
   uint32_t nextStringId_{2};

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -20,13 +20,6 @@
 #include "ActivityType.h"
 #include "GenericTraceActivity.h"
 
-
-//#include "core/common/profiler_common.h"
-
-#ifdef HAS_ROCTRACER
-
-#endif
-
 class RoctracerLogger;
 class roctracerRow;
 
@@ -58,8 +51,8 @@ class RoctracerActivityApi {
     const std::set<ActivityType>& selected_activities);
   void clearActivities();
 
-  int processActivities(ActivityLogger& logger
-                        , std::function<const ITraceActivity*(int32_t)> linkedActivity);
+  int processActivities(ActivityLogger& logger,
+                        std::function<const ITraceActivity*(int32_t)> linkedActivity);
 
   void setMaxBufferSize(int size);
 

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -8,111 +8,31 @@
 
 #pragma once
 
-#include <functional>
-#include <list>
-#include <memory>
-#include <set>
 #include <vector>
 #include <map>
-#include <unordered_map>
-#include <deque>
+#include <set>
 #include <atomic>
-#include <mutex>
 
 #ifdef HAS_ROCTRACER
 #include <roctracer.h>
-#include <roctracer_hcc.h>
-#include <roctracer_hip.h>
-#include <roctracer_ext.h>
-#include <roctracer_roctx.h>
 #endif
 
 #include "ActivityType.h"
 #include "GenericTraceActivity.h"
-#include "RoctracerActivityBuffer.h"
 
+
+//#include "core/common/profiler_common.h"
+
+#ifdef HAS_ROCTRACER
+
+#endif
+
+class RoctracerLogger;
+class roctracerRow;
 
 namespace KINETO_NAMESPACE {
 
 using namespace libkineto;
-
-class ApiIdList
-{
-public:
-  ApiIdList();
-  bool invertMode() { return invert_; }
-  void setInvertMode(bool invert) { invert_ = invert; }
-  void add(std::string apiName);
-  void remove(std::string apiName);
-  bool loadUserPrefs();
-  bool contains(uint32_t apiId);
-  const std::unordered_map<uint32_t, uint32_t> &filterList() { return filter_; }
-
-private:
-  std::unordered_map<uint32_t, uint32_t> filter_;
-  bool invert_;
-};
-
-struct roctracerRow {
-  roctracerRow(uint64_t id, uint32_t domain, uint32_t cid, uint32_t pid
-             , uint32_t tid, uint64_t begin, uint64_t end)
-    : id(id), domain(domain), cid(cid), pid(pid), tid(tid), begin(begin), end(end) {}
-  uint64_t id;  // correlation_id
-  uint32_t domain;
-  uint32_t cid;
-  uint32_t pid;
-  uint32_t tid;
-  uint64_t begin;
-  uint64_t end;
-};
-
-struct kernelRow : public roctracerRow {
-  kernelRow(uint64_t id, uint32_t domain, uint32_t cid, uint32_t pid
-          , uint32_t tid, uint64_t begin, uint64_t end
-          , const void *faddr, hipFunction_t function
-          , unsigned int gx, unsigned int gy, unsigned int gz
-          , unsigned int wx, unsigned int wy, unsigned int wz
-          , size_t gss, hipStream_t stream)
-    : roctracerRow(id, domain, cid, pid, tid, begin, end), functionAddr(faddr)
-    , function(function), gridX(gx), gridY(gy), gridZ(gz)
-    , workgroupX(wx), workgroupY(wy), workgroupZ(wz), groupSegmentSize(gss)
-    , stream(stream) {}
-  const void* functionAddr;
-  hipFunction_t function;
-  unsigned int gridX;
-  unsigned int gridY;
-  unsigned int gridZ;
-  unsigned int workgroupX;
-  unsigned int workgroupY;
-  unsigned int workgroupZ;
-  size_t groupSegmentSize;
-  hipStream_t stream;
-};
-
-struct copyRow : public roctracerRow {
-  copyRow(uint64_t id, uint32_t domain, uint32_t cid, uint32_t pid
-             , uint32_t tid, uint64_t begin, uint64_t end
-             , const void* src, const void *dst, size_t size, hipMemcpyKind kind
-             , hipStream_t stream)
-    : roctracerRow(id, domain, cid, pid, tid, begin, end)
-    , src(src), dst(dst), size(size), kind(kind), stream(stream) {}
-  const void *src;
-  const void *dst;
-  size_t size;
-  hipMemcpyKind kind;
-  hipStream_t stream;
-};
-
-struct mallocRow : public roctracerRow {
-  mallocRow(uint64_t id, uint32_t domain, uint32_t cid, uint32_t pid
-             , uint32_t tid, uint64_t begin, uint64_t end
-             , const void* ptr, size_t size)
-    : roctracerRow(id, domain, cid, pid, tid, begin, end)
-    , ptr(ptr), size(size) {}
-  const void *ptr;
-  size_t size;
-};
-
 
 class RoctracerActivityApi {
  public:
@@ -148,31 +68,15 @@ class RoctracerActivityApi {
   bool registered_{false};
   void endTracing();
 
-#ifdef HAS_ROCTRACER
-  roctracer_pool_t *hccPool_{NULL};
-  static void api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg);
-  static void activity_callback(const char* begin, const char* end, void* arg);
-
   //Name cache
   uint32_t nextStringId_{2};
   std::map<uint32_t, std::string> strings_;
   std::map<std::string, uint32_t> reverseStrings_;
   std::map<activity_correlation_id_t, uint32_t> kernelNames_;
 
-  ApiIdList loggedIds_;
-
-  // Api callback data
-  std::deque<roctracerRow> rows_;
-  std::deque<kernelRow> kernelRows_;
-  std::deque<copyRow> copyRows_;
-  std::deque<mallocRow> mallocRows_;
   std::map<activity_correlation_id_t, GenericTraceActivity> kernelLaunches_;
-  std::mutex mutex_;
-#endif
 
-  int maxGpuBufferCount_{0};
-  std::unique_ptr<std::list<RoctracerActivityBuffer>> gpuTraceBuffers_;
-  bool externalCorrelationEnabled_{true};
+  RoctracerLogger *d;
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -1,0 +1,353 @@
+#include "RoctracerLogger.h"
+
+#include <cstring>
+#include <chrono>
+#include <time.h>
+
+#include "ThreadUtil.h"
+
+typedef uint64_t timestamp_t;
+
+static timestamp_t timespec_to_ns(const timespec& time) {
+    return ((timestamp_t)time.tv_sec * 1000000000) + time.tv_nsec;
+  }
+
+using namespace std::chrono;
+
+constexpr size_t kBufSize(2 * 1024 * 1024);
+
+RoctracerLogger& RoctracerLogger::singleton() {
+  static RoctracerLogger instance;
+  return instance;
+}
+
+RoctracerLogger::RoctracerLogger() {
+  gpuTraceBuffers_ = std::make_unique<std::list<RoctracerActivityBuffer>>();
+}
+
+RoctracerLogger::~RoctracerLogger() {
+  stopLogging();
+  endTracing();
+}
+
+namespace {
+  thread_local std::deque<uint64_t> t_externalIds[RoctracerLogger::CorrelationDomain::size];
+}
+
+void RoctracerLogger::pushCorrelationID(uint64_t id, CorrelationDomain type) {
+  if (!singleton().externalCorrelationEnabled_) {
+    return;
+  }
+  t_externalIds[type].push_back(id);
+}
+
+void RoctracerLogger::popCorrelationID(CorrelationDomain type) {
+  if (!singleton().externalCorrelationEnabled_) {
+    return;
+  }
+  t_externalIds[type].pop_back();
+}
+
+void RoctracerLogger::clearLogs() {
+  rows_.clear();
+  kernelRows_.clear();
+  copyRows_.clear();
+  mallocRows_.clear();
+  gpuTraceBuffers_->clear();
+  for (int i = 0; i < CorrelationDomain::size; ++i) {
+    externalCorrelations_[i].clear();
+  }
+}
+
+void RoctracerLogger::api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg)
+{
+  RoctracerLogger *dis = &singleton();
+
+  if (domain == ACTIVITY_DOMAIN_HIP_API && dis->loggedIds_.contains(cid)) {
+    const hip_api_data_t* data = (const hip_api_data_t*)(callback_data);
+
+    // Pack callbacks into row structures
+
+    thread_local timespec timestamp;
+
+    if (data->phase == ACTIVITY_API_PHASE_ENTER) {
+      clock_gettime(CLOCK_MONOTONIC, &timestamp);  // record proper clock
+    }
+    else { // (data->phase == ACTIVITY_API_PHASE_EXIT)
+      timespec endTime;
+      timespec startTime { timestamp };
+      clock_gettime(CLOCK_MONOTONIC, &endTime);  // record proper clock
+
+      switch (cid) {
+        case HIP_API_ID_hipLaunchKernel:
+        case HIP_API_ID_hipExtLaunchKernel:
+        case HIP_API_ID_hipLaunchCooperativeKernel:     // Should work here
+          {
+          auto &args = data->args.hipLaunchKernel;
+          dis->kernelRows_.emplace_back(data->correlation_id,
+                              domain,
+                              cid,
+                              processId(),
+                              systemThreadId(),
+                              timespec_to_ns(startTime),
+                              timespec_to_ns(endTime),
+                              args.function_address,
+                              nullptr,
+                              args.numBlocks.x,
+                              args.numBlocks.y,
+                              args.numBlocks.z,
+                              args.dimBlocks.x,
+                              args.dimBlocks.y,
+                              args.dimBlocks.z,
+                              args.sharedMemBytes,
+                              args.stream
+                            );
+          }
+          break;
+        case HIP_API_ID_hipHccModuleLaunchKernel:
+        case HIP_API_ID_hipModuleLaunchKernel:
+        case HIP_API_ID_hipExtModuleLaunchKernel:
+          {
+          auto &args = data->args.hipModuleLaunchKernel;
+          dis->kernelRows_.emplace_back(data->correlation_id,
+                              domain,
+                              cid,
+                              processId(),
+                              systemThreadId(),
+                              timespec_to_ns(startTime),
+                              timespec_to_ns(endTime),
+                              nullptr,
+                              args.f,
+                              args.gridDimX,
+                              args.gridDimY,
+                              args.gridDimZ,
+                              args.blockDimX,
+                              args.blockDimY,
+                              args.blockDimZ,
+                              args.sharedMemBytes,
+                              args.stream
+                            );
+          }
+          break;
+        case HIP_API_ID_hipLaunchCooperativeKernelMultiDevice:
+        case HIP_API_ID_hipExtLaunchMultiKernelMultiDevice:
+#if 0
+          {
+            auto &args = data->args.hipLaunchCooperativeKernelMultiDevice.launchParamsList__val;
+            dis->kernelRows_.emplace_back(data->correlation_id,
+                              domain,
+                              cid,
+                              processId(),
+                              systemThreadId(),
+                              timespec_to_ns(startTime),
+                              timespec_to_ns(endTime),
+                              args.function_address,
+                              nullptr,
+                              args.numBlocks.x,
+                              args.numBlocks.y,
+                              args.numBlocks.z,
+                              args.dimBlocks.x,
+                              args.dimBlocks.y,
+                              args.dimBlocks.z,
+                              args.sharedMemBytes,
+                              args.stream
+                            );
+          }
+#endif
+          break;
+        case HIP_API_ID_hipMalloc:
+            dis->mallocRows_.emplace_back(data->correlation_id,
+                              domain,
+                              cid,
+                              processId(),
+                              systemThreadId(),
+                              timespec_to_ns(startTime),
+                              timespec_to_ns(endTime),
+                              data->args.hipMalloc.ptr__val,
+                              data->args.hipMalloc.size
+                              );
+          break;
+        case HIP_API_ID_hipFree:
+            dis->mallocRows_.emplace_back(data->correlation_id,
+                              domain,
+                              cid,
+                              processId(),
+                              systemThreadId(),
+                              timespec_to_ns(startTime),
+                              timespec_to_ns(endTime),
+                              data->args.hipFree.ptr,
+                              0
+                              );
+          break;
+        case HIP_API_ID_hipMemcpy:
+          {
+            auto &args = data->args.hipMemcpy;
+            dis->copyRows_.emplace_back(data->correlation_id,
+                              domain,
+                              cid,
+                              processId(),
+                              systemThreadId(),
+                              timespec_to_ns(startTime),
+                              timespec_to_ns(endTime),
+                              args.src,
+                              args.dst,
+                              args.sizeBytes,
+                              args.kind,
+                              static_cast<hipStream_t>(0)  // use placeholder?
+                              );
+          }
+          break;
+        case HIP_API_ID_hipMemcpyAsync:
+        case HIP_API_ID_hipMemcpyWithStream:
+          {
+            auto &args = data->args.hipMemcpyAsync;
+            dis->copyRows_.emplace_back(data->correlation_id,
+                              domain,
+                              cid,
+                              processId(),
+                              systemThreadId(),
+                              timespec_to_ns(startTime),
+                              timespec_to_ns(endTime),
+                              args.src,
+                              args.dst,
+                              args.sizeBytes,
+                              args.kind,
+                              args.stream
+                              );
+          }
+          break;
+        default:
+          dis->rows_.emplace_back(data->correlation_id,
+                              domain,
+                              cid,
+                              processId(),
+                              systemThreadId(),
+                              timespec_to_ns(startTime),
+                              timespec_to_ns(endTime)
+                              );
+          break;
+      }  // switch
+      // External correlation
+      for (int it = CorrelationDomain::begin; it < CorrelationDomain::end; ++it) {
+        if (t_externalIds[it].size() > 0) {
+          dis->externalCorrelations_[it][data->correlation_id] = t_externalIds[it].back();
+        }
+      }
+    }  // phase exit
+  }
+}
+
+void RoctracerLogger::activity_callback(const char* begin, const char* end, void* arg)
+{
+  size_t size = end - begin;
+  uint8_t *buffer = (uint8_t*) malloc(size);
+  auto &gpuTraceBuffers = singleton().gpuTraceBuffers_;
+  memcpy(buffer, begin, size);
+  gpuTraceBuffers->emplace_back(buffer, size);
+}
+
+void RoctracerLogger::startLogging() {
+  if (!registered_) {
+    roctracer_set_properties(ACTIVITY_DOMAIN_HIP_API, nullptr);  // Magic encantation
+
+    // Set some api calls to ignore
+    loggedIds_.setInvertMode(true);  // Omit the specified api
+    loggedIds_.add("hipGetDevice");
+    loggedIds_.add("hipSetDevice");
+    loggedIds_.add("hipGetLastError");
+    loggedIds_.add("__hipPushCallConfiguration");
+    loggedIds_.add("__hipPopCallConfiguration");
+    loggedIds_.add("hipCtxSetCurrent");
+    loggedIds_.add("hipEventRecord");
+    loggedIds_.add("hipEventQuery");
+    loggedIds_.add("hipGetDeviceProperties");
+    loggedIds_.add("hipPeekAtLastError");
+    loggedIds_.add("hipModuleGetFunction");
+    loggedIds_.add("hipEventCreateWithFlags");
+
+    // Enable API callbacks
+    if (loggedIds_.invertMode() == true) {
+        // exclusion list - enable entire domain and turn off things in list
+        roctracer_enable_domain_callback(ACTIVITY_DOMAIN_HIP_API, api_callback, nullptr);
+        const std::unordered_map<uint32_t, uint32_t> &filter = loggedIds_.filterList();
+        for (auto it = filter.begin(); it != filter.end(); ++it) {
+            roctracer_disable_op_callback(ACTIVITY_DOMAIN_HIP_API, it->first);
+        }
+    }
+    else {
+        // inclusion list - only enable things in the list
+        const std::unordered_map<uint32_t, uint32_t> &filter = loggedIds_.filterList();
+        roctracer_disable_domain_callback(ACTIVITY_DOMAIN_HIP_API);
+        for (auto it = filter.begin(); it != filter.end(); ++it) {
+            roctracer_enable_op_callback(ACTIVITY_DOMAIN_HIP_API, it->first, api_callback, nullptr);
+        }
+    }
+    //roctracer_enable_domain_callback(ACTIVITY_DOMAIN_ROCTX, api_callback, nullptr);
+
+    // Allocate default tracing pool
+    roctracer_properties_t properties;
+    memset(&properties, 0, sizeof(roctracer_properties_t));
+    properties.buffer_size = 0x1000;
+    roctracer_open_pool(&properties);
+
+    // Enable async op collection
+    roctracer_properties_t hcc_cb_properties;
+    memset(&hcc_cb_properties, 0, sizeof(roctracer_properties_t));
+    hcc_cb_properties.buffer_size = 0x4000;
+    hcc_cb_properties.buffer_callback_fun = activity_callback;
+    roctracer_open_pool_expl(&hcc_cb_properties, &hccPool_);
+    roctracer_enable_domain_activity_expl(ACTIVITY_DOMAIN_HCC_OPS, hccPool_);
+
+    registered_ = true;
+  }
+
+  externalCorrelationEnabled_ = true;
+  roctracer_start();
+}
+
+void RoctracerLogger::stopLogging() {
+  roctracer_stop();
+  roctracer_flush_activity_expl(hccPool_);
+}
+
+void RoctracerLogger::endTracing() {
+  if (registered_ == true) {
+    roctracer_disable_domain_callback(ACTIVITY_DOMAIN_HIP_API);
+    //roctracer_disable_domain_callback(ACTIVITY_DOMAIN_ROCTX);
+
+    roctracer_disable_domain_activity(ACTIVITY_DOMAIN_HCC_OPS);
+    roctracer_close_pool_expl(hccPool_);
+  }
+}
+
+
+ApiIdList::ApiIdList()
+: invert_(true)
+{
+}
+
+void ApiIdList::add(const std::string &apiName)
+{
+  uint32_t cid = 0;
+  if (roctracer_op_code(ACTIVITY_DOMAIN_HIP_API, apiName.c_str(), &cid, nullptr) == ROCTRACER_STATUS_SUCCESS) {
+    filter_[cid] = 1;
+  }
+}
+void ApiIdList::remove(const std::string &apiName)
+{
+  uint32_t cid = 0;
+  if (roctracer_op_code(ACTIVITY_DOMAIN_HIP_API, apiName.c_str(), &cid, nullptr) == ROCTRACER_STATUS_SUCCESS) {
+    filter_.erase(cid);
+  }
+}
+
+bool ApiIdList::loadUserPrefs()
+{
+  // placeholder
+  return false;
+}
+bool ApiIdList::contains(uint32_t apiId)
+{
+  return (filter_.find(apiId) != filter_.end()) ? !invert_ : invert_;  // XOR
+}
+

--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -317,6 +317,7 @@ void RoctracerLogger::endTracing() {
 
     roctracer_disable_domain_activity(ACTIVITY_DOMAIN_HCC_OPS);
     roctracer_close_pool_expl(hccPool_);
+    hccPool_ = nullptr;
   }
 }
 

--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -1,0 +1,175 @@
+#pragma once
+
+#include <functional>
+#include <list>
+#include <memory>
+#include <set>
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <deque>
+#include <atomic>
+
+#include <roctracer.h>
+#include <roctracer_hcc.h>
+#include <roctracer_hip.h>
+#include <roctracer_ext.h>
+#include <roctracer_roctx.h>
+
+
+namespace onnxruntime{
+namespace profiling {
+class RocmProfiler;
+}
+}
+
+namespace libkineto {
+class RoctracerActivityApi;
+}
+
+class RoctracerActivityBuffer {
+public:
+  // data must be allocated using malloc.
+  // Ownership is transferred to this object.
+  RoctracerActivityBuffer(uint8_t* data, size_t validSize)
+      : data_(data), validSize_(validSize) {}
+
+  ~RoctracerActivityBuffer() {
+    free(data_);
+  }
+
+  // Allocated by malloc
+  uint8_t* data_{nullptr};
+
+  // Number of bytes used
+  size_t validSize_;
+};
+
+
+class ApiIdList
+{
+public:
+  ApiIdList();
+  bool invertMode() { return invert_; }
+  void setInvertMode(bool invert) { invert_ = invert; }
+  void add(const std::string &apiName);
+  void remove(const std::string &apiName);
+  bool loadUserPrefs();
+  bool contains(uint32_t apiId);
+  const std::unordered_map<uint32_t, uint32_t> &filterList() { return filter_; }
+
+private:
+  std::unordered_map<uint32_t, uint32_t> filter_;
+  bool invert_;
+};
+
+struct roctracerRow {
+  roctracerRow(uint64_t id, uint32_t domain, uint32_t cid, uint32_t pid
+             , uint32_t tid, uint64_t begin, uint64_t end)
+    : id(id), domain(domain), cid(cid), pid(pid), tid(tid), begin(begin), end(end) {}
+  uint64_t id;  // correlation_id
+  uint32_t domain;
+  uint32_t cid;
+  uint32_t pid;
+  uint32_t tid;
+  uint64_t begin;
+  uint64_t end;
+};
+
+struct kernelRow : public roctracerRow {
+  kernelRow(uint64_t id, uint32_t domain, uint32_t cid, uint32_t pid
+          , uint32_t tid, uint64_t begin, uint64_t end
+          , const void *faddr, hipFunction_t function
+          , unsigned int gx, unsigned int gy, unsigned int gz
+          , unsigned int wx, unsigned int wy, unsigned int wz
+          , size_t gss, hipStream_t stream)
+    : roctracerRow(id, domain, cid, pid, tid, begin, end), functionAddr(faddr)
+    , function(function), gridX(gx), gridY(gy), gridZ(gz)
+    , workgroupX(wx), workgroupY(wy), workgroupZ(wz), groupSegmentSize(gss)
+    , stream(stream) {}
+  const void* functionAddr;
+  hipFunction_t function;
+  unsigned int gridX;
+  unsigned int gridY;
+  unsigned int gridZ;
+  unsigned int workgroupX;
+  unsigned int workgroupY;
+  unsigned int workgroupZ;
+  size_t groupSegmentSize;
+  hipStream_t stream;
+};
+
+struct copyRow : public roctracerRow {
+  copyRow(uint64_t id, uint32_t domain, uint32_t cid, uint32_t pid
+             , uint32_t tid, uint64_t begin, uint64_t end
+             , const void* src, const void *dst, size_t size, hipMemcpyKind kind
+             , hipStream_t stream)
+    : roctracerRow(id, domain, cid, pid, tid, begin, end)
+    , src(src), dst(dst), size(size), kind(kind), stream(stream) {}
+  const void *src;
+  const void *dst;
+  size_t size;
+  hipMemcpyKind kind;
+  hipStream_t stream;
+};
+
+struct mallocRow : public roctracerRow {
+  mallocRow(uint64_t id, uint32_t domain, uint32_t cid, uint32_t pid
+             , uint32_t tid, uint64_t begin, uint64_t end
+             , const void* ptr, size_t size)
+    : roctracerRow(id, domain, cid, pid, tid, begin, end)
+    , ptr(ptr), size(size) {}
+  const void *ptr;
+  size_t size;
+};
+
+
+class RoctracerLogger {
+ public:
+  enum CorrelationDomain {
+    begin,
+    Default = begin,
+    Domain0 = begin,
+    Domain1,
+    end,
+    size = end
+  };
+
+  RoctracerLogger();
+  RoctracerLogger(const RoctracerLogger&) = delete;
+  RoctracerLogger& operator=(const RoctracerLogger&) = delete;
+
+  virtual ~RoctracerLogger();
+
+  static RoctracerLogger& singleton();
+
+  static void pushCorrelationID(uint64_t id, CorrelationDomain type);
+  static void popCorrelationID(CorrelationDomain type);
+
+  void startLogging();
+  void stopLogging();
+  void clearLogs();
+
+ private:
+  bool registered_{false};
+  void endTracing();
+
+  roctracer_pool_t *hccPool_{NULL};
+  static void api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg);
+  static void activity_callback(const char* begin, const char* end, void* arg);
+
+  ApiIdList loggedIds_;
+
+  // Api callback data
+  std::deque<roctracerRow> rows_;
+  std::deque<kernelRow> kernelRows_;
+  std::deque<copyRow> copyRows_;
+  std::deque<mallocRow> mallocRows_;
+  std::map<uint64_t,uint64_t> externalCorrelations_[CorrelationDomain::size];	// tracer -> ext
+
+  std::unique_ptr<std::list<RoctracerActivityBuffer>> gpuTraceBuffers_;
+  bool externalCorrelationEnabled_{true};
+
+  friend class onnxruntime::profiling::RocmProfiler;
+  friend class libkineto::RoctracerActivityApi;
+};


### PR DESCRIPTION
Refactor roctracer support.  Add RoctracerLogger.* which is generic roctracer collection implementation.  RoctracerActivityApi.* is now an adapter for Kineto, all Kineto concerns are addressed there.

RoctracerLogger supports tracking external correlation.  Added external correlation support to RoctracerActivityApi.  Looks up ITraceActivity records from CuptiActivityProfiler::activityMap_.  Reports those as linkedActivity() in its activitities.