### PR TITLE
Call CUPTI range profiler deinit inside Range profiler instead of in static destructor

### DIFF
--- a/libkineto/src/CuptiRangeProfiler.cpp
+++ b/libkineto/src/CuptiRangeProfiler.cpp
@@ -317,10 +317,4 @@ CuptiRangeProfilerInit::CuptiRangeProfilerInit() {
   });
 }
 
-CuptiRangeProfilerInit::~CuptiRangeProfilerInit() {
-  if (success) {
-    CuptiRBProfilerSession::deInitCupti();
-  }
-}
-
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiRangeProfiler.h
+++ b/libkineto/src/CuptiRangeProfiler.h
@@ -114,8 +114,6 @@ class CuptiRangeProfiler : public libkineto::IActivityProfiler {
 
 struct CuptiRangeProfilerInit {
   CuptiRangeProfilerInit();
-  ~CuptiRangeProfilerInit();
-
   bool success = false;
 };
 

--- a/libkineto/src/CuptiRangeProfilerApi.cpp
+++ b/libkineto/src/CuptiRangeProfilerApi.cpp
@@ -684,8 +684,7 @@ bool CuptiRBProfilerSession::createCounterDataImage() {
   initScratchBufferParams.counterDataImageSize =
     calculateSizeParams.counterDataImageSize;
 
-  initScratchBufferParams.pCounterDataImage =
-    initializeParams.pCounterDataImage;
+  initScratchBufferParams.pCounterDataImage = initializeParams.pCounterDataImage;
   initScratchBufferParams.counterDataScratchBufferSize =
     scratchBufferSizeParams.counterDataScratchBufferSize;
   initScratchBufferParams.pCounterDataScratchBuffer =
@@ -695,6 +694,12 @@ bool CuptiRBProfilerSession::createCounterDataImage() {
       &initScratchBufferParams));
 
   return true;
+}
+
+CuptiRBProfilerSession::~CuptiRBProfilerSession() {
+  if (initSuccess_) {
+    CuptiRBProfilerSession::deInitCupti();
+  }
 }
 
 #else
@@ -707,6 +712,7 @@ CuptiRBProfilerSession::CuptiRBProfilerSession(
       maxRanges_(opts.maxRanges),
       numNestingLevels_(opts.numNestingLevels),
       cuContext_(opts.cuContext) {};
+CuptiRBProfilerSession::~CuptiRBProfilerSession() {}
 void CuptiRBProfilerSession::stop() {}
 void CuptiRBProfilerSession::enable() {}
 void CuptiRBProfilerSession::disable() {}

--- a/libkineto/src/CuptiRangeProfilerApi.h
+++ b/libkineto/src/CuptiRangeProfilerApi.h
@@ -71,7 +71,7 @@ class CuptiRBProfilerSession {
 
   explicit CuptiRBProfilerSession(const CuptiRangeProfilerOptions& opts);
 
-  virtual ~CuptiRBProfilerSession() = default;
+  virtual ~CuptiRBProfilerSession();
 
   // Start profiling session
   // This function has to be called from the CPU thread running


### PR DESCRIPTION
Summary:
The CUPTI range profiler module calls a deinitCupti() during destruction. This could cause issues due to SIOF = https://en.cppreference.com/w/cpp/language/siof

We can completely remove this situation by not calling CUPTI range profiler deinit() during destruction but rather when range profiler is actually done with profiling. This way we do not invoke Range profiler API unless requested.

Differential Revision: D41053362

