### PR TITLE
Possible fix for static order deinit with loggercollector

### DIFF
--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -41,7 +41,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
 
 #if !USE_GOOGLE_LOG
   static void setLoggerCollectorFactory(
-      std::function<std::unique_ptr<LoggerCollector>()> factory);
+      std::function<std::shared_ptr<LoggerCollector>()> factory);
 #endif // !USE_GOOGLE_LOG
 
   static void addLoggerFactory(
@@ -100,6 +100,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
 
   std::unique_ptr<CuptiActivityProfiler> profiler_;
   std::unique_ptr<ActivityLogger> logger_;
+  std::shared_ptr<LoggerCollector> loggerCollectorFactory_;
   std::thread* profilerThread_{nullptr};
   std::atomic_bool stopRunloop_{false};
   std::atomic<std::int64_t> iterationCount_{-1};


### PR DESCRIPTION
Summary:
Root cause explanation-
* During the teardown part.. a config thread periodically checks for configs but the singleton was likely released.
* It then proceeds to LOG() something that creates a short lived Logger object.
* The logger object has a set of observers and we see a crash in one of them.
* Reason for this is the observers is a set of raw pointers, but the actual object `loggerCollectorFactory()` might have de-init behave we removed it from the set.

Fix involves the ActivityProfilerController class holding a reference (shared pointer) to loggerCollectorFactory so it will not get destroyed before this object removes it from the list of logger observers.

Differential Revision: D45972789

