### PR TITLE
make input shape collection opt-in for on-demand tracing

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -424,7 +424,8 @@ class Config : public AbstractConfig {
   int activitiesWarmupIterations_;
 
   // Enable Profiler Config Options
-  bool enableReportInputShapes_{true};
+  // Temporarily disable shape collection until we re-roll out the feature for on-demand cases
+  bool enableReportInputShapes_{false};
   bool enableProfileMemory_{false};
   bool enableWithStack_{false};
   bool enableWithFlops_{false};


### PR DESCRIPTION
Summary: Make input shape collection opt-in as we are re-rolling out the feature for on-demand tracing. Making this default right away could cause bloated trace size for inferences

Differential Revision: D44377341

