### PR TITLE
[easy] append process id to name of trace file

### DIFF
--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -344,6 +344,10 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   } else if (!name.compare(kActivitiesLogFileKey)) {
     activitiesLogFile_ = val;
     activitiesLogUrl_ = fmt::format("file://{}", val);
+    size_t jidx = activitiesLogUrl_.find(".json");
+    if (jidx != std::string::npos) {
+      activitiesLogUrl_.replace(jidx, 5, fmt::format("_{}.json", processId()));
+    }
     activitiesOnDemandTimestamp_ = timestamp();
   } else if (!name.compare(kActivitiesMaxGpuBufferSizeKey)) {
     activitiesMaxGpuBufferSize_ = toInt32(val) * 1024 * 1024;


### PR DESCRIPTION
In a system will multiple processes active (using different GPUs) we need to distinguish the trace files from one another. This change will be helpful when the tracing requests are forwarded via a daemon. 

TestPlan:
Tested using SLURM 
```
ACTIVITIES_LOG_FILE=/private/home/bcountinho/test_gpu_trace//libkineto_trace.json
```
The trace was finally saved to 
/private/home/bcountinho/test_gpu_trace//libkineto_trace_1758097.json