### PR TITLE
Fix link missing definitions error for new source files in PyTorch libtorch_cpu

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -12,6 +12,7 @@ def get_libkineto_api_srcs():
 def get_libkineto_cupti_srcs(with_api = True):
     return [
         "src/CudaDeviceProperties.cpp",
+        "src/CudaUtil.cpp",
         "src/CuptiActivityApi.cpp",
         "src/CuptiActivityPlatform.cpp",
         "src/CuptiCallbackApi.cpp",
@@ -36,6 +37,7 @@ def get_libkineto_roctracer_srcs(with_api = True):
 def get_libkineto_cpu_only_srcs(with_api = True):
     return [
         "src/AbstractConfig.cpp",
+        "src/ActivityTrace.cpp",
         "src/CuptiActivityProfiler.cpp",
         "src/ActivityProfilerController.cpp",
         "src/ActivityProfilerProxy.cpp",

--- a/libkineto/src/CudaUtil.h
+++ b/libkineto/src/CudaUtil.h
@@ -7,6 +7,10 @@
 
 namespace KINETO_NAMESPACE {
 
+#ifdef HAS_CUPTI
 bool isGpuAvailable();
+#else
+bool isGpuAvailable() { return false; }
+#endif
 
 } // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Summary: Recently two new .cpp files were added, ActivityTrace.cpp and CudaUtil.cpp. They were not added to the bazel build definition, and thus were missing at link time in PyTorch build. Added them to the bazel file, as well as skipped CudaUtil.cpp for non Cupti source files.

Differential Revision: D38293317

Pulled By: aaronenyeshi

