### PR TITLE
Remove unset external id from trace json

### DIFF
--- a/tb_plugin/test/gpu_metrics_expected.json
+++ b/tb_plugin/test/gpu_metrics_expected.json
@@ -2643,7 +2643,7 @@
     "ts": 1621401187236853, "dur": 10,
     "args": {
       "cbid": 165, "correlation": 605,
-      "external id": 0, "external ts": 0
+      "external id": 605, "external ts": 0
     }
   },
   {

--- a/tb_plugin/test/gpu_metrics_input.json
+++ b/tb_plugin/test/gpu_metrics_input.json
@@ -2643,7 +2643,7 @@
     "ts": 1621401187236853, "dur": 10,
     "args": {
       "cbid": 165, "correlation": 605,
-      "external id": 0, "external ts": 0
+      "external id": 605, "external ts": 0
     }
   },
   {

--- a/tb_plugin/test/test_profiler.py
+++ b/tb_plugin/test/test_profiler.py
@@ -355,13 +355,13 @@ class TestProfiler(unittest.TestCase):
                 "ph": "X", "cat": "Runtime",
                 "name": "cudaLaunchKernel", "pid": 13721, "tid": "456",
                 "ts": 130, "dur": 20,
-                "args": {"correlation": 335, "external id": 0}
+                "args": {"correlation": 335, "external id": 335}
             },
             {
                 "ph": "X", "cat": "Kernel",
                 "name": "void gemmSN_TN_kernel_64addr", "pid": 0, "tid": "stream 7",
                 "ts": 220, "dur": 8,
-                "args": {"correlation": 335, "external id": 0, "device": 0}
+                "args": {"correlation": 335, "external id": 335, "device": 0}
             }
         ]
         """
@@ -768,7 +768,7 @@ class TestProfiler(unittest.TestCase):
                 "ph": "X", "cat": "Kernel",
                 "name": "void cunn_ClassNLLCriterion_updateGradInput_kernel<float>", "pid": 0, "tid": "stream 7",
                 "ts": 150, "dur": 90,
-                "args": {"correlation": 123, "external id": 0, "device": 0}
+                "args": {"correlation": 123, "external id": 123, "device": 0}
             },
             {
                 "ph": "X", "cat": "Memcpy",
@@ -857,7 +857,7 @@ class TestProfiler(unittest.TestCase):
                 "ph": "X", "cat": "Kernel",
                 "name": "void cunn_ClassNLLCriterion_updateGradInput_kernel<float>", "pid": 0, "tid": "stream 7",
                 "ts": 90, "dur": 20,
-                "args": {"correlation": 123, "external id": 0, "device": 0}
+                "args": {"correlation": 123, "external id": 123, "device": 0}
             },
             {
                 "ph": "X", "cat": "Runtime",
@@ -2505,7 +2505,6 @@ class TestModuleView(unittest.TestCase):
                 "ts": 1,
                 "dur": 19367,
                 "args": {
-                    "External id": 0,
                     "Python id": 1,
                     "Python thread": 0
                 }
@@ -2519,7 +2518,6 @@ class TestModuleView(unittest.TestCase):
                 "ts": 2,
                 "dur": 211,
                 "args": {
-                    "External id": 0,
                     "Python id": 2,
                     "Python parent id": 1,
                     "Python module id": 0
@@ -2534,7 +2532,6 @@ class TestModuleView(unittest.TestCase):
                 "ts": 5,
                 "dur": 62,
                 "args": {
-                    "External id": 0,
                     "Python id": 3,
                     "Python parent id": 2,
                     "Python thread": 0,
@@ -2565,7 +2562,6 @@ class TestModuleView(unittest.TestCase):
                 "ts": 1000,
                 "dur": 211,
                 "args": {
-                    "External id": 0,
                     "Python id": 4,
                     "Python parent id": 1,
                     "Python module id": 0
@@ -2580,7 +2576,6 @@ class TestModuleView(unittest.TestCase):
                 "ts": 1001,
                 "dur": 62,
                 "args": {
-                    "External id": 0,
                     "Python id": 5,
                     "Python parent id": 4,
                     "Python thread": 0,
@@ -2611,7 +2606,6 @@ class TestModuleView(unittest.TestCase):
                 "ts": 2000,
                 "dur": 211,
                 "args": {
-                    "External id": 0,
                     "Python id": 6,
                     "Python parent id": 1,
                     "Python module id": 0
@@ -2626,7 +2620,6 @@ class TestModuleView(unittest.TestCase):
                 "ts": 2001,
                 "dur": 62,
                 "args": {
-                    "External id": 0,
                     "Python id": 7,
                     "Python parent id": 6,
                     "Python thread": 0,
@@ -2657,7 +2650,6 @@ class TestModuleView(unittest.TestCase):
                 "ts": 3000,
                 "dur": 211,
                 "args": {
-                    "External id": 0,
                     "Python id": 8,
                     "Python parent id": 1,
                     "Python module id": 100


### PR DESCRIPTION
Summary: For python_function events, the external id is never set, and defaults to 0. We don't need to add these external ids to the trace file. Update the args metadata for events to support zero args, and no external id.

Reviewed By: chaekit

Differential Revision: D40327869

Pulled By: aaronenyeshi

