### PR TITLE
Remove extra newline and whitespace showing in Cupti events

### DIFF
--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -184,7 +184,8 @@ inline bool RuntimeActivity::flowStart() const {
 }
 
 inline const std::string RuntimeActivity::metadataJson() const {
-  return fmt::format(R"JSON("cbid": {}, "correlation": {})JSON",
+  return fmt::format(R"JSON(
+      "cbid": {}, "correlation": {})JSON",
       activity_.cbid, activity_.correlationId);
 }
 

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -350,13 +350,18 @@ void ChromeTraceLogger::handleLink(
     return;
   }
 
+  std::string binding = "";
+  if (type == kFlowEnd) {
+    binding = ", \"bp\": \"e\"";
+  }
+
   // clang-format off
   traceOf_ << fmt::format(R"JSON(
   {{
     "ph": "{}", "id": {}, "pid": {}, "tid": {}, "ts": {},
-    "cat": "{}", "name": "{}", "bp": "e"
+    "cat": "{}", "name": "{}"{}
   }},)JSON",
-      type, id, e.deviceId(), e.resourceId(), e.timestamp(), cat, name);
+      type, id, e.deviceId(), e.resourceId(), e.timestamp(), cat, name, binding);
   // clang-format on
 }
 

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -286,7 +286,7 @@ void ChromeTraceLogger::handleActivity(
   const std::string op_metadata = op.metadataJson();
   std::string separator = "";
   if (op_metadata.find_first_not_of(" \t\n") != std::string::npos) {
-    separator = ",\n      ";
+    separator = ",";
   }
   int device = op.deviceId();
   int resource = op.resourceId();


### PR DESCRIPTION
Summary: Remove the extra newline and whitespace that is showing for all cupti activity events.

Reviewed By: robieta, slgong-fb

Differential Revision: D40325117

Pulled By: aaronenyeshi

