### PR TITLE
Env variable to set log level

### DIFF
--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -95,6 +95,13 @@ extern "C" {
 
 // Return true if no CUPTI errors occurred during init
 void libkineto_init(bool cpuOnly, bool logOnError) {
+  // Start with initializing the log level
+  const char* logLevelEnv = getenv("KINETO_LOG_LEVEL");
+  if (logLevelEnv) {
+    // atoi returns 0 on error, so that's what we want - default to VERBOSE
+    static_assert (static_cast<int>(VERBOSE) == 0);
+    SET_LOG_SEVERITY_LEVEL(atoi(logLevelEnv));
+  }
 
   // Factory to connect to open source daemon if present
 #if __linux__
@@ -169,7 +176,11 @@ int InitializeInjection(void) {
 }
 
 void suppressLibkinetoLogMessages() {
-  SET_LOG_SEVERITY_LEVEL(ERROR);
+  // Only suppress messages if explicit override wasn't provided
+  const char* logLevelEnv = getenv("KINETO_LOG_LEVEL");
+  if (!logLevelEnv || !*logLevelEnv) {
+    SET_LOG_SEVERITY_LEVEL(ERROR);
+  }
 }
 
 } // extern C


### PR DESCRIPTION
Small improvement for debugging. Env var is better than the config since it's applied during initialization too. Also it makes suppressLibKinetoLogMessage a noop if env var was provided. Pytorch always calls it thus kind of defeating the purpose for configuring the log level