### PR TITLE
Move CUPTI subscriber logs to teardown API only

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -366,6 +366,7 @@ void CuptiActivityApi::teardownContext() {
       // Force Flush before finalize
       CUPTI_CALL(cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
 
+      LOG(INFO) << "  CUPTI subscriber before finalize:" << cbapi_->getCuptiSubscriber();
       teardownCupti_ = 1;
       std::unique_lock<std::mutex> lck(finalizeMutex_);
       finalizeCond_.wait(lck, [&]{return teardownCupti_ == 0;});
@@ -380,9 +381,11 @@ void CuptiActivityApi::teardownContext() {
       cbapi_->disableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
 
       // Re-enable callbacks from the past.
-      LOG(INFO) << "Re-enabling previous CUPTI callbacks";
+      LOG(INFO) << "Re-enable previous CUPTI callbacks starting";
+      LOG(INFO) << "  CUPTI subscriber before reinit:" << cbapi_->getCuptiSubscriber();
       cbapi_->initCallbackApi();
       if (cbapi_->initSuccess()) {
+        LOG(INFO) << "  CUPTI subscriber after reinit:" << cbapi_->getCuptiSubscriber();
         status = cbapi_->reenableCallbacks();
         if (!status) {
           LOG(WARNING) << "Failed to reenableCallbacks";
@@ -391,6 +394,7 @@ void CuptiActivityApi::teardownContext() {
         LOG(WARNING) << "Failed to initCallbackApi";
       }
       cbapi_.reset();
+      LOG(INFO) << "Re-enable previous CUPTI callbacks complete";
     });
     teardownThread.detach();
   }

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -173,12 +173,10 @@ std::shared_ptr<CuptiCallbackApi> CuptiCallbackApi::singleton() {
 void CuptiCallbackApi::initCallbackApi() {
 #ifdef HAS_CUPTI
   lastCuptiStatus_ = CUPTI_ERROR_UNKNOWN;
-  LOG(INFO) << "  Calling cuptiSubscribe, subscriber:" << subscriber_;
   lastCuptiStatus_ = CUPTI_CALL_NOWARN(
     cuptiSubscribe(&subscriber_,
       (CUpti_CallbackFunc)callback_switchboard,
       nullptr));
-  LOG(INFO) << "    subscriber: " << subscriber_;
 
   initSuccess_ = (lastCuptiStatus_ == CUPTI_SUCCESS);
 #endif

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -80,6 +80,10 @@ class CuptiCallbackApi {
   CUptiResult getCuptiStatus() const {
     return lastCuptiStatus_;
   }
+
+  CUpti_SubscriberHandle getCuptiSubscriber() const {
+    return subscriber_;
+  }
 #endif
 
   bool registerCallback(


### PR DESCRIPTION
Summary:
Remove the logs in initCallbackApi() which is becoming noisy for several libraries.

Move these logs into the teardown API area only. This doesn't happen often, so log this information to prod investigations.

Differential Revision: D43777568

Pulled By: aaronenyeshi

