### PR TITLE
Remove guards from Python stack tracing OD flow

### DIFF
--- a/libkineto/include/ClientInterface.h
+++ b/libkineto/include/ClientInterface.h
@@ -15,11 +15,7 @@ class ClientInterface {
   virtual ~ClientInterface() {}
   virtual void init() = 0;
   virtual void warmup(bool setupOpInputsCollection) = 0;
-#ifdef USE_KINETO_MIN_CHANGE
   virtual void start(bool withStack) = 0;
-#else
-  virtual void start() = 0;
-#endif
   virtual void stop() = 0;
 };
 

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -787,12 +787,8 @@ const time_point<system_clock> CuptiActivityProfiler::performRunLoopStep(
         }
         startTrace(now);
         if (libkineto::api().client()) {
-#ifdef USE_KINETO_MIN_CHANGE
           libkineto::api().client()->start(
               derivedConfig_->profileWithPythonStack());
-#else
-          libkineto::api().client()->start();
-#endif
         }
         if (nextWakeupTime > derivedConfig_->profileEndTime()) {
           new_wakeup_time = derivedConfig_->profileEndTime();


### PR DESCRIPTION
Summary:
Diff for removing #ifdef guard from Python stack tracing option on on-demand flow.
1. Point a new Kineto submodule to compile in CIs with kineto.submodule.txt
2. The new Kineto submodule has 'withStack' inside #ifdef USE_KINETO_MIN_CHANGE
3. This diff removed #ifdef from codes
4. but we still need another diff to deprecate 'USE_KINETO_MIN_CHANGE' from TARGETS and .bzl files.

Differential Revision: D38963630

