### PR TITLE
Add Kineto ActivityProfiler interface API for PyTorch Profiler

### DIFF
--- a/libkineto/include/ActivityProfilerInterface.h
+++ b/libkineto/include/ActivityProfilerInterface.h
@@ -92,6 +92,14 @@ class ActivityProfilerInterface {
   // to enable custom framework events.
   virtual void addChildActivityProfiler(
       std::unique_ptr<IActivityProfiler> profiler) {}
+
+  // Log Invariant Violation to factories enabled. This helps record
+  // instances when the profiler behaves unexpectedly.
+  virtual void logInvariantViolation(
+      const std::string&,
+      const std::string&,
+      const std::string&,
+      const std::string& = "") {}
 };
 
 } // namespace libkineto

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -103,6 +103,16 @@ static std::unique_ptr<ActivityLogger> makeLogger(const Config& config) {
   return loggerFactory().makeLogger(config.activitiesLogUrl());
 }
 
+static std::unique_ptr<InvariantViolationsLogger>& invariantViolationsLoggerFactory() {
+  static std::unique_ptr<InvariantViolationsLogger> factory = nullptr;
+  return factory;
+}
+
+void ActivityProfilerController::setInvariantViolationsLoggerFactory(
+    const std::function<std::unique_ptr<InvariantViolationsLogger>()>& factory) {
+  invariantViolationsLoggerFactory() = factory();
+}
+
 bool ActivityProfilerController::canAcceptConfig() {
   return !profiler_->isActive();
 }

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -327,4 +327,14 @@ void ActivityProfilerController::addMetadata(
   profiler_->addMetadata(key, value);
 }
 
+void ActivityProfilerController::logInvariantViolation(
+    const std::string& profile_id,
+    const std::string& assertion,
+    const std::string& error,
+    const std::string& group_profile_id) {
+  if (invariantViolationsLoggerFactory()) {
+    invariantViolationsLoggerFactory()->logInvariantViolation(profile_id, assertion, error, group_profile_id);
+  }
+}
+
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -81,6 +81,12 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
 
   void addMetadata(const std::string& key, const std::string& value);
 
+  void logInvariantViolation(
+    const std::string& profile_id,
+    const std::string& assertion,
+    const std::string& error,
+    const std::string& group_profile_id = "");
+
  private:
   bool shouldActivateIterationConfig(int64_t currentIter);
   bool shouldActivateTimestampConfig(

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -23,6 +23,7 @@
 #include "ConfigLoader.h"
 #include "CuptiActivityApi.h"
 #include "LoggerCollector.h"
+#include "InvariantViolations.h"
 
 namespace KINETO_NAMESPACE {
 
@@ -45,6 +46,9 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   static void addLoggerFactory(
       const std::string& protocol,
       ActivityLoggerFactory::FactoryFunc factory);
+
+  static void setInvariantViolationsLoggerFactory(
+      const std::function<std::unique_ptr<InvariantViolationsLogger>()>& factory);
 
   // These API are used for On-Demand Tracing.
   bool canAcceptConfig() override;

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -139,4 +139,12 @@ void ActivityProfilerProxy::addChildActivityProfiler(
   controller_->addChildActivityProfiler(std::move(profiler));
 }
 
+void ActivityProfilerProxy::logInvariantViolation(
+    const std::string& profile_id,
+    const std::string& assertion,
+    const std::string& error,
+    const std::string& group_profile_id) {
+    controller_->logInvariantViolation(profile_id, assertion, error, group_profile_id);
+}
+
 } // namespace libkineto

--- a/libkineto/src/ActivityProfilerProxy.h
+++ b/libkineto/src/ActivityProfilerProxy.h
@@ -70,6 +70,12 @@ class ActivityProfilerProxy : public ActivityProfilerInterface {
   virtual void addChildActivityProfiler(
       std::unique_ptr<IActivityProfiler> profiler) override;
 
+  void logInvariantViolation(
+      const std::string& profile_id,
+      const std::string& assertion,
+      const std::string& error,
+      const std::string& group_profile_id = "") override;
+
  private:
   bool cpuOnly_{true};
   ConfigLoader& configLoader_;

--- a/libkineto/src/InvariantViolations.h
+++ b/libkineto/src/InvariantViolations.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace KINETO_NAMESPACE {
+
+class InvariantViolationsLogger {
+  public:
+    virtual ~InvariantViolationsLogger() = default;
+    virtual void logInvariantViolation(
+      const std::string& profile_id,
+      const std::string& assertion,
+      const std::string& error,
+      const std::string& group_profile_id) = 0;
+    static void registerFactory();
+};
+
+}


### PR DESCRIPTION
Summary: Add the InvariantViolations API to ActivityProfiler for PyTorch Profiler to call into.

Differential Revision: D42212426

Pulled By: aaronenyeshi

