### PR TITLE
Enable EventProfiler when config has METRICS or EVENTS and track started

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -68,6 +68,10 @@ class Config : public AbstractConfig {
     return activitiesLogToMemory_;
   }
 
+  bool eventProfilerEnabled() const {
+    return !eventNames_.empty() || !metricNames_.empty();
+  }
+
   // Is profiling enabled for the given device?
   bool eventProfilerEnabledForDevice(uint32_t dev) const {
     return 0 != (eventProfilerDeviceMask_ & (1 << dev));

--- a/libkineto/src/EventProfilerController.h
+++ b/libkineto/src/EventProfilerController.h
@@ -37,7 +37,7 @@ class EventProfilerController : public ConfigLoader::ConfigHandler {
   ~EventProfilerController();
 
   static void start(CUcontext ctx, ConfigLoader& configLoader);
-  static void stop(CUcontext ctx);
+  static void stopIfEnabled(CUcontext ctx);
 
   static void addLoggerFactory(
       std::function<std::unique_ptr<SampleListener>(const Config&)> factory);
@@ -56,6 +56,7 @@ class EventProfilerController : public ConfigLoader::ConfigHandler {
       detail::HeartbeatMonitor& heartbeatMonitor);
   bool enableForDevice(Config& cfg);
   void profilerLoop();
+  static bool& started();
 
   ConfigLoader& configLoader_;
   std::unique_ptr<Config> newOnDemandConfig_;


### PR DESCRIPTION
Summary:
Event profiler is deprecating soon, due to introduction of DCGM. This patch is to reduce the usage of it.

To handle two issues here:
1) Only initialize the event profiler when the Kineto Config has the EVENTS or METRICS field. This prevents using the event profiler when host does not request it.
2) Skip the stop when the EventProfilerController::start was never called. This avoids creation of the singleton profilerMap on destruction.

Reviewed By: briancoutinho

Differential Revision: D41205038

Pulled By: aaronenyeshi

