### PR TITLE
Sanitize JSON strings for event names

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -37,9 +37,7 @@ static constexpr char kDefaultLogFileFmt[] = "libkineto_activities_{}.json";
 
 std::string& ChromeTraceLogger::sanitizeStrForJSON(std::string& value) {
 // Replace all backslashes with forward slash because Windows paths causing JSONDecodeError.
-#ifdef _WIN32
   std::replace(value.begin(), value.end(), '\\', '/');
-#endif
   return value;
 }
 
@@ -315,7 +313,7 @@ void ChromeTraceLogger::handleActivity(
     "ph": "X", "cat": "{}", "name": "{}", "pid": {}, "tid": {},
     "ts": {}, "dur": {}{}
   }},)JSON",
-          toString(op.type()), op_name, device, resource,
+          toString(op.type()), sanitizeStrForJSON(op_name), device, resource,
           ts, duration, args);
   // clang-format on
   if (op.flowId() > 0) {


### PR DESCRIPTION
Summary:
This JSON string shows events in the chrome trace. The names for these events can sometimes be file paths, e.g. for python tracing. On windows, file paths contain backslashes, so we need to sanitize these strings.

I also changed the sanitization function so that it always removes backslashes instead of only doing it on windows. That should make testing easier (and we probably don't want backslashes anyway?)

Differential Revision: D45095675

