### PR TITLE
Add the Trace URI for logging for all Configs

### DIFF
--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -470,33 +470,33 @@ void Config::setReportPeriod(milliseconds msecs) {
 }
 
 void Config::printActivityProfilerConfig(std::ostream& s) const {
-  s << "Log file: " << activitiesLogFile() << std::endl;
+  s << "  Log file: " << activitiesLogFile() << std::endl;
   if (hasProfileStartIteration()) {
-    s << "Trace start Iteration: " << profileStartIteration() << std::endl;
-    s << "Trace warmup Iterations: " << activitiesWarmupIterations() << std::endl;
-    s << "Trace profile Iterations: " << activitiesRunIterations() << std::endl;
+    s << "  Trace start Iteration: " << profileStartIteration() << std::endl;
+    s << "  Trace warmup Iterations: " << activitiesWarmupIterations() << std::endl;
+    s << "  Trace profile Iterations: " << activitiesRunIterations() << std::endl;
     if (profileStartIterationRoundUp() > 0) {
-      s << "Trace start iteration roundup : " << profileStartIterationRoundUp()
+      s << "  Trace start iteration roundup : " << profileStartIterationRoundUp()
         << std::endl;
     }
   } else if (hasProfileStartTime()) {
     std::time_t t_c = system_clock::to_time_t(requestTimestamp());
-    LOG(INFO) << "Trace start time: "
+    s << "  Trace start time: "
               << fmt::format("{:%Y-%m-%d %H:%M:%S}", fmt::localtime(t_c));
-    s << "Trace duration: " << activitiesDuration().count() << "ms"
+    s << "  Trace duration: " << activitiesDuration().count() << "ms"
       << std::endl;
-    s << "Warmup duration: " << activitiesWarmupDuration().count() << "s"
+    s << "  Warmup duration: " << activitiesWarmupDuration().count() << "s"
       << std::endl;
   }
 
-  s << "Max GPU buffer size: " << activitiesMaxGpuBufferSize() / 1024 / 1024
+  s << "  Max GPU buffer size: " << activitiesMaxGpuBufferSize() / 1024 / 1024
     << "MB" << std::endl;
 
   std::vector<const char*> activities;
   for (const auto& activity : selectedActivityTypes_) {
     activities.push_back(toString(activity));
   }
-  s << "Enabled activities: "
+  s << "  Enabled activities: "
     << fmt::format("{}", fmt::join(activities, ",")) << std::endl;
 
   AbstractConfig::printActivityProfilerConfig(s);

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -626,7 +626,6 @@ void CuptiActivityProfiler::configure(
   if (!config_->requestGroupTraceID().empty()) {
     LOGGER_OBSERVER_SET_GROUP_TRACE_ID(config_->requestGroupTraceID());
   }
-  LOGGER_OBSERVER_ADD_DESTINATION(config_->activitiesLogUrl());
 
 #if defined(HAS_CUPTI) || defined(HAS_ROCTRACER)
   if (!cpuOnly_) {

--- a/libkineto/src/LoggerCollector.h
+++ b/libkineto/src/LoggerCollector.h
@@ -59,7 +59,8 @@ class LoggerCollector : public ILoggerObserver {
   }
 
   void addDestination(const std::string& dest) override {
-    destinations.insert(dest);
+    if (!dest.empty())
+      destinations.insert(dest);
   }
 
   void addMetadata(const std::string& key, const std::string& value) override {};


### PR DESCRIPTION
Summary:
PyTorch Profiler API and On-Demand perform saves different times. For the PyTorch API, it is after post processing. For On-Demand, it is before the end of post processing.

To handle all cases, generate the Trace URI during config time. Also, fix some formatting for prints.

Differential Revision: D39451333

Pulled By: aaronenyeshi

