### PR TITLE
Add gpu trace option to profile by iteration count

### DIFF
--- a/libkineto/src/IpcFabricConfigClient.cpp
+++ b/libkineto/src/IpcFabricConfigClient.cpp
@@ -90,7 +90,8 @@ IpcFabricConfigClient::IpcFabricConfigClient() : jobId_(getJobId()), pids_(getPi
   std::string ep_name = "dynoconfigclient" + uuid::generate_uuid_v4();
 
   fabricManager_ = ::dynolog::ipcfabric::FabricManager::factory(ep_name);
-  LOG(INFO) << "Setting up IPC Fabric at endpoint: " << ep_name;
+  LOG(INFO) << "Setting up IPC Fabric at endpoint: " << ep_name
+            << " status = " << (fabricManager_ ? "initialized" : "failed (null)");
 }
 
 int32_t IpcFabricConfigClient::registerInstance(int32_t gpu) {


### PR DESCRIPTION
Summary:
Enables GPU trace using iteration option.
Pytorch app needs to call profiler.step() right now for this to work.

Showing new options
```
dyno-gputrace
Capture gputrace

USAGE:
    dyno gputrace [OPTIONS] --log-file <LOG_FILE>

OPTIONS:
        --iterations <ITERATIONS>                                              Training iterations to collect, this takes precedence over duration [default: -1]
        --profile-start-iteration-roundup <PROFILE_START_ITERATION_ROUNDUP>    Start iteration roundup, starts an iteration based trace at a multiple of this value [default: 1]
```

Reviewed By: anupambhatnagar

Differential Revision: D41662294

