### PR TITLE
Update ipc config client to support string job ids

### DIFF
--- a/libkineto/src/IpcFabricConfigClient.h
+++ b/libkineto/src/IpcFabricConfigClient.h
@@ -51,7 +51,10 @@ class IpcFabricConfigClient {
   }
 
  protected:
+  // Temporarily keep both int and string job id until IPC related code is updated to handle
+  // string job id.
   int64_t jobId_;
+  std::string jobIdStr_;
   std::vector<int32_t> pids_;
   bool ipcFabricEnabled_;
 


### PR DESCRIPTION
To prepare for supporting string job ids in on demand tracing, we introduce a temporary `jobIdStr_` member on `IpcFabricConfigClient`. Future diffs that update the IPC client to handle string job ids will remove the integer jobId member, so the redundancy introduced by the `jobIdStr_` member is temporary.