### PR TITLE
After a cuptiFinalize, reset the CUPTI subscriber handle

### DIFF
--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -106,6 +106,7 @@ void CuptiCallbackApi::__callback_switchboard(
           // Teardown CUPTI calling cuptiFinalize()
           CUPTI_CALL(cuptiFinalize());
           initSuccess_ = false;
+          subscriber_ = 0;
           CuptiActivityApi::singleton().teardownCupti_ = 0;
           CuptiActivityApi::singleton().finalizeCond_.notify_all();
           return;

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -141,7 +141,7 @@ class CuptiCallbackApi {
 
 #ifdef HAS_CUPTI
   CUptiResult lastCuptiStatus_;
-  CUpti_SubscriberHandle subscriber_;
+  CUpti_SubscriberHandle subscriber_ {0};
 #endif
 };
 


### PR DESCRIPTION
Summary: After a teardown, we are resetting the entire cupti context. This includes disabling all the existing CUPTI callbacks. It may also invalidate the CUpti_SubscriberHandle, we should set it back to 0, so that the next cuptiSubscribe will initialize a new value.

Reviewed By: leitian

Differential Revision: D43549826

Pulled By: aaronenyeshi

