### PR TITLE
Fix Config's destruction order issue

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -333,6 +333,12 @@ class Config : public AbstractConfig {
 
   void print(std::ostream& s) const;
 
+  // Config relies on some state with global static lifetime. If other
+  // threads are using the config, it's possible that the global state
+  // is destroyed before the threads stop. By hanging onto this handle,
+  // correct destruction order can be ensured.
+  static std::shared_ptr<void> getStaticObjectsLifetimeHandle();
+
  private:
   explicit Config(const Config& other) = default;
 

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -166,10 +166,8 @@ struct FactoryMap {
 
 std::shared_ptr<FactoryMap> configFactories() {
   // Ensure this is safe to call during shutdown, even as static
-  // destructors are invoked. Once factories destructor has been
-  // invoked, weak_ptr.lock() will return nullptr.
-  // But calls before that point will have a valid shared_ptr,
-  // delaying destruction of the underlying FactoryMap.
+  // destructors are invoked. getStaticObjectLifetimeHandle hangs onto
+  // FactoryMap delaying its destruction.
   static auto factories = std::make_shared<FactoryMap>();
   static std::weak_ptr<FactoryMap> weak_ptr = factories;
   return weak_ptr.lock();
@@ -221,6 +219,10 @@ Config::Config()
   if (factories) {
     factories->addFeatureConfigs(*this);
   }
+}
+
+std::shared_ptr<void> Config::getStaticObjectsLifetimeHandle() {
+  return configFactories();
 }
 
 uint8_t Config::createDeviceMask(const string& val) {

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -116,6 +116,7 @@ class ConfigLoader {
   IDaemonConfigLoader* daemonConfigLoader();
 
   void startThread();
+  void stopThread();
   void updateConfigThread();
   void updateBaseConfig();
 


### PR DESCRIPTION
The previous trick with `weak_ptr` didn't work on its own and led to crashes like in https://github.com/pytorch/pytorch/pull/89174 . This seems to be sufficient to guarantee lifetime even though it still accesses destroyed `weak_ptr` instance which is technically UD. A more proper fix would probably be to pass FactoryMap as Config constructor, but it's a more involved refactoring.