### PR TITLE
C++14 support fix for static assert in init.cpp

### DIFF
--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -98,8 +98,11 @@ void libkineto_init(bool cpuOnly, bool logOnError) {
   // Start with initializing the log level
   const char* logLevelEnv = getenv("KINETO_LOG_LEVEL");
   if (logLevelEnv) {
+    // TODO CXX 17 - https://github.com/pytorch/kineto/issues/650
+#if __cplusplus >= 201703L
     // atoi returns 0 on error, so that's what we want - default to VERBOSE
     static_assert (static_cast<int>(VERBOSE) == 0);
+#endif
     SET_LOG_SEVERITY_LEVEL(atoi(logLevelEnv));
   }
 


### PR DESCRIPTION
Summary:
as above, this fixes a CI issue merging into pytorch
https://github.com/pytorch/pytorch/actions/runs/4018859054/jobs/6904997997
Error = "language feature 'terse static assert' requires compiler flag '/std:c++17"

Reviewed By: haowangludx

Differential Revision: D42786282

