### PR TITLE
Make on demand update duration configurable

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -277,6 +277,10 @@ class Config : public AbstractConfig {
     return enableIpcFabric_;
   }
 
+  std::chrono::seconds onDemandConfigUpdateIntervalSecs() const {
+    return onDemandConfigUpdateIntervalSecs_;
+  }
+
   static std::chrono::milliseconds alignUp(
       std::chrono::milliseconds duration,
       std::chrono::milliseconds alignment) {
@@ -450,6 +454,7 @@ class Config : public AbstractConfig {
 
   // Enable IPC Fabric instead of thrift communication
   bool enableIpcFabric_;
+  std::chrono::seconds onDemandConfigUpdateIntervalSecs_;
 
   // Logger Metadata
   std::string requestTraceID_;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -42,6 +42,7 @@ constexpr int kDefaultSamplesPerReport(1);
 constexpr int kDefaultMaxEventProfilersPerGpu(1);
 constexpr int kDefaultEventProfilerHearbeatMonitorPeriod(0);
 constexpr seconds kMaxRequestAge(10);
+constexpr seconds kDefaultOnDemandConfigUpdateIntervalSecs(5);
 // 3200000 is the default value set by CUPTI
 constexpr size_t kDefaultCuptiDeviceBufferSize(3200000);
 // Default value set by CUPTI is 250
@@ -127,6 +128,8 @@ constexpr char kEnableSigUsr2Key[] = "ENABLE_SIGUSR2";
 // Enable communication through IPC Fabric
 // and disable thrift communication with dynolog daemon
 constexpr char kEnableIpcFabricKey[] = "ENABLE_IPC_FABRIC";
+// Period to pull on-demand config from dynolog daemon
+constexpr char kOnDemandConfigUpdateIntervalSecsKey[] = "ON_DEMAND_CONFIG_UPDATE_INTERVAL_SECS";
 
 // Verbose log level
 // The actual glog is not used and --v and --vmodule has no effect.
@@ -213,6 +216,7 @@ Config::Config()
       requestTimestamp_(milliseconds(0)),
       enableSigUsr2_(false),
       enableIpcFabric_(false),
+      onDemandConfigUpdateIntervalSecs_(kDefaultOnDemandConfigUpdateIntervalSecs),
       cuptiDeviceBufferSize_(kDefaultCuptiDeviceBufferSize),
       cuptiDeviceBufferPoolLimit_(kDefaultCuptiDeviceBufferPoolLimit) {
   auto factories = configFactories();
@@ -387,6 +391,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     enableSigUsr2_ = toBool(val);
   } else if (!name.compare(kEnableIpcFabricKey)) {
     enableIpcFabric_ = toBool(val);
+  } else if (!name.compare(kOnDemandConfigUpdateIntervalSecsKey)) {
+    onDemandConfigUpdateIntervalSecs_ = seconds(toInt32(val));
   } else {
     return false;
   }

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -36,7 +36,6 @@ constexpr char kOnDemandConfigFile[] = "libkineto.conf";
 #endif
 
 constexpr std::chrono::seconds kConfigUpdateIntervalSecs(300);
-constexpr std::chrono::seconds kOnDemandConfigUpdateIntervalSecs(5);
 
 #ifdef __linux__
 static struct sigaction originalUsr2Handler = {};
@@ -144,7 +143,9 @@ int ConfigLoader::contextCountForGpu(uint32_t device) {
 
 ConfigLoader::ConfigLoader()
     : configUpdateIntervalSecs_(kConfigUpdateIntervalSecs),
-      onDemandConfigUpdateIntervalSecs_(kOnDemandConfigUpdateIntervalSecs),
+      // on-demand config will be overwritten by the value read from the regular config
+      // so the initial value is not important
+      onDemandConfigUpdateIntervalSecs_(kConfigUpdateIntervalSecs),
       stopFlag_(false),
       onDemandSignal_(false) {
 }
@@ -272,37 +273,44 @@ void ConfigLoader::updateConfigThread() {
   // function finishes.
   auto handle = Config::getStaticObjectsLifetimeHandle();
 
-  auto now = system_clock::now();
-  auto next_config_load_time = now;
-  auto next_on_demand_load_time = now + onDemandConfigUpdateIntervalSecs_;
-  seconds interval = configUpdateIntervalSecs_;
-  if (interval > onDemandConfigUpdateIntervalSecs_) {
-    interval = onDemandConfigUpdateIntervalSecs_;
-  }
+  // We're trying to update two configs here:
+  // 1. Base config - this is the config that is read from the config file
+  // 2. On-demand config - this is the config that is read via IPC channel
+  //    from daemon. It's layered on top of the base config.
+  // They have different update intervals (on demand is more frequent).
+  // Besides, on-demand update frequency can be configured via base config.
+
+  // initialze with some time buffer in the past
+  auto prev_config_load_time = system_clock::now() - configUpdateIntervalSecs_ * 2;
+  auto prev_on_demand_load_time = prev_config_load_time;
   auto onDemandConfig = std::make_unique<Config>();
 
   // This can potentially sleep for long periods of time, so allow
-  // the desctructor to wake it to avoid a 5-minute long destruct period.
+  // the destructor to wake it to avoid a 5-minute long destruct period.
   for (;;) {
-    {
+    auto interval = std::min(
+        configUpdateIntervalSecs_ + prev_config_load_time,
+        onDemandConfigUpdateIntervalSecs_ + prev_on_demand_load_time) - system_clock::now();
+    if (interval.count() > 0) {
       std::unique_lock<std::mutex> lock(updateThreadMutex_);
       updateThreadCondVar_.wait_for(lock, interval);
     }
     if (stopFlag_) {
       break;
     }
-    now = system_clock::now();
-    if (now > next_config_load_time) {
+    auto now = system_clock::now();
+    if (now > prev_config_load_time + configUpdateIntervalSecs_) {
       updateBaseConfig();
-      next_config_load_time = now + configUpdateIntervalSecs_;
+      onDemandConfigUpdateIntervalSecs_ = config_->onDemandConfigUpdateIntervalSecs();
+      prev_config_load_time = now;
     }
     if (onDemandSignal_.exchange(false)) {
       onDemandConfig = config_->clone();
       configureFromSignal(now, *onDemandConfig);
-    } else if (now > next_on_demand_load_time) {
+    } else if (now > prev_on_demand_load_time + onDemandConfigUpdateIntervalSecs_) {
       onDemandConfig = std::make_unique<Config>();
       configureFromDaemon(now, *onDemandConfig);
-      next_on_demand_load_time = now + onDemandConfigUpdateIntervalSecs_;
+      prev_on_demand_load_time = now;
     }
     if (onDemandConfig->verboseLogLevel() >= 0) {
       LOG(INFO) << "Setting verbose level to "


### PR DESCRIPTION
What title says. We read it from the main config and apply it to the next iteration of ondemand config loading. It also refactors the background thread loop to do time accounting properly if the update intervals are not divisible