### PR TITLE
To support extend Profiler

### DIFF
--- a/libkineto/include/ActivityProfilerBase.h
+++ b/libkineto/include/ActivityProfilerBase.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <chrono>
+
+#include "IActivityProfiler.h"
+#include "ITraceActivity.h"
+
+namespace libkineto {
+
+class ActivityProfilerBase {
+
+ public:
+  virtual ~ActivityProfilerBase() = default;
+
+  virtual bool isActive() const {
+    fail();
+    return false;
+  }
+
+  virtual const std::chrono::time_point<std::chrono::system_clock> performRunLoopStep(
+      const std::chrono::time_point<std::chrono::system_clock>& now,
+      const std::chrono::time_point<std::chrono::system_clock>& nextWakeupTime,
+      int64_t currentIter = -1) {
+    fail();
+    return nextWakeupTime;
+  }
+
+  virtual void setLogger(ActivityLogger* logger) {
+    fail();
+  }
+
+  virtual void startTrace(
+      const std::chrono::time_point<std::chrono::system_clock>& now) {
+    fail();
+  }
+
+  virtual void stopTrace(
+      const std::chrono::time_point<std::chrono::system_clock>& now) {
+    fail();
+  }
+
+  virtual void processTrace(ActivityLogger& logger) {
+    fail();
+  }
+
+  virtual void reset() {
+    fail();
+  }
+
+  virtual void configure(
+      const Config& config,
+      const std::chrono::time_point<std::chrono::system_clock>& now) {
+    fail();
+  }
+
+  virtual void transferCpuTrace(
+      std::unique_ptr<CpuTraceBuffer> cpuTrace) {
+    fail();
+  }
+
+  virtual const Config& config() {
+    fail();
+    Config* config_;
+    return *config_;
+  }
+
+  virtual inline void recordThreadInfo() {
+    fail();
+  }
+
+  virtual void addMetadata(const std::string& key, const std::string& value) {
+    fail();
+  }
+
+  virtual void addChildActivityProfiler(
+      std::unique_ptr<IActivityProfiler> profiler) {
+    fail();
+  }
+
+ private:
+  void fail() const {
+    throw std::runtime_error("KINETO: ActivityProfilerBase class not instantiated.");
+  }
+};
+
+}

--- a/libkineto/include/ActivityProfilerInterface.h
+++ b/libkineto/include/ActivityProfilerInterface.h
@@ -15,6 +15,7 @@
 
 #include "ActivityType.h"
 #include "ActivityTraceInterface.h"
