### PR TITLE
Add missing include for std::function

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -9,6 +9,7 @@
 #include "ActivityProfilerController.h"
 
 #include <chrono>
+#include <functional>
 #include <thread>
 
 #include "ActivityLoggerFactory.h"

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <thread>

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -14,6 +14,7 @@
 #include <fmt/format.h>
 #include <chrono>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <istream>
 #include <mutex>

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <chrono>
 #include <fstream>
+#include <functional>
 #include <memory>
 
 #include "DaemonConfigLoader.h"

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <thread>

--- a/libkineto/src/EventProfilerController.cpp
+++ b/libkineto/src/EventProfilerController.cpp
@@ -9,6 +9,7 @@
 #include "EventProfilerController.h"
 
 #include <chrono>
+#include <functional>
 #include <thread>
 #include <vector>
 

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -8,6 +8,7 @@
 
 #include <cstring>
 #include <chrono>
+#include <functional>
 #include <time.h>
 
 #include "RoctracerActivityApi.h"

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -12,6 +12,7 @@
 #include <map>
 #include <set>
 #include <atomic>
+#include <functional>
 
 #ifdef HAS_ROCTRACER
 #include <roctracer.h>


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/93219 is blocked since libkineto relies on some transitive includes of std::functional from libfmt which appears to have been removed. This fix just applies IWYU rules by inserting `#include <functional>` to every file that use std::function