### PR TITLE
Improve Config Options for Input Shapes, Memory, Stack, Flops, and Modules - Part 1

### DIFF
--- a/libkineto/include/ClientInterface.h
+++ b/libkineto/include/ClientInterface.h
@@ -14,10 +14,9 @@ class ClientInterface {
  public:
   virtual ~ClientInterface() {}
   virtual void init() = 0;
-  virtual void warmup(bool setupOpInputsCollection) = 0;
+  virtual void prepare(bool, bool, bool, bool, bool) = 0;
   virtual void start() = 0;
   virtual void stop() = 0;
-  virtual void set_withstack(bool withStack) = 0;
 };
 
 } // namespace libkineto

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -180,12 +180,24 @@ class Config : public AbstractConfig {
     selectedActivityTypes_ = types;
   }
 
-  bool isOpInputsCollectionEnabled() const {
-    return enableOpInputsCollection_;
+  bool isReportInputShapesEnabled() const {
+    return enableReportInputShapes_;
   }
 
-  bool isPythonStackTraceEnabled() const {
-    return enablePythonStackTrace_;
+  bool isProfileMemoryEnabled() const {
+    return enableProfileMemory_;
+  }
+
+  bool isWithStackEnabled() const {
+    return enableWithStack_;
+  }
+
+  bool isWithFlopsEnabled() const {
+    return enableWithFlops_;
+  }
+
+  bool isWithModulesEnabled() const {
+    return enableWithModules_;
   }
 
   // Trace for this long
@@ -411,12 +423,12 @@ class Config : public AbstractConfig {
   std::chrono::seconds activitiesWarmupDuration_;
   int activitiesWarmupIterations_;
 
-  // Client Interface
-  // Enable inputs collection when tracing ops
-  bool enableOpInputsCollection_{true};
-
-  // Enable Python Stack Tracing
-  bool enablePythonStackTrace_{false};
+  // Enable Profiler Config Options
+  bool enableReportInputShapes_{true};
+  bool enableProfileMemory_{false};
+  bool enableWithStack_{false};
+  bool enableWithFlops_{false};
+  bool enableWithModules_{false};
 
   // Profile for specified iterations and duration
   std::chrono::milliseconds activitiesDuration_;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -73,8 +73,15 @@ constexpr char kActivitiesMaxGpuBufferSizeKey[] =
     "ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB";
 
 // Client Interface
+// TODO: keep supporting these older config options, deprecate in the future using replacements.
 constexpr char kClientInterfaceEnableOpInputsCollection[] = "CLIENT_INTERFACE_ENABLE_OP_INPUTS_COLLECTION";
 constexpr char kPythonStackTrace[] = "PYTHON_STACK_TRACE";
+// Profiler Config Options
+constexpr char kProfileReportInputShapes[] = "PROFILE_REPORT_INPUT_SHAPES";
+constexpr char kProfileProfileMemory[] = "PROFILE_PROFILE_MEMORY";
+constexpr char kProfileWithStack[] = "PROFILE_WITH_STACK";
+constexpr char kProfileWithFlops[] = "PROFILE_WITH_FLOPS";
+constexpr char kProfileWithModules[] = "PROFILE_WITH_MODULES";
 
 constexpr char kActivitiesWarmupIterationsKey[] =
     "ACTIVITIES_WARMUP_ITERATIONS";
@@ -368,11 +375,24 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     activitiesWarmupIterations_ = toInt32(val);
   }
 
-  // Client Interface
+  // TODO: Deprecate Client Interface
   else if (!name.compare(kClientInterfaceEnableOpInputsCollection)) {
-    enableOpInputsCollection_ = toBool(val);
+    enableReportInputShapes_ = toBool(val);
   } else if (!name.compare(kPythonStackTrace)) {
-    enablePythonStackTrace_ = toBool(val);
+    enableWithStack_ = toBool(val);
+  }
+
+  // Profiler Config
+  else if (!name.compare(kProfileReportInputShapes)) {
+    enableReportInputShapes_ = toBool(val);
+  } else if (!name.compare(kProfileProfileMemory)) {
+    enableProfileMemory_ = toBool(val);
+  } else if (!name.compare(kProfileWithStack)) {
+    enableWithStack_ = toBool(val);
+  } else if (!name.compare(kProfileWithFlops)) {
+    enableWithFlops_ = toBool(val);
+  } else if (!name.compare(kProfileWithModules)) {
+    enableWithModules_ = toBool(val);
   }
 
   // Common

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -60,7 +60,6 @@ ConfigDerivedState::ConfigDerivedState(const Config& config) {
     profileEndIter_ = (std::numeric_limits<decltype(profileEndIter_)>::max)();
     profileEndTime_ = profileStartTime_ + config.activitiesDuration();
   }
-  profileWithStack_ = config.isPythonStackTraceEnabled();
 }
 
 bool ConfigDerivedState::canStart(
@@ -660,7 +659,12 @@ void CuptiActivityProfiler::configure(
   }
 
   if (libkineto::api().client()) {
-    libkineto::api().client()->warmup(config_->isOpInputsCollectionEnabled());
+    libkineto::api().client()->prepare(
+      config_->isReportInputShapesEnabled(),
+      config_->isProfileMemoryEnabled(),
+      config_->isWithStackEnabled(),
+      config_->isWithFlopsEnabled(),
+      config_->isWithModulesEnabled());
   }
 
   if (derivedConfig_->isProfilingByIteration()) {
@@ -788,7 +792,6 @@ const time_point<system_clock> CuptiActivityProfiler::performRunLoopStep(
         }
         startTrace(now);
         if (libkineto::api().client()) {
-          libkineto::api().client()->set_withstack(derivedConfig_->profileWithPythonStack());
           libkineto::api().client()->start();
         }
         if (nextWakeupTime > derivedConfig_->profileEndTime()) {

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -86,9 +86,6 @@ struct ConfigDerivedState final {
   int64_t profileStartIteration() const { return profileStartIter_; }
   int64_t profileEndIteration() const { return profileEndIter_; }
   bool isProfilingByIteration() const { return profilingByIter_; }
-  bool profileWithPythonStack() const {
-    return profileWithStack_;
-  }
 
  private:
   std::set<ActivityType> profileActivityTypes_;
@@ -100,7 +97,6 @@ struct ConfigDerivedState final {
   int64_t profileStartIter_{-1};
   int64_t profileEndIter_{-1};
   bool profilingByIter_{false};
-  bool profileWithStack_{false};
 };
 
 class CuptiActivityProfiler {


### PR DESCRIPTION
Summary:
Improve On-Demand Kineto config to enable toggling of [profiler options](https://pytorch.org/docs/stable/profiler.html) via the config file. New config strings:
- PROFILE_REPORT_INPUT_SHAPES
- PROFILE_PROFILE_MEMORY
- PROFILE_WITH_STACK
- PROFILE_WITH_FLOPS
- PROFILE_WITH_MODULES

Also marked for deprecation, but still valid, old config options:
- CLIENT_INTERFACE_ENABLE_OP_INPUTS_COLLECTION
- PYTHON_STACK_TRACE

Reviewed By: leitian

Differential Revision: D44275220

Pulled By: aaronenyeshi

