### PR TITLE
Disable EventProfiler::stop() if it was never started

### DIFF
--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -47,7 +47,7 @@ static void initProfilers(
     VLOG(0) << "libkineto profilers activated";
   }
   if (getenv("KINETO_DISABLE_EVENT_PROFILER") != nullptr) {
-    VLOG(0) << "Event profiler disabled via env var";
+    LOG(INFO) << "Kineto EventProfiler disabled via env var, skipping start";
   } else {
     ConfigLoader& config_loader = libkineto::api().configLoader();
     config_loader.initBaseConfig();
@@ -77,7 +77,12 @@ static void stopProfiler(
 
   LOG(INFO) << "CUDA Context destroyed";
   std::lock_guard<std::mutex> lock(initMutex);
-  EventProfilerController::stop(ctx);
+
+  if (getenv("KINETO_DISABLE_EVENT_PROFILER") != nullptr) {
+    LOG(INFO) << "Kineto EventProfiler disabled via env var, skipping stop";
+  } else {
+    EventProfilerController::stop(ctx);
+  }
 }
 
 static std::unique_ptr<CuptiRangeProfilerInit> rangeProfilerInit;


### PR DESCRIPTION
Summary: Guard the EventProfiler::stop with the same check as EventProfiler::start, so that we are not trying to stop what is not enabled. If we call this, it will create the profilerMap() singleton, which will run into an SIOF bug on the destruction of EventProfilerController and the profilerMap singleton.

Reviewed By: chaekit

Differential Revision: D41097646

Pulled By: aaronenyeshi

