### PR TITLE
Make Cupti and Roctracer teardown match

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <chrono>
 #include <mutex>
+#include <thread>
 
 #include "cupti_call.h"
 #include "Logger.h"

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -207,7 +207,7 @@ const std::pair<int, int> CuptiActivityApi::processActivities(
   return res;
 }
 
-void CuptiActivityApi::clearCuptiActivities() {
+void CuptiActivityApi::clearActivities() {
   {
     std::lock_guard<std::mutex> guard(mutex_);
     if (allocatedGpuTraceBuffers_.empty()) {
@@ -340,7 +340,7 @@ void CuptiActivityApi::disableCuptiActivities(
 #endif
 }
 
-void CuptiActivityApi::teardownCuptiContext() {
+void CuptiActivityApi::teardownContext() {
 #ifdef HAS_CUPTI
   if (!tracingEnabled_) {
     return;

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -61,8 +61,8 @@ class CuptiActivityApi {
     const std::set<ActivityType>& selected_activities);
   void disableCuptiActivities(
     const std::set<ActivityType>& selected_activities);
-  void clearCuptiActivities();
-  void teardownCuptiContext();
+  void clearActivities();
+  void teardownContext();
 
   virtual std::unique_ptr<CuptiActivityBufferMap> activityBuffers();
 

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -759,7 +759,7 @@ const time_point<system_clock> CuptiActivityProfiler::performRunLoopStep(
       if (!cpuOnly_ && currentIter < 0 &&
           (derivedConfig_->isProfilingByIteration() ||
            nextWakeupTime < derivedConfig_->profileStartTime())) {
-        cupti_.clearCuptiActivities();
+        cupti_.clearActivities();
       }
 
       if (cupti_.stopCollection) {
@@ -931,8 +931,8 @@ void CuptiActivityProfiler::finalizeTrace(const Config& config, ActivityLogger& 
 void CuptiActivityProfiler::resetTraceData() {
 #if defined(HAS_CUPTI) || defined(HAS_ROCTRACER)
   if (!cpuOnly_) {
-    cupti_.clearCuptiActivities();
-    cupti_.teardownCuptiContext();
+    cupti_.clearActivities();
+    cupti_.teardownContext();
   }
 #endif // HAS_CUPTI || HAS_ROCTRACER
   activityMap_.clear();

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -50,6 +50,7 @@ class RoctracerActivityApi {
   void disableActivities(
     const std::set<ActivityType>& selected_activities);
   void clearActivities();
+  void teardownContext() {}
 
   int processActivities(ActivityLogger& logger,
                         std::function<const ITraceActivity*(int32_t)> linkedActivity);


### PR DESCRIPTION
Summary: This is not a long term solution as the two can (and certainly will) drift apart again. However it will let us build with rocm and update the pinned commit in pytorch. (Which will limit further issues until we have a more principled solution.)

Differential Revision: D41407295

