### PR TITLE
add prototype for isGpuAvailable()

### DIFF
--- a/libkineto/src/CudaUtil.cpp
+++ b/libkineto/src/CudaUtil.cpp
@@ -14,6 +14,7 @@ namespace KINETO_NAMESPACE {
 bool gpuAvailable = false;
 
 bool isGpuAvailable() {
+#ifdef HAS_CUPTI
   static std::once_flag once;
   std::call_once(once, [] {
     // determine GPU availability on the system
@@ -24,6 +25,9 @@ bool isGpuAvailable() {
   });
 
   return gpuAvailable;
+#else
+  return false;
+#endif
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CudaUtil.h
+++ b/libkineto/src/CudaUtil.h
@@ -7,10 +7,6 @@
 
 namespace KINETO_NAMESPACE {
 
-#ifdef HAS_CUPTI
 bool isGpuAvailable();
-#else
-bool isGpuAvailable() { return false; }
-#endif
 
 } // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Summary: This is a generic util function that checks if GPU is available on the system but the current impl is not compatible for mobile build CIs. due to missing prototype error.

Reviewed By: aaronenyeshi

Differential Revision: D38803286

