### PR TITLE
Support Cupti domain callback subscribing

### DIFF
--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -110,6 +110,7 @@ void libkineto_init(bool cpuOnly, bool logOnError) {
     // If it is not available (e.g. CUDA is not installed),
     // then this call will return an error and we just abort init.
     auto cbapi = CuptiCallbackApi::singleton();
+    cbapi->initCallbackApi();
     bool status = false;
     bool initRangeProfiler = true;
 


### PR DESCRIPTION
Summary: In a follow-up patch, we will support cuptiFinalize which will reset all cupti callbacks. cuptiFinalize is essential to detach cupti and remove intermediate memory that may cause slowdowns. Track the callbacks that have been enabled, and provide an api, reenableCallbacks to turn on previously enabled callbacks.

Reviewed By: chaekit

Differential Revision: D41098126

Pulled By: aaronenyeshi

