### PR TITLE
Exit `profilerLoop` after sleep when requested

### DIFF
--- a/libkineto/src/EventProfilerController.cpp
+++ b/libkineto/src/EventProfilerController.cpp
@@ -368,6 +368,9 @@ void EventProfilerController::profilerLoop() {
     }
     int sleep_time = duration_cast<milliseconds>(now - start_sleep).count();
 
+    if(stopRunloop_)
+      break;
+
     auto start_sample = now;
     profiler_->collectSample();
     now = system_clock::now();


### PR DESCRIPTION
I see a SEGFAULT on application shutdown as the system is shutting down but the profiler thread is sleeping and then tries to report a last sample but the loggers are already gone.
So check the flag after the sleep to mitigate this.

Actually this is an example of static deinit fiasco. But fixing this is really hard...