### PR TITLE
Early loading of custom config

### DIFF
--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -50,13 +50,18 @@ void ActivityProfilerProxy::prepareTrace(
   Config config;
   bool validate_required = true;
 
-  // allow user provided config to override default options
+  // allow user provided config (ExperimentalConfig)to override default options
   if (!configStr.empty()) {
     if (!config.parse(configStr)) {
       LOG(WARNING) << "Failed to parse config : " << configStr;
     }
     // parse also runs validate
     validate_required = false;
+  }
+  // user provided config (KINETO_CONFIG) to override default options
+  auto loaded_config = configLoader_.getConfString();
+  if (!loaded_config.empty()) {
+    config.parse(loaded_config);
   }
 
   config.setClientDefaults();

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -90,7 +90,7 @@ static void setupSignalHandler(bool enableSigUsr2) {
 }
 
 // return an empty string if reading gets any errors. Otherwise a config string.
-static std::string readConfigFromConfigFile(const char* filename) {
+static std::string readConfigFromConfigFile(const char* filename, bool verbose=true) {
   // Read whole file into a string.
   std::ifstream file(filename);
   std::string conf;
@@ -98,8 +98,10 @@ static std::string readConfigFromConfigFile(const char* filename) {
     conf.assign(
         std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
   } catch (std::exception& e) {
-    VLOG(0) << "Error reading " << filename << ": "
-            << e.what();
+    if (verbose) {
+      VLOG(0) << "Error reading " << filename << ": " << e.what();
+    }
+
     conf = "";
   }
   return conf;
@@ -198,6 +200,14 @@ IDaemonConfigLoader* ConfigLoader::daemonConfigLoader() {
     daemonConfigLoader_->setCommunicationFabric(config_->ipcFabricEnabled());
   }
   return daemonConfigLoader_.get();
+}
+
+const char* ConfigLoader::customConfigFileName() {
+  return getenv(kConfigFileEnvVar);
+}
+
+const std::string ConfigLoader::getConfString(){
+  return readConfigFromConfigFile(configFileName(), false);
 }
 
 void ConfigLoader::updateBaseConfig() {

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -106,6 +106,8 @@ class ConfigLoader {
   static void setDaemonConfigLoaderFactory(
       std::function<std::unique_ptr<IDaemonConfigLoader>()> factory);
 
+  const std::string getConfString();
+
  private:
   ConfigLoader();
   ~ConfigLoader();
@@ -129,6 +131,8 @@ class ConfigLoader {
 
   std::string readOnDemandConfigFromDaemon(
       std::chrono::time_point<std::chrono::system_clock> now);
+
+  const char* customConfigFileName();
 
   std::mutex configLock_;
   std::atomic<const char*> configFileName_{nullptr};


### PR DESCRIPTION
Summary:
- `FBConfig` options are not applied as expected as config loader is running after `ActivityProfilerController` is configured.
- Added early loading into `prepareTrace()` (before Config input)

Differential Revision: D40292052

