### PR TITLE
Use Google Cloud Application Default Credentials when available.

### DIFF
--- a/tb_plugin/torch_tb_profiler/io/gs.py
+++ b/tb_plugin/torch_tb_profiler/io/gs.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # -------------------------------------------------------------------------
 from google.cloud import storage
+from google.auth import exceptions
 
 from .. import utils
 from .base import BaseFileSystem, RemotePath, StatData
@@ -122,6 +123,12 @@ class GoogleBlobSystem(RemotePath, BaseFileSystem):
         return bucket, path
 
     def create_google_cloud_client(self):
-        # TODO: support client with credential?
-        client = storage.Client.create_anonymous_client()
+        try:
+            client = storage.Client()
+            logger.debug('Using default Google Cloud credentials.')
+        except exceptions.DefaultCredentialsError:
+            client = storage.Client.create_anonymous_client()
+            logger.debug(
+                'Default Google Cloud credentials not available. '
+                'Falling back to anonymous credentials.')
         return client


### PR DESCRIPTION
When passing a gs:// path to --log_dir, periodically, torch-tb-profiler logs exceptions with the error message

    ValueError: Anonymous credentials cannot be refreshed.

due to its default use of anonymous credentials. This commit changes torch-tb-profiler to use Google Cloud Application Default Credentials (https://google-auth.readthedocs.io/en/master/user-guide.html#application-default-credentials, https://google-auth.readthedocs.io/en/master/reference/google.auth.html) (ADCs) by default, falling back to anonymous credentials when Application Default Credentials are not available. The commit causes the aforementioned exception to no longer be triggered when ADCs are available.

I tested this via the following steps and inspecting the outputs:

```
$ gcloud auth application-default login
$ tensorboard --log_dir=gs://<bucket>
$ gcloud auth application-default revoke
$ tensorboard --log_dir=gs://<bucket>
```

Full stack trace:

```
Traceback (most recent call last):
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/torch_tb_profiler/plugin.py", line 440, in _monitor_runs
    for run_dir in run_dirs:
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/torch_tb_profiler/plugin.py", line 484, in _get_run_dirs
    for root, _, files in io.walk(self.logdir):
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/torch_tb_profiler/io/file.py", line 587, in walk
    yield from fs.walk(top, topdown, onerror)
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/torch_tb_profiler/io/gs.py", line 83, in walk
    for blob in blobs:
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/api_core/page_iterator.py", line 208, in _items_iter
    for page in self._page_iter(increment=False):
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/api_core/page_iterator.py", line 244, in _page_iter
    page = self._next_page()
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/api_core/page_iterator.py", line 373, in _next_page
    response = self._get_next_page_response()
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/api_core/page_iterator.py", line 432, in _get_next_page_response
    return self.api_request(
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/cloud/storage/_http.py", line 72, in api_request
    return call()
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/api_core/retry.py", line 283, in retry_wrapped_func
    return retry_target(
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/api_core/retry.py", line 190, in retry_target
    return target()
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/cloud/_http/__init__.py", line 482, in api_request
    response = self._make_request(
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/cloud/_http/__init__.py", line 341, in _make_request
    return self._do_request(
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/cloud/_http/__init__.py", line 379, in _do_request
    return self.http.request(
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/auth/transport/requests.py", line 585, in request
    self.credentials.refresh(auth_request)
  File "/Users/kal/Code/kineto/venv/lib/python3.9/site-packages/google/auth/credentials.py", line 195, in refresh
    raise ValueError("Anonymous credentials cannot be refreshed.")
ValueError: Anonymous credentials cannot be refreshed.
```