### PR TITLE
Use previous capitalized Kernel instead of kernel

### DIFF
--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -23,7 +23,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
     {"gpu_user_annotation", ActivityType::GPU_USER_ANNOTATION},
     {"gpu_memcpy", ActivityType::GPU_MEMCPY},
     {"gpu_memset", ActivityType::GPU_MEMSET},
-    {"kernel", ActivityType::CONCURRENT_KERNEL},
+    {"Kernel", ActivityType::CONCURRENT_KERNEL}, // Legacy tools using capitalized Kernel
     {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
     {"cuda_runtime", ActivityType::CUDA_RUNTIME},
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},


### PR DESCRIPTION
Summary:
In OSS, users are using Tensorboard 0.4.0. Which does not contain the fix to support lowercase kernel (PR#593). So we can revert back to capitalized Kernel for backwards compatibility.

Fixes https://github.com/pytorch/kineto/issues/659 and https://github.com/pytorch/kineto/issues/564.

Reviewed By: slgong-fb

Differential Revision: D40691653

Pulled By: aaronenyeshi

