### PR TITLE
Fix crash during shutdown when profiler was used

### DIFF
--- a/libkineto/src/EventProfilerController.cpp
+++ b/libkineto/src/EventProfilerController.cpp
@@ -233,9 +233,14 @@ EventProfilerController::~EventProfilerController() {
 
 // Must be called under lock
 void EventProfilerController::start(CUcontext ctx, ConfigLoader& configLoader) {
-  profilerMap()[ctx] = unique_ptr<EventProfilerController>(
+  // Avoid static initialization order fiasco:
+  // We need the profilerMap and with it all controllers to be destroyed
+  // before everything the controller accesses gets destroyed.
+  // Hence access the profilerMap after initialization of the controller.
+  auto controller = unique_ptr<EventProfilerController>(
       new EventProfilerController(
           ctx, configLoader, detail::HeartbeatMonitor::instance()));
+  profilerMap()[ctx] = std::move(controller);
 }
 
 // Must be called under lock


### PR DESCRIPTION
The EventProfilerController uses the loggers, so when they get destroyed before the controller you'll get a segfault.
Currently the creation / function calls are in this order:
- profilerMap
- loggers
- makeLoggers

This means the loggers will be destroyed first (reverse order of construction).
This changes puts the profilerMap call to the end destroying that first, then the loggers.