### PR TITLE
Snappier start time (10s->2s) when initial timestamp is not specified

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -299,6 +299,8 @@ class Config : public AbstractConfig {
     return activitiesOnDemandTimestamp_;
   }
 
+  static constexpr std::chrono::milliseconds kControllerIntervalMsecs{1000};
+
   // Users may request and set trace id and group trace id.
   const std::string& requestTraceID() const {
     return requestTraceID_;

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -27,8 +27,6 @@ using namespace std::chrono;
 
 namespace KINETO_NAMESPACE {
 
-constexpr milliseconds kProfilerIntervalMsecs(1000);
-
 #if !USE_GOOGLE_LOG
 static std::unique_ptr<LoggerCollector>& loggerCollectorFactory() {
   static std::unique_ptr<LoggerCollector> factory = nullptr;
@@ -129,11 +127,11 @@ bool ActivityProfilerController::shouldActivateTimestampConfig(
   if (asyncRequestConfig_->hasProfileStartIteration()) {
     return false;
   }
-  // Note on now + kProfilerIntervalMsecs
+  // Note on now + Config::kControllerIntervalMsecs:
   // Profiler interval does not align perfectly up to startTime - warmup.
   // Waiting until the next tick won't allow sufficient time for the profiler to warm up.
   // So check if we are very close to the warmup time and trigger warmup.
-  if (now + kProfilerIntervalMsecs
+  if (now + Config::kControllerIntervalMsecs
       >= (asyncRequestConfig_->requestTimestamp() - asyncRequestConfig_->activitiesWarmupDuration())) {
     LOG(INFO) << "Received on-demand activity trace request by "
               << " profile timestamp = "
@@ -188,7 +186,7 @@ void ActivityProfilerController::profilerLoop() {
   VLOG(0) << "Entering activity profiler loop";
 
   auto now = system_clock::now();
-  auto next_wakeup_time = now + kProfilerIntervalMsecs;
+  auto next_wakeup_time = now + Config::kControllerIntervalMsecs;
 
   while (!stopRunloop_) {
     now = system_clock::now();
@@ -209,7 +207,7 @@ void ActivityProfilerController::profilerLoop() {
     }
 
     while (next_wakeup_time < now) {
-      next_wakeup_time += kProfilerIntervalMsecs;
+      next_wakeup_time += Config::kControllerIntervalMsecs;
     }
 
     if (profiler_->isActive()) {
@@ -240,7 +238,7 @@ void ActivityProfilerController::step() {
 
   if (profiler_->isActive()) {
     auto now = system_clock::now();
-    auto next_wakeup_time = now + kProfilerIntervalMsecs;
+    auto next_wakeup_time = now + Config::kControllerIntervalMsecs;
     profiler_->performRunLoopStep(now, next_wakeup_time, currentIter);
   }
 }

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -31,12 +31,13 @@ using std::vector;
 
 namespace KINETO_NAMESPACE {
 
+constexpr std::chrono::milliseconds Config::kControllerIntervalMsecs;
+
 constexpr milliseconds kDefaultSamplePeriodMsecs(1000);
 constexpr milliseconds kDefaultMultiplexPeriodMsecs(1000);
 constexpr milliseconds kDefaultActivitiesProfileDurationMSecs(500);
 constexpr int kDefaultActivitiesMaxGpuBufferSize(128 * 1024 * 1024);
 constexpr seconds kDefaultActivitiesWarmupDurationSecs(5);
-constexpr seconds kDefaultBufferUntilWarmup(10);
 constexpr seconds kDefaultReportPeriodSecs(1);
 constexpr int kDefaultSamplesPerReport(1);
 constexpr int kDefaultMaxEventProfilersPerGpu(1);
@@ -454,9 +455,9 @@ void Config::validate(
   if (!hasProfileStartTime()) {
     VLOG(0)
         << "No explicit timestamp has been set. "
-        << "Defaulting it to now + activitiesWarmupDuration with buffer.";
+        << "Defaulting it to now + activitiesWarmupDuration with a buffer of double the period of the monitoring thread.";
     profileStartTime_ = fallbackProfileStartTime +
-        activitiesWarmupDuration() + kDefaultBufferUntilWarmup;
+        activitiesWarmupDuration() + 2 * Config::kControllerIntervalMsecs;
   }
 
   if (profileStartIterationRoundUp_ == 0) {


### PR DESCRIPTION
I think it's sufficient and gives slightly better UX