### PR TITLE
Add cuptiUnsubscribe before cuptiFinalize

### DIFF
--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -105,6 +105,7 @@ void CuptiCallbackApi::__callback_switchboard(
         if (cbInfo->callbackSite == CUPTI_API_EXIT) {
           LOG(INFO) << "  Calling cuptiFinalize in exit callsite";
           // Teardown CUPTI calling cuptiFinalize()
+          CUPTI_CALL(cuptiUnsubscribe(subscriber_));
           CUPTI_CALL(cuptiFinalize());
           initSuccess_ = false;
           subscriber_ = 0;


### PR DESCRIPTION
Summary: Ensure that the subscriber handle is unsubscribed with CUPTI with cuptiUnsubscribe() API before cuptiFinalize() and setting it to 0.

Reviewed By: leitian

Differential Revision: D43858432

Pulled By: aaronenyeshi

