### PR TITLE
Add logging around CUPTI API calls

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -376,6 +376,7 @@ void CuptiActivityApi::teardownContext() {
       tracingEnabled_ = 0;
 
       // Re-enable callbacks from the past.
+      LOG(INFO) << "Re-enabling previous CUPTI callbacks";
       cbapi_->initCallbackApi();
       cbapi_->reenableCallbacks();
       status = cbapi_->disableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -103,6 +103,7 @@ void CuptiCallbackApi::__callback_switchboard(
       // This is required to teardown cupti after profiling to prevent QPS slowdown.
       if (CuptiActivityApi::singleton().teardownCupti_) {
         if (cbInfo->callbackSite == CUPTI_API_EXIT) {
+          LOG(INFO) << "  Calling cuptiFinalize in exit callsite";
           // Teardown CUPTI calling cuptiFinalize()
           CUPTI_CALL(cuptiFinalize());
           initSuccess_ = false;
@@ -172,10 +173,12 @@ std::shared_ptr<CuptiCallbackApi> CuptiCallbackApi::singleton() {
 void CuptiCallbackApi::initCallbackApi() {
 #ifdef HAS_CUPTI
   lastCuptiStatus_ = CUPTI_ERROR_UNKNOWN;
+  LOG(INFO) << "  Calling cuptiSubscribe, subscriber:" << subscriber_;
   lastCuptiStatus_ = CUPTI_CALL_NOWARN(
     cuptiSubscribe(&subscriber_,
       (CUpti_CallbackFunc)callback_switchboard,
       nullptr));
+  LOG(INFO) << "    subscriber: " << subscriber_;
 
   initSuccess_ = (lastCuptiStatus_ == CUPTI_SUCCESS);
 #endif


### PR DESCRIPTION
Summary: To improve logs, add additional logging around CUPTI API usage. Check the subscriber_ value before and after cuptiSubscribe.

Reviewed By: leitian

Differential Revision: D43664811

Pulled By: aaronenyeshi

