### PR TITLE
Remove invalid "bp": "e" from start flow events

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -350,13 +350,17 @@ void ChromeTraceLogger::handleLink(
     return;
   }
 
+  // Flow events much bind to specific slices in order to exist.
+  // Only Flow end needs to specify a binding point to enclosing slice.
+  // Flow start automatically sets binding point to enclosing slice.
+  const auto binding = (type == kFlowEnd) ? ", \"bp\": \"e\"" : "";
   // clang-format off
   traceOf_ << fmt::format(R"JSON(
   {{
     "ph": "{}", "id": {}, "pid": {}, "tid": {}, "ts": {},
-    "cat": "{}", "name": "{}", "bp": "e"
+    "cat": "{}", "name": "{}"{}
   }},)JSON",
-      type, id, e.deviceId(), e.resourceId(), e.timestamp(), cat, name);
+      type, id, e.deviceId(), e.resourceId(), e.timestamp(), cat, name, binding);
   // clang-format on
 }
 


### PR DESCRIPTION
Summary:
Based on Trace Event Format documentation, flow events only support the binding point enclosing slice for flow end. Therefore remove the metadata for all flow start.

Ref: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview

Reviewed By: slgong-fb

Differential Revision: D40324494

Pulled By: aaronenyeshi

