### PR TITLE
enable ipc fabric using env variable

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -460,4 +460,6 @@ class Config : public AbstractConfig {
   size_t cuptiDeviceBufferPoolLimit_;
 };
 
+constexpr char kUseDaemonEnvVar[] = "KINETO_USE_DAEMON";
+
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -219,6 +219,9 @@ Config::Config()
   if (factories) {
     factories->addFeatureConfigs(*this);
   }
+#if __linux__
+  enableIpcFabric_ = (getenv(kUseDaemonEnvVar) != nullptr);
+#endif
 }
 
 std::shared_ptr<void> Config::getStaticObjectsLifetimeHandle() {

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -98,7 +98,7 @@ void libkineto_init(bool cpuOnly, bool logOnError) {
 
   // Factory to connect to open source daemon if present
 #if __linux__
-  if (getenv("KINETO_USE_DAEMON") != nullptr) {
+  if (getenv(kUseDaemonEnvVar) != nullptr) {
     LOG(INFO) << "Registering daemon config loader";
     DaemonConfigLoader::registerFactory();
   }


### PR DESCRIPTION
Summary: This will remove the need to explicitly enable IPC fabric in a config.

Differential Revision: D42646533

