### PR TITLE
[kineto] Add support for reading SLURM job id

### DIFF
--- a/libkineto/src/DaemonConfigLoader.cpp
+++ b/libkineto/src/DaemonConfigLoader.cpp
@@ -24,6 +24,7 @@ IpcFabricConfigClient* getConfigClient() {
 }
 
 std::string DaemonConfigLoader::readBaseConfig() {
+  LOG(INFO) << "Reading base config";
   auto configClient = getConfigClient();
   if (!configClient) {
     LOG_EVERY_N(WARNING, 10) << "Failed to read config: No dyno config client";
@@ -72,7 +73,11 @@ void DaemonConfigLoader::setCommunicationFabric(bool enabled) {
 
 void DaemonConfigLoader::registerFactory() {
   ConfigLoader::setDaemonConfigLoaderFactory(
-      []() { return std::make_unique<DaemonConfigLoader>(); });
+      []() {
+        auto loader = std::make_unique<DaemonConfigLoader>();
+        loader->setCommunicationFabric(true);
+        return loader;
+      });
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/IpcFabricConfigClient.cpp
+++ b/libkineto/src/IpcFabricConfigClient.cpp
@@ -71,7 +71,13 @@ static std::vector<int32_t> getPids() {
 }
 
 static int64_t getJobId() {
-  const char* id = getenv("CHRONOS_JOB_INSTANCE_ID");
+  /* Look up a job id using env variables from job schedulers
+   */
+  // SLURM Job ID https://slurm.schedmd.com/sbatch.html#OPT_SLURM_JOB_ID
+  const char* id = getenv("SLURM_JOB_ID");
+
+  // Feel free to add other env variable look ups here
+  // for different schedulers
   if (id == nullptr) {
     return 0;
   }

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -95,6 +95,7 @@ void libkineto_init(bool cpuOnly, bool logOnError) {
   // Factory to connect to open source daemon if present
 #if __linux__
   if (getenv("KINETO_USE_DAEMON") != nullptr) {
+    LOG(INFO) << "Registering daemon config loader";
     DaemonConfigLoader::registerFactory();
   }
 #endif


### PR DESCRIPTION
SLURM is a popular Job scheduler for open source environments. This PR helps us detect the SLURM Job id in Kineto and this can be used to target this job for on-demand tracing (instead of knowing the pid of a process).
- The job id is read from the process' environment.
- Also updates config loader to use ipcfabric by default if user sets KINETO_USE_DAEMON=1

Note: it only supports numeric job ids right now, and defaults to 0 otherwise.