### PR TITLE
Fix for the atomic file write (fixes #687)

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -12,7 +12,6 @@
 #include <fstream>
 #include <time.h>
 #include <map>
-#include <unistd.h>
 
 #include "Config.h"
 #ifdef HAS_CUPTI
@@ -74,15 +73,8 @@ static std::string defaultFileName() {
 }
 
 void ChromeTraceLogger::openTraceFile() {
-  char tempBuf[] = "/tmp/libkineto_activities_tmp.json.XXXXXX";
-  int fd = mkstemp(tempBuf);
-  if (fd == -1) {
-    PLOG(ERROR) << "Failed to create temp file " << tempFileName_;
-    return;
-  }
-  tempFileName_ = tempBuf;
+  tempFileName_ = fileName_ + ".tmp";
   traceOf_.open(tempFileName_, std::ofstream::out | std::ofstream::trunc);
-  close(fd);
   if (!traceOf_) {
     PLOG(ERROR) << "Failed to open '" << fileName_ << "'";
   } else {


### PR DESCRIPTION
Patches the issue outlined in https://github.com/pytorch/kineto/pull/687:
- `rename` doesn't work across file systems
- windows build fails on `mkstemp`

Instead we just use `.tmp` suffix in the same location. It should be good enough and the consumers can easily filter out `.tmp` files when waiting for the trace to be populated