### PR TITLE
Fix uuid generation for IPC fabric

### DIFF
--- a/libkineto/src/IpcFabricConfigClient.cpp
+++ b/libkineto/src/IpcFabricConfigClient.cpp
@@ -22,37 +22,37 @@
 namespace KINETO_NAMESPACE {
 
 namespace uuid {
-    static std::random_device rd;
-    static std::mt19937 gen(rd());
-    static std::uniform_int_distribution<> dis(0, 15);
-    static std::uniform_int_distribution<> dis2(8, 11);
+std::string generate_uuid_v4() {
+  static std::random_device rd;
+  static std::mt19937 gen(rd());
+  static std::uniform_int_distribution<> dis(0, 15);
+  static std::uniform_int_distribution<> dis2(8, 11);
 
-    std::string generate_uuid_v4() {
-        std::stringstream ss;
-        int i;
-        ss << std::hex;
-        for (i = 0; i < 8; i++) {
-            ss << dis(gen);
-        }
-        ss << "-";
-        for (i = 0; i < 4; i++) {
-            ss << dis(gen);
-        }
-        ss << "-4";
-        for (i = 0; i < 3; i++) {
-            ss << dis(gen);
-        }
-        ss << "-";
-        ss << dis2(gen);
-        for (i = 0; i < 3; i++) {
-            ss << dis(gen);
-        }
-        ss << "-";
-        for (i = 0; i < 12; i++) {
-            ss << dis(gen);
-        };
-        return ss.str();
-    }
+  std::stringstream ss;
+  int i;
+  ss << std::hex;
+  for (i = 0; i < 8; i++) {
+      ss << dis(gen);
+  }
+  ss << "-";
+  for (i = 0; i < 4; i++) {
+      ss << dis(gen);
+  }
+  ss << "-4";
+  for (i = 0; i < 3; i++) {
+      ss << dis(gen);
+  }
+  ss << "-";
+  ss << dis2(gen);
+  for (i = 0; i < 3; i++) {
+      ss << dis(gen);
+  }
+  ss << "-";
+  for (i = 0; i < 12; i++) {
+      ss << dis(gen);
+  };
+  return ss.str();
+}
 }
 
 // Connect to the Dynolog service through Fabric name `dynolog`


### PR DESCRIPTION
PyTorch calls IPCFabric initialization from static initializer. So it might be called before global variables in this translation unit are initialized. That was happening before (at least in my build) - all uuids generated had all zeroes in them since the random generator was in a bad state.