### PR TITLE
Record cuLaunchKernel events

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -25,6 +25,7 @@ enum class ActivityType {
     CONCURRENT_KERNEL, // on-device kernels
     EXTERNAL_CORRELATION,
     CUDA_RUNTIME, // host side cuda runtime events
+    CUDA_DRIVER, // host side cuda driver events
     CPU_INSTANT_EVENT, // host side point-like events
     PYTHON_FUNCTION,
     OVERHEAD, // CUPTI induced overhead events sampled from its overhead API.

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -26,6 +26,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
     {"kernel", ActivityType::CONCURRENT_KERNEL},
     {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
     {"cuda_runtime", ActivityType::CUDA_RUNTIME},
+    {"cuda_driver", ActivityType::CUDA_DRIVER},
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
     {"python_function", ActivityType::PYTHON_FUNCTION},
     {"overhead", ActivityType::OVERHEAD},

--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -159,6 +159,10 @@ inline void RuntimeActivity::log(ActivityLogger& logger) const {
   logger.handleActivity(*this);
 }
 
+inline void DriverActivity::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+}
+
 inline void OverheadActivity::log(ActivityLogger& logger) const {
   logger.handleActivity(*this);
 }
@@ -187,6 +191,22 @@ inline const std::string RuntimeActivity::metadataJson() const {
   return fmt::format(R"JSON(
       "cbid": {}, "correlation": {})JSON",
       activity_.cbid, activity_.correlationId);
+}
+
+inline bool DriverActivity::flowStart() const {
+  return activity_.cbid == CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel;
+}
+
+inline const std::string DriverActivity::metadataJson() const {
+  return fmt::format(R"JSON(
+      "cbid": {}, "correlation": {})JSON",
+      activity_.cbid, activity_.correlationId);
+}
+
+inline const std::string DriverActivity::name() const {
+  // currently only cuLaunchKernel is expected
+  assert(activity_.cbid == CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel);
+  return "cuLaunchKernel";
 }
 
 template<class T>

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -77,6 +77,26 @@ struct RuntimeActivity : public CuptiActivity<CUpti_ActivityAPI> {
   const int32_t threadId_;
 };
 
+// CUpti_ActivityAPI - CUDA driver activities
+struct DriverActivity : public CuptiActivity<CUpti_ActivityAPI> {
+  explicit DriverActivity(
+      const CUpti_ActivityAPI* activity,
+      const ITraceActivity* linked,
+      int32_t threadId)
+      : CuptiActivity(activity, linked), threadId_(threadId) {}
+  int64_t correlationId() const override {return activity_.correlationId;}
+  int64_t deviceId() const override {return processId();}
+  int64_t resourceId() const override {return threadId_;}
+  ActivityType type() const override {return ActivityType::CUDA_DRIVER;}
+  bool flowStart() const override;
+  const std::string name() const override;
+  void log(ActivityLogger& logger) const override;
+  const std::string metadataJson() const override;
+
+ private:
+  const int32_t threadId_;
+};
+
 // CUpti_ActivityAPI - CUDA runtime activities
 struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
   explicit OverheadActivity(

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -328,6 +328,9 @@ void CuptiActivityApi::enableCuptiActivities(
     if (activity == ActivityType::CUDA_RUNTIME) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_RUNTIME));
     }
+    if (activity == ActivityType::CUDA_DRIVER) {
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_DRIVER));
+    }
     if (activity == ActivityType::OVERHEAD) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_OVERHEAD));
     }
@@ -358,6 +361,9 @@ void CuptiActivityApi::disableCuptiActivities(
     }
     if (activity == ActivityType::CUDA_RUNTIME) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_RUNTIME));
+    }
+    if (activity == ActivityType::CUDA_DRIVER) {
+      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_DRIVER));
     }
     if (activity == ActivityType::OVERHEAD) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_OVERHEAD));

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -305,6 +305,8 @@ class CuptiActivityProfiler {
       const CUpti_ActivityExternalCorrelation* correlation);
   void handleRuntimeActivity(
       const CUpti_ActivityAPI* activity, ActivityLogger* logger);
+  void handleDriverActivity(
+      const CUpti_ActivityAPI* activity, ActivityLogger* logger);
   void handleOverheadActivity(
       const CUpti_ActivityOverhead* activity, ActivityLogger* logger);
   void handleGpuActivity(const ITraceActivity& act,

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -95,7 +95,8 @@ TEST(ParseTest, ActivityTypes) {
                             ActivityType::CONCURRENT_KERNEL,
                             ActivityType::EXTERNAL_CORRELATION,
                             ActivityType::OVERHEAD,
-                            ActivityType::CUDA_RUNTIME}));
+                            ActivityType::CUDA_RUNTIME,
+                            ActivityType::CUDA_DRIVER}));
 
   Config cfg2;
   EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES=gpu_memcpy,gpu_MeMsEt,kernel"));


### PR DESCRIPTION
Summary:
Triton kernels launched by PT2 launch via cuLaunchKernel instead of cudaLaunchKernel:
* cudaLaunchKernel is part of the runtime API, which we already record.
* cuLaunchKernel is part of the driver API, which we didn't record before this change.

This diff registers callbacks for the driver api events; but it ignores all events other than cuLaunchKernel.

Differential Revision: D45071601

