### PR TITLE
Add user_annotation event to tb_plugin

### DIFF
--- a/tb_plugin/torch_tb_profiler/profiler/trace.py
+++ b/tb_plugin/torch_tb_profiler/profiler/trace.py
@@ -30,6 +30,7 @@ class EventTypes(object):
     MODULE = 'Module'
     PL_PROFILE = 'pl_profile'
     PL_MODULE = 'pl_module'
+    USER_ANNOTATION = 'user_annotation'
 
 
 EventTypeMap = {
@@ -44,7 +45,9 @@ EventTypeMap = {
     'gpu_memset': EventTypes.MEMSET,
     'python': EventTypes.PYTHON,
     'memory': EventTypes.MEMORY,
-    'python_function': EventTypes.PYTHON_FUNCTION
+    'python_function': EventTypes.PYTHON_FUNCTION,
+    'user_annotation': EventTypes.USER_ANNOTATION,
+    'gpu_user_annotation': EventTypes.USER_ANNOTATION
 }
 
 
@@ -181,7 +184,11 @@ def create_event(event, is_pytorch_lightning) -> Optional[BaseEvent]:
 def create_trace_event(event, is_pytorch_lightning) -> Optional[BaseEvent]:
     category = event.get('cat')
     event_type = EventTypeMap.get(category.lower())
-    if event_type == EventTypes.OPERATOR:
+    if event_type == EventTypes.USER_ANNOTATION:
+        name = event.get('name')
+        if name and name.startswith('ProfilerStep#'):
+            return ProfilerStepEvent(event)
+    elif event_type == EventTypes.OPERATOR:
         name = event.get('name')
         if name and name.startswith('ProfilerStep#'):
             return ProfilerStepEvent(event)
@@ -205,8 +212,7 @@ def create_trace_event(event, is_pytorch_lightning) -> Optional[BaseEvent]:
             return PythonFunctionEvent(event_type, event)
     elif event_type is not None:
         return DurationEvent(event_type, event)
-    else:
-        return None
+    return None
 
 
 def create_association_events(events) -> Dict[int, int]:


### PR DESCRIPTION
Summary: The ProfilerStep# event added to traces are being added via record function as a user_annotation instead of operator. This will allow the ProfilerStep# event to be accepted as Operator (old usage) and user_annotation (new usage).

Differential Revision: D42318580

Pulled By: aaronenyeshi

