### PR TITLE
Filter roctracer events to active timespan

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -220,7 +220,9 @@ void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
     VLOG(0) << "Retrieving GPU activity buffers";
     const int count = cupti_.processActivities(
         logger,
-        std::bind(&CuptiActivityProfiler::cpuActivity, this, std::placeholders::_1));
+        std::bind(&CuptiActivityProfiler::cpuActivity, this, std::placeholders::_1),
+        captureWindowStartTime_,
+        captureWindowEndTime_);
     LOG(INFO) << "Processed " << count << " GPU records";
     LOGGER_OBSERVER_ADD_EVENT_COUNT(count);
   }

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -80,6 +80,8 @@ int RoctracerActivityApi::processActivities(
   clock_gettime(CLOCK_REALTIME, &t00);
 
   const timestamp_t toffset = (timespec_to_ns(t0) >> 1) + (timespec_to_ns(t00) >> 1) - timespec_to_ns(t1);
+  // Our stored timestamps (from roctracer and generated) are in CLOCK_MONOTONIC domain (in ns).
+  // Convert the guards rather than each timestamp.
   startTime = (startTime * 1000) - toffset;
   endTime = (endTime * 1000) - toffset;
 

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -64,8 +64,13 @@ void RoctracerActivityApi::setMaxBufferSize(int size) {
   //maxGpuBufferCount_ = 1 + size / kBufSize;
 }
 
+inline bool inRange(int64_t start, int64_t end, int64_t stamp) {
+    return ((stamp > start) and (stamp < end));
+}
+
 int RoctracerActivityApi::processActivities(
-    ActivityLogger& logger, std::function<const ITraceActivity*(int32_t)> linkedActivity) {
+    ActivityLogger& logger, std::function<const ITraceActivity*(int32_t)> linkedActivity,
+    int64_t startTime, int64_t endTime) {
   // Find offset to map from monotonic clock to system clock.
   // This will break time-ordering of events but is status quo.
 
@@ -75,6 +80,8 @@ int RoctracerActivityApi::processActivities(
   clock_gettime(CLOCK_REALTIME, &t00);
 
   const timestamp_t toffset = (timespec_to_ns(t0) >> 1) + (timespec_to_ns(t00) >> 1) - timespec_to_ns(t1);
+  startTime = (startTime * 1000) - toffset;
+  endTime = (startTime * 1000) - toffset;
 
   int count = 0;
 
@@ -83,6 +90,8 @@ int RoctracerActivityApi::processActivities(
   // Basic Api calls
 
   for (auto &item : d->rows_) {
+    if (!inRange(startTime, endTime, item.begin))
+        continue;
     GenericTraceActivity a;
     a.startTime = (item.begin + toffset) / 1000;
     a.endTime = (item.end + toffset) / 1000;
@@ -104,6 +113,8 @@ int RoctracerActivityApi::processActivities(
 
   // Malloc/Free calls
   for (auto &item : d->mallocRows_) {
+    if (!inRange(startTime, endTime, item.begin))
+        continue;
     GenericTraceActivity a;
     a.startTime = (item.begin + toffset) / 1000;
     a.endTime = (item.end + toffset) / 1000;
@@ -130,6 +141,8 @@ int RoctracerActivityApi::processActivities(
 
   // HipMemcpy calls
   for (auto &item : d->copyRows_) {
+    if (!inRange(startTime, endTime, item.begin))
+        continue;
     GenericTraceActivity a;
     a.startTime = (item.begin + toffset) / 1000;
     a.endTime = (item.end + toffset) / 1000;
@@ -160,6 +173,8 @@ int RoctracerActivityApi::processActivities(
   // Kernel Launch Api calls
 
   for (auto &item : d->kernelRows_) {
+    if (!inRange(startTime, endTime, item.begin))
+        continue;
     GenericTraceActivity a;
     a.startTime = (item.begin + toffset) / 1000;
     a.endTime = (item.end + toffset) / 1000;
@@ -240,8 +255,10 @@ int RoctracerActivityApi::processActivities(
         auto it = externalCorrelations.find(a.id);
         a.linked = linkedActivity(it == externalCorrelations.end() ? 0 : it->second);
 
-        logger.handleGenericActivity(a);
-        ++count;
+        if (inRange(startTime, endTime, record->begin_ns)) {
+            logger.handleGenericActivity(a);
+            ++count;
+        }
       }
       else if (record->domain == ACTIVITY_DOMAIN_HCC_OPS) {
         // Overlay launch metadata for kernels
@@ -272,8 +289,10 @@ int RoctracerActivityApi::processActivities(
           a.activityName = strings_[it->second];
         }
 
-        logger.handleGenericActivity(a);
-        ++count;
+        if (inRange(startTime, endTime, record->begin_ns)) {
+            logger.handleGenericActivity(a);
+            ++count;
+        }
       }
 
       roctracer_next_record(record, &record);

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -65,7 +65,7 @@ void RoctracerActivityApi::setMaxBufferSize(int size) {
 }
 
 inline bool inRange(int64_t start, int64_t end, int64_t stamp) {
-    return ((stamp > start) and (stamp < end));
+    return ((stamp > start) && (stamp < end));
 }
 
 int RoctracerActivityApi::processActivities(
@@ -81,7 +81,7 @@ int RoctracerActivityApi::processActivities(
 
   const timestamp_t toffset = (timespec_to_ns(t0) >> 1) + (timespec_to_ns(t00) >> 1) - timespec_to_ns(t1);
   startTime = (startTime * 1000) - toffset;
-  endTime = (startTime * 1000) - toffset;
+  endTime = (endTime * 1000) - toffset;
 
   int count = 0;
 

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -53,7 +53,8 @@ class RoctracerActivityApi {
   void teardownContext() {}
 
   int processActivities(ActivityLogger& logger,
-                        std::function<const ITraceActivity*(int32_t)> linkedActivity);
+                        std::function<const ITraceActivity*(int32_t)> linkedActivity,
+                        int64_t startTime, int64_t endTime);
 
   void setMaxBufferSize(int size);
 


### PR DESCRIPTION
When kineto is in "warmup" mode, both cupti and roctracer are active, logging events.  Output events should be limited to the "active" range (and not include the "warmup" events).

CuptiActivityProfiler.cpp provides this filtering for cupti.  Added equivalent filtering to RoctracerActivityApi.cpp.

Emulating the non-optimal behavior of the cupti path where these warmup events are fully logged and stored.  Events could be suppressed at collection-time rather than output-time.