### PR TITLE
Kineto even logging: make log file write atomic

### DIFF
--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -344,9 +344,14 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   } else if (!name.compare(kActivitiesLogFileKey)) {
     activitiesLogFile_ = val;
     activitiesLogUrl_ = fmt::format("file://{}", val);
-    size_t jidx = activitiesLogUrl_.find(".json");
+    size_t jidx = activitiesLogUrl_.find(".pt.trace.json");
     if (jidx != std::string::npos) {
-      activitiesLogUrl_.replace(jidx, 5, fmt::format("_{}.json", processId()));
+      activitiesLogUrl_.replace(jidx, 14, fmt::format("_{}.pt.trace.json", processId()));
+    } else {
+      jidx = activitiesLogUrl_.find(".json");
+      if (jidx != std::string::npos) {
+        activitiesLogUrl_.replace(jidx, 5, fmt::format("_{}.json", processId()));
+      }
     }
     activitiesOnDemandTimestamp_ = timestamp();
   } else if (!name.compare(kActivitiesMaxGpuBufferSizeKey)) {

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <time.h>
 #include <map>
+#include <unistd.h>
 
 #include "Config.h"
 #ifdef HAS_CUPTI
@@ -73,11 +74,19 @@ static std::string defaultFileName() {
 }
 
 void ChromeTraceLogger::openTraceFile() {
-  traceOf_.open(fileName_, std::ofstream::out | std::ofstream::trunc);
+  char tempBuf[] = "/tmp/libkineto_activities_tmp.json.XXXXXX";
+  int fd = mkstemp(tempBuf);
+  if (fd == -1) {
+    PLOG(ERROR) << "Failed to create temp file " << tempFileName_;
+    return;
+  }
+  tempFileName_ = tempBuf;
+  traceOf_.open(tempFileName_, std::ofstream::out | std::ofstream::trunc);
+  close(fd);
   if (!traceOf_) {
     PLOG(ERROR) << "Failed to open '" << fileName_ << "'";
   } else {
-    LOG(INFO) << "Tracing to " << fileName_;
+    LOG(INFO) << "Tracing to temporary file " << fileName_;
   }
 }
 
@@ -425,6 +434,11 @@ void ChromeTraceLogger::finalizeTrace(
   // clang-format on
 
   traceOf_.close();
+  if (rename(tempFileName_.c_str(), fileName_.c_str()) != 0) {
+    PLOG(ERROR) << "Failed to rename " << tempFileName_ << " to " << fileName_;
+  } else {
+    LOG(INFO) << "Renamed the trace file to " << fileName_;
+  }
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -81,6 +81,7 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   std::string& sanitizeStrForJSON(std::string& value);
 
   std::string fileName_;
+  std::string tempFileName_;
   std::ofstream traceOf_;
 };
 


### PR DESCRIPTION
It's useful for letting an external script know when logging is done.

Also recognize `.pt.trace.json` extension when appending the pid - it's a convention used in some visualizations (we probably should make {pid} a template instead)