### PR TITLE
Revert "reverted diff: Add python stack tracing option on on-demand flow" (#82378)

### DIFF
--- a/libkineto/include/ClientInterface.h
+++ b/libkineto/include/ClientInterface.h
@@ -1,4 +1,5 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
 
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,7 +13,11 @@ class ClientInterface {
   virtual ~ClientInterface() {}
   virtual void init() = 0;
   virtual void warmup(bool setupOpInputsCollection) = 0;
+#ifdef USE_KINETO_MIN_CHANGE
+  virtual void start(bool withStack) = 0;
+#else
   virtual void start() = 0;
+#endif
   virtual void stop() = 0;
 };
 

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -1,4 +1,5 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
 
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -177,6 +178,10 @@ class Config : public AbstractConfig {
     return enableOpInputsCollection_;
   }
 
+  bool isPythonStackTraceEnabled() const {
+    return enablePythonStackTrace_;
+  }
+
   // Trace for this long
   std::chrono::milliseconds activitiesDuration() const {
     return activitiesDuration_;
@@ -202,7 +207,7 @@ class Config : public AbstractConfig {
   // Timestamp at which the profiling to start, requested by the user.
   const std::chrono::time_point<std::chrono::system_clock> requestTimestamp()
       const {
-    if  (profileStartTime_.time_since_epoch().count()) {
+    if (profileStartTime_.time_since_epoch().count()) {
       return profileStartTime_;
     }
     // If no one requested timestamp, return 0.
@@ -309,8 +314,8 @@ class Config : public AbstractConfig {
 
   void printActivityProfilerConfig(std::ostream& s) const override;
 
-  void validate(
-      const std::chrono::time_point<std::chrono::system_clock>& fallbackProfileStartTime) override;
+  void validate(const std::chrono::time_point<std::chrono::system_clock>&
+                    fallbackProfileStartTime) override;
 
   static void addConfigFactory(
       std::string name,
@@ -389,6 +394,9 @@ class Config : public AbstractConfig {
   // Client Interface
   // Enable inputs collection when tracing ops
   bool enableOpInputsCollection_{true};
+
+  // Enable Python Stack Tracing
+  bool enablePythonStackTrace_{false};
 
   // Profile for specified iterations and duration
   std::chrono::milliseconds activitiesDuration_;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -1,4 +1,5 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
 
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -66,8 +67,10 @@ constexpr char kActivitiesMaxGpuBufferSizeKey[] =
 
 // Client Interface
 constexpr char kClientInterfaceEnableOpInputsCollection[] = "CLIENT_INTERFACE_ENABLE_OP_INPUTS_COLLECTION";
+constexpr char kPythonStackTrace[] = "PYTHON_STACK_TRACE";
 
-constexpr char kActivitiesWarmupIterationsKey[] = "ACTIVITIES_WARMUP_ITERATIONS";
+constexpr char kActivitiesWarmupIterationsKey[] =
+    "ACTIVITIES_WARMUP_ITERATIONS";
 constexpr char kActivitiesIterationsKey[] = "ACTIVITIES_ITERATIONS";
 // Common
 
@@ -108,8 +111,8 @@ constexpr char kProfileStartIterationKey[] = "PROFILE_START_ITERATION";
 //   The profile will then be collected on the next multiple of 1000 ie. 3000
 // Note PROFILE_START_ITERATION_ROUNDUP will also take precedence over
 // PROFILE_START_TIME.
-constexpr char kProfileStartIterationRoundUpKey[]
-  = "PROFILE_START_ITERATION_ROUNDUP";
+constexpr char kProfileStartIterationRoundUpKey[] =
+    "PROFILE_START_ITERATION_ROUNDUP";
 
 // Enable on-demand trigger via kill -USR2 <pid>
 // When triggered in this way, /tmp/libkineto.conf will be used as config.
@@ -135,7 +138,6 @@ constexpr uint8_t kMaxDevices = 8;
 namespace {
 
 struct FactoryMap {
-
   void addFactory(
       std::string name,
       std::function<AbstractConfig*(Config&)> factory) {
@@ -150,8 +152,8 @@ struct FactoryMap {
     }
   }
 
-// Config factories are shared between objects and since
-// config objects can be created by multiple threads, we need a lock.
+  // Config factories are shared between objects and since
+  // config objects can be created by multiple threads, we need a lock.
   std::mutex lock_;
   std::map<std::string, std::function<AbstractConfig*(Config&)>> factories_;
 };
@@ -262,16 +264,16 @@ static time_point<system_clock> handleProfileStartTime(int64_t start_time_ms) {
   auto now = system_clock::now();
   if ((now - t) > kMaxRequestAge) {
     throw std::invalid_argument(fmt::format(
-      "Invalid {}: {} - start time is more than {}s in the past",
-      kProfileStartTimeKey,
-      getTimeStr(t),
-      kMaxRequestAge.count()));
+        "Invalid {}: {} - start time is more than {}s in the past",
+        kProfileStartTimeKey,
+        getTimeStr(t),
+        kMaxRequestAge.count()));
   }
   return t;
 }
 
 void Config::setActivityTypes(
-  const std::vector<std::string>& selected_activities) {
+    const std::vector<std::string>& selected_activities) {
   selectedActivityTypes_.clear();
   if (selected_activities.size() > 0) {
     for (const auto& activity : selected_activities) {
@@ -314,8 +316,7 @@ bool Config::handleOption(const std::string& name, std::string& val) {
 
   // Activity Profiler
   else if (!name.compare(kActivitiesDurationKey)) {
-    activitiesDuration_ =
-        duration_cast<milliseconds>(seconds(toInt32(val)));
+    activitiesDuration_ = duration_cast<milliseconds>(seconds(toInt32(val)));
     activitiesOnDemandTimestamp_ = timestamp();
   } else if (!name.compare(kActivityTypesKey)) {
     vector<string> activity_types = splitAndTrim(toLower(val), ',');
@@ -347,6 +348,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   // Client Interface
   else if (!name.compare(kClientInterfaceEnableOpInputsCollection)) {
     enableOpInputsCollection_ = toBool(val);
+  } else if (!name.compare(kPythonStackTrace)) {
+    enablePythonStackTrace_ = toBool(val);
   }
 
   // Common

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -1,4 +1,5 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
 
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
@@ -83,6 +84,9 @@ struct ConfigDerivedState final {
   int64_t profileStartIteration() const { return profileStartIter_; }
   int64_t profileEndIteration() const { return profileEndIter_; }
   bool isProfilingByIteration() const { return profilingByIter_; }
+  bool profileWithPythonStack() const {
+    return profileWithStack_;
+  }
 
  private:
   std::set<ActivityType> profileActivityTypes_;
@@ -91,9 +95,10 @@ struct ConfigDerivedState final {
   std::chrono::time_point<std::chrono::system_clock> profileEndTime_;
   std::chrono::milliseconds profileDuration_;
   std::chrono::seconds profileWarmupDuration_;
-  int64_t profileStartIter_ {-1};
-  int64_t profileEndIter_ {-1};
-  bool profilingByIter_ {false};
+  int64_t profileStartIter_{-1};
+  int64_t profileEndIter_{-1};
+  bool profilingByIter_{false};
+  bool profileWithStack_{false};
 };
 
 class CuptiActivityProfiler {


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/82378

Changes:
add an option in Config; can use 'PYTHON_STACK_TRACE=true' option (via .conf)
deliver PYTHON_STACK_TRACE value to kineto_client_interface start()
abstract class also changed.
Trace after changes by running //kineto/libkineto/fb/integration_tests/trace_tester.cpp (requested by chaekit)
https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Fdynocli%2F0%2F1657304871%2F127.0.0.1%2Flibkineto_activities_3502962.json.gz&bucket=gpu_traces

Reviewed By: chaekit

Differential Revision: D38220201

