### PR TITLE
Remove std::endl which makes json invalid when including logs

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -457,8 +457,8 @@ void CuptiActivityProfiler::checkTimestampOrder(const ITraceActivity* act1) {
   if (act1->timestamp() > act2->timestamp()) {
     LOG_FIRST_N(WARNING, 10) << "GPU op timestamp (" << act2->timestamp()
                              << ") < runtime timestamp (" << act1->timestamp() << ") by "
-                             << act1->timestamp() - act2->timestamp() << "us" << std::endl
-                             << "Name: " << act2->name() << " Device: " << act2->deviceId()
+                             << act1->timestamp() - act2->timestamp() << "us"
+                             << " Name: " << act2->name() << " Device: " << act2->deviceId()
                              << " Stream: " << act2->resourceId();
   }
 }


### PR DESCRIPTION
Summary: The traces are recording the LOGs for INFO and WARNING, however the strings need to be JSON friendly. In this case, the std::endl will break the json parser. Removing it will enable the trace viewer again.

Reviewed By: leitian

Differential Revision: D41826592

Pulled By: aaronenyeshi

