### PR TITLE
Remove unused registered flag in CuptiActivityApi.cpp

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -277,11 +277,8 @@ void CuptiActivityApi::bufferCompleted(
 void CuptiActivityApi::enableCuptiActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_CUPTI
-  static bool registered = false;
-  if (!registered) {
   CUPTI_CALL(
       cuptiActivityRegisterCallbacks(bufferRequestedTrampoline, bufferCompletedTrampoline));
-  }
 
   externalCorrelationEnabled_ = false;
   for (const auto& activity : selected_activities) {


### PR DESCRIPTION
Summary: The registered flag seems to be old code that is never set to true. We don't need this check, since it may confuse devs.

Reviewed By: chaekit

Differential Revision: D43505512

Pulled By: aaronenyeshi

