### PR TITLE
guard against negative durations in Chrome trace generation

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -264,6 +264,14 @@ void ChromeTraceLogger::handleActivity(
 
   int64_t ts = op.timestamp();
   int64_t duration = op.duration();
+
+  if (duration < 0) {
+    // This should never happen but can occasionally suffer from regression in handling incomplete events.
+    // Having negative duration in Chrome trace can yield in very poor experience so add an extra guard
+    // before we generate trace events.
+    duration = 0;
+  }
+
   if (op.type() ==  ActivityType::GPU_USER_ANNOTATION) {
     // The GPU user annotations start at the same time as the
     // first associated GPU op. Since they appear later


### PR DESCRIPTION
Summary: the profiler may have 0 end time stamp which was recently fixed in D38426342. even though thats the source of negative duration, we should be extra cautious with negative duration in chrome trace generation as thats where the side effect is the worst: super zoomed out trace that is annoying

Reviewed By: aaronenyeshi

Differential Revision: D38607705

