### PR TITLE
Remove the callbacks used for finalize before re-init callbacks

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -375,14 +375,20 @@ void CuptiActivityApi::teardownContext() {
       teardownCupti_ = 0;
       tracingEnabled_ = 0;
 
+      // Remove the callbacks used specifically for cuptiFinalize
+      cbapi_->disableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);
+      cbapi_->disableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
+
       // Re-enable callbacks from the past.
       LOG(INFO) << "Re-enabling previous CUPTI callbacks";
       cbapi_->initCallbackApi();
-      cbapi_->reenableCallbacks();
-      status = cbapi_->disableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);
-      status = status && cbapi_->disableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
-      if (!status) {
-        LOG(WARNING) << "CUPTI Callback failed to disable for domain";
+      if (cbapi_->initSuccess()) {
+        status = cbapi_->reenableCallbacks();
+        if (!status) {
+          LOG(WARNING) << "Failed to reenableCallbacks";
+        }
+      } else {
+        LOG(WARNING) << "Failed to initCallbackApi";
       }
       cbapi_.reset();
     });

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -281,10 +281,10 @@ bool CuptiCallbackApi::enableCallback(
 bool CuptiCallbackApi::disableCallback(
     CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
 #ifdef HAS_CUPTI
+  enabledCallbacks_.erase({domain, cbid});
   if (initSuccess_) {
     lastCuptiStatus_ = CUPTI_CALL_NOWARN(
         cuptiEnableCallback(0, subscriber_, domain, cbid));
-    enabledCallbacks_.erase({domain, cbid});
     return (lastCuptiStatus_ == CUPTI_SUCCESS);
   }
 #endif
@@ -307,10 +307,10 @@ bool CuptiCallbackApi::enableCallbackDomain(
 bool CuptiCallbackApi::disableCallbackDomain(
     CUpti_CallbackDomain domain) {
 #ifdef HAS_CUPTI
+  enabledCallbacks_.erase({domain, MAX_CUPTI_CALLBACK_ID_ALL});
   if (initSuccess_) {
     lastCuptiStatus_ = CUPTI_CALL_NOWARN(
         cuptiEnableDomain(0, subscriber_, domain));
-    enabledCallbacks_.erase({domain, MAX_CUPTI_CALLBACK_ID_ALL});
     return (lastCuptiStatus_ == CUPTI_SUCCESS);
   }
 #endif


### PR DESCRIPTION
Summary: Before re-init of previous callbacks, remove the domain and resource call backs used specifically for cuptiFinalize. Then re-init the previous callbacks before teardown. It is good enough to remove them from the callback tracker set. Also, add more logging for failure cases.

Reviewed By: chaekit

Differential Revision: D43665392

Pulled By: aaronenyeshi