+#include "DeviceType.h"
 #include "IActivityProfiler.h"
 
 namespace libkineto {
@@ -28,7 +29,7 @@ class ActivityProfilerInterface {
  public:
   virtual ~ActivityProfilerInterface() {};
 
-  virtual void init() {}
+  virtual void init(DeviceType t) {}
   virtual bool isInitialized() {
     return false;
   }

--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -25,6 +25,7 @@ enum class ActivityType {
     CONCURRENT_KERNEL, // on-device kernels
     EXTERNAL_CORRELATION,
     CUDA_RUNTIME, // host side cuda runtime events
+    XPU_RUNTIME, // host side xpu runtime events
     CPU_INSTANT_EVENT, // host side point-like events
     PYTHON_FUNCTION,
     OVERHEAD, // CUPTI induced overhead events sampled from its overhead API.

--- a/libkineto/include/DeviceType.h
+++ b/libkineto/include/DeviceType.h
@@ -1,0 +1,30 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <array>
+#include <string>
+
+namespace libkineto {
+
+// Note : All device types are not enabled by default. Please add them
+// at correct position in the enum
+enum class DeviceType {
+    // Device types enabled by default
+    CPU = 0, // cpu backend 
+    XPU,    // xpu backend
+    CUDA,   // cuda backend, /w cupti
+
+    ENUM_COUNT, // This is to add buffer and not used for any profiling logic. Add your new type before it.
+};
+
+const char* toString(DeviceType t);
+DeviceType toDeviceType(const std::string& str);
+
+// Return an array of all device types except COUNT
+constexpr int deviceTypeCount = (int)DeviceType::ENUM_COUNT;
+constexpr int defaultDeviceTypeCount = (int)DeviceType::ENUM_COUNT;
+const std::array<DeviceType, deviceTypeCount> deviceTypes();
+const std::array<DeviceType, defaultDeviceTypeCount> defaultDeviceTypes();
+
+} // namespace libkineto

--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -21,9 +21,11 @@
 #include <vector>
 #include <deque>
 
+#include "ActivityProfilerBase.h"
 #include "ActivityProfilerInterface.h"
 #include "ActivityType.h"
 #include "ClientInterface.h"
+#include "DeviceType.h"
 #include "GenericTraceActivity.h"
 #include "TraceSpan.h"
 #include "IActivityProfiler.h"
@@ -41,6 +43,11 @@ namespace libkineto {
 
 class Config;
 class ConfigLoader;
+
+// Claim of registerExtendProfiler method at top for extend backends to use
+void registerExtendProfiler(
+    std::unique_ptr<libkineto::ActivityProfilerBase> (*func)(bool cpuOnly),
+    libkineto::DeviceType t);
 
 struct CpuTraceBuffer {
   template <class... Args>
@@ -92,12 +99,12 @@ class LibkinetoApi {
     return client_;
   }
 
-  void initProfilerIfRegistered() {
+  void initProfilerIfRegistered(DeviceType t = DeviceType::CPU) {
     static std::once_flag once;
     if (activityProfiler_) {
-      std::call_once(once, [this] {
+      std::call_once(once, [this, t] {
         if (!activityProfiler_->isInitialized()) {
-          activityProfiler_->init();
+          activityProfiler_->init(t);
           initChildActivityProfilers();
         }
       });

--- a/libkineto/src/ActivityLoggerFactory.h
+++ b/libkineto/src/ActivityLoggerFactory.h
@@ -15,6 +15,8 @@
 #include <map>
 #include <string>
 
+#include "output_base.h"
+
 namespace KINETO_NAMESPACE {
 
 class ActivityLogger;

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -16,10 +16,8 @@
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
+#include "libkineto.h"
 #include "ActivityLoggerFactory.h"
-#include "CuptiActivityProfiler.h"
-#include "ActivityProfilerInterface.h"
-#include "ActivityTraceInterface.h"
 #include "ConfigLoader.h"
 #include "CuptiActivityApi.h"
 #include "LoggerCollector.h"
@@ -30,7 +28,7 @@ class Config;
 
 class ActivityProfilerController : public ConfigLoader::ConfigHandler {
  public:
-  explicit ActivityProfilerController(ConfigLoader& configLoader, bool cpuOnly);
+  explicit ActivityProfilerController(ConfigLoader& configLoader, bool cpuOnly, DeviceType t);
   ActivityProfilerController(const ActivityProfilerController&) = delete;
   ActivityProfilerController& operator=(const ActivityProfilerController&) =
       delete;
@@ -87,12 +85,15 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   std::unique_ptr<Config> asyncRequestConfig_;
   std::mutex asyncConfigLock_;
 
-  std::unique_ptr<CuptiActivityProfiler> profiler_;
+//  std::unique_ptr<CuptiActivityProfiler> profiler_;
+  std::unique_ptr<ActivityProfilerBase> profiler_;
   std::unique_ptr<ActivityLogger> logger_;
   std::thread* profilerThread_{nullptr};
   std::atomic_bool stopRunloop_{false};
   std::atomic<std::int64_t> iterationCount_{-1};
   ConfigLoader& configLoader_;
 };
+
+void registerExtendProfiler(std::unique_ptr<ActivityProfilerBase> (*func)(bool cpuOnly), DeviceType t);
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -11,6 +11,7 @@
 #include "ActivityProfilerController.h"
 #include "Config.h"
 #include "CuptiActivityApi.h"
+#include "DeviceType.h"
 #include "Logger.h"
 #include <chrono>
 #ifdef HAS_ROCTRACER
@@ -28,9 +29,9 @@ ActivityProfilerProxy::~ActivityProfilerProxy() {
   delete controller_;
 };
 
-void ActivityProfilerProxy::init() {
+void ActivityProfilerProxy::init(DeviceType t) {
   if (!controller_) {
-    controller_ = new ActivityProfilerController(configLoader_, cpuOnly_);
+    controller_ = new ActivityProfilerController(configLoader_, cpuOnly_, t);
   }
 }
 

--- a/libkineto/src/ActivityProfilerProxy.h
+++ b/libkineto/src/ActivityProfilerProxy.h
@@ -15,11 +15,13 @@
 #include <vector>
 
 #include "ActivityType.h"
+#include "DeviceType.h"
 #include "ITraceActivity.h"
 
 namespace libkineto {
   // previous declaration is struct so this one must be too.
   struct CpuTraceBuffer;
+  class ActivityLogger;
 }
 
 namespace KINETO_NAMESPACE {
@@ -36,7 +38,7 @@ class ActivityProfilerProxy : public ActivityProfilerInterface {
   ActivityProfilerProxy(bool cpuOnly, ConfigLoader& configLoader);
   ~ActivityProfilerProxy() override;
 
-  void init() override;
+  void init(DeviceType t) override;
   bool isInitialized() override {
     return controller_ != nullptr;
   }

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -26,6 +26,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
     {"kernel", ActivityType::CONCURRENT_KERNEL},
     {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
     {"cuda_runtime", ActivityType::CUDA_RUNTIME},
+    {"xpu_runtime", ActivityType::XPU_RUNTIME},
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
     {"python_function", ActivityType::PYTHON_FUNCTION},
     {"overhead", ActivityType::OVERHEAD},

--- a/libkineto/src/DeviceType.cpp
+++ b/libkineto/src/DeviceType.cpp
@@ -1,0 +1,57 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "DeviceType.h"
+
+#include <fmt/format.h>
+
+namespace libkineto {
+
+struct DeviceTypeName {
+  const char* name;
+  DeviceType type;
+};
+
+static constexpr std::array<DeviceTypeName, deviceTypeCount + 1> map{{
+    {"cpu", DeviceType::CPU},
+    {"xpu", DeviceType::XPU},
+    {"cuda", DeviceType::CUDA},
+    {"ENUM_COUNT", DeviceType::ENUM_COUNT}
+}};
+
+static constexpr bool matchingOrder(int idx = 0) {
+  return map[idx].type == DeviceType::ENUM_COUNT ||
+    ((idx == (int) map[idx].type) && matchingOrder(idx + 1));
+}
+static_assert(matchingOrder(), "DeviceTypeName map is out of order");
+
+const char* toString(DeviceType t) {
+  return map[(int)t].name;
+}
+
+DeviceType toDeviceType(const std::string& str) {
+  for (int i = 0; i < deviceTypeCount; i++) {
+    if (str == map[i].name) {
+      return map[i].type;
+    }
+  }
+  throw std::invalid_argument(fmt::format("Invalid device type: {}", str));
+}
+
+const std::array<DeviceType, deviceTypeCount> deviceTypes() {
+  std::array<DeviceType, deviceTypeCount> res;
+  for (int i = 0; i < deviceTypeCount; i++) {
+    res[i] = map[i].type;
+  }
+  return res;
+}
+
+const std::array<DeviceType, defaultDeviceTypeCount> defaultDeviceTypes() {
+  std::array<DeviceType, defaultDeviceTypeCount> res;
+  for (int i = 0; i < defaultDeviceTypeCount; i++) {
+    res[i] = map[i].type;
+  }
+  return res;
+}
+
+
+} // namespace libkineto


### PR DESCRIPTION
With this patch, the kineto will be able to support extend profiler to register themselves and co-work with kineto's tracing strategy. In this patch, we made three important changes in kineto.

1. The middle level has been abstracted as an abstract class - ActivityProfilerBase. All profiler instantiations inside or outside the kineto will inherit this class with overriding necessary APIs. Detailed design for this structure please refer to this [RFC](https://github.com/pytorch/kineto/issues/647)

2. The DeviceType enum class has been added to include/ as same as ActivityType. This enum class will make the profiler controller be enabled to choose integrated or extend path for instantiating the profiler_. This argument will be passed via front APIs such as initProfilerIfRegistered, which called by PyTorch.

3. A simple hook has been added into include/libkineto.h, with the hook function - registerExtendProfiler. This hook enables extend plug-ins such as Intel® Extension for PyTorch* to register extend profiler into kineto and override the constructor of profiler_ in controller which inherit the abstract class - ActivityProfilerBase described above.

* Any questions with this patch please contact Xunsong, Huang (xunsong.huang@intel.com)

Signed-off-by: Xunsong, Huang <xunsong.huang@intel.com>