### PR TITLE
Revert D42825031: Multisect successfully blamed D42825031 for test or build failures

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -31,7 +31,6 @@ enum class ActivityType {
     OVERHEAD, // CUPTI induced overhead events sampled from its overhead API.
 
     // Optional Activity types
-    CUDA_SYNC, // synchronization events between runtime and kernels
     GLOW_RUNTIME, // host side glow runtime events
     MTIA_RUNTIME, // host side MTIA runtime events
     CUDA_PROFILER_RANGE, // CUPTI Profiler range for performance metrics
@@ -40,7 +39,7 @@ enum class ActivityType {
     XPU_RUNTIME, // host side xpu runtime events
 
     ENUM_COUNT, // This is to add buffer and not used for any profiling logic. Add your new type before it.
-    OPTIONAL_ACTIVITY_TYPE_START = CUDA_SYNC,
+    OPTIONAL_ACTIVITY_TYPE_START = GLOW_RUNTIME,
 };
 
 const char* toString(ActivityType t);

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -222,15 +222,6 @@ class Config : public AbstractConfig {
     return activitiesWarmupIterations_;
   }
 
-  // Show CUDA Synchronization Stream Wait Events
-  bool activitiesCudaSyncWaitEvents() const {
-    return activitiesCudaSyncWaitEvents_;
-  }
-
-  void setActivitiesCudaSyncWaitEvents(bool enable) {
-    activitiesCudaSyncWaitEvents_ = enable;
-  }
-
   // Timestamp at which the profiling to start, requested by the user.
   const std::chrono::time_point<std::chrono::system_clock> requestTimestamp()
       const {
@@ -437,7 +428,6 @@ class Config : public AbstractConfig {
   int activitiesMaxGpuBufferSize_;
   std::chrono::seconds activitiesWarmupDuration_;
   int activitiesWarmupIterations_;
-  bool activitiesCudaSyncWaitEvents_;
 
   // Enable Profiler Config Options
   // Temporarily disable shape collection until we re-roll out the feature for on-demand cases

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -30,7 +30,6 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
     {"python_function", ActivityType::PYTHON_FUNCTION},
     {"overhead", ActivityType::OVERHEAD},
-    {"cuda_sync", ActivityType::CUDA_SYNC},
     {"glow_runtime", ActivityType::GLOW_RUNTIME},
     {"mtia_runtime", ActivityType::MTIA_RUNTIME},
     {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -73,7 +73,6 @@ constexpr char kActivitiesDurationMsecsKey[] = "ACTIVITIES_DURATION_MSECS";
 constexpr char kActivitiesWarmupDurationSecsKey[] = "ACTIVITIES_WARMUP_PERIOD_SECS";
 constexpr char kActivitiesMaxGpuBufferSizeKey[] =
     "ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB";
-constexpr char kActivitiesDisplayCudaSyncWaitEvents[] = "ACTIVITIES_DISPLAY_CUDA_SYNC_WAIT_EVENTS";
 
 // Client Interface
 // TODO: keep supporting these older config options, deprecate in the future using replacements.
@@ -217,7 +216,6 @@ Config::Config()
       activitiesMaxGpuBufferSize_(kDefaultActivitiesMaxGpuBufferSize),
       activitiesWarmupDuration_(kDefaultActivitiesWarmupDurationSecs),
       activitiesWarmupIterations_(0),
-      activitiesCudaSyncWaitEvents_(true),
       activitiesDuration_(kDefaultActivitiesProfileDurationMSecs),
       activitiesRunIterations_(0),
       activitiesOnDemandTimestamp_(milliseconds(0)),
@@ -380,8 +378,6 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     activitiesWarmupDuration_ = seconds(toInt32(val));
   } else if (!name.compare(kActivitiesWarmupIterationsKey)) {
     activitiesWarmupIterations_ = toInt32(val);
-  } else if (!name.compare(kActivitiesDisplayCudaSyncWaitEvents)) {
-    activitiesCudaSyncWaitEvents_ = toBool(val);
   }
 
   // TODO: Deprecate Client Interface

--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -18,9 +18,6 @@ namespace KINETO_NAMESPACE {
 
 using namespace libkineto;
 
-// forward declaration
-uint32_t contextIdtoDeviceId(uint32_t contextId);
-
 template<>
 inline const std::string GpuActivity<CUpti_ActivityKernel4>::name() const {
   return demangle(raw().name);
@@ -29,57 +26,6 @@ inline const std::string GpuActivity<CUpti_ActivityKernel4>::name() const {
 template<>
 inline ActivityType GpuActivity<CUpti_ActivityKernel4>::type() const {
   return ActivityType::CONCURRENT_KERNEL;
-}
-
-inline bool isEventSync(CUpti_ActivitySynchronizationType type) {
-  return (
-    type == CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_EVENT_SYNCHRONIZE ||
-    type == CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT);
-}
-
-inline std::string eventSyncInfo(
-    const CUpti_ActivitySynchronization& act, int32_t srcStream) {
-  return fmt::format(R"JSON(
-      "wait_on_stream": {},
-      "wait_on_cuda_event_id": {},)JSON",
-      srcStream,
-      act.cudaEventId
-  );
-}
-
-inline const std::string CudaSyncActivity::name() const {
-  return syncTypeString(raw().type);
-}
-
-inline int64_t CudaSyncActivity::deviceId() const {
-  return contextIdtoDeviceId(raw().contextId);
-}
-
-int64_t CudaSyncActivity::resourceId() const {
-  // For Context and Device Sync events stream ID is invalid and
-  // set to CUPTI_SYNCHRONIZATION_INVALID_VALUE (-1)
-  // converting to an integer will automatically wrap the number to -1
-  // in the trace.
-  return int32_t(raw().streamId);
-}
-
-inline void CudaSyncActivity::log(ActivityLogger& logger) const {
-  logger.handleActivity(*this);
-}
-
-inline const std::string CudaSyncActivity::metadataJson() const {
-  const CUpti_ActivitySynchronization& sync = raw();
-  // clang-format off
-  return fmt::format(R"JSON(
-      "cuda_sync_kind": "{}",{}
-      "stream": {}, "correlation": {},
-      "device": {}, "context": {})JSON",
-      syncTypeString(sync.type),
-      isEventSync(raw().type) ? eventSyncInfo(raw(), srcStream_) : "",
-      sync.streamId, sync.correlationId,
-      deviceId(), sync.contextId);
-  // clang-format on
-  return "";
 }
 
 template<class T>
@@ -238,13 +184,7 @@ inline bool RuntimeActivity::flowStart() const {
       activity_.cbid ==
           CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernelMultiDevice_v9000 ||
       activity_.cbid ==
-          CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000 ||
-      activity_.cbid ==
-          CUPTI_RUNTIME_TRACE_CBID_cudaStreamSynchronize_v3020 ||
-      activity_.cbid ==
-          CUPTI_RUNTIME_TRACE_CBID_cudaDeviceSynchronize_v3020 ||
-      activity_.cbid ==
-          CUPTI_RUNTIME_TRACE_CBID_cudaStreamWaitEvent_v3020;
+          CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000;
 }
 
 inline const std::string RuntimeActivity::metadataJson() const {

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -124,28 +124,6 @@ struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
   const int32_t threadId_;
 };
 
-// CUpti_ActivitySynchronization - CUDA synchronization events
-struct CudaSyncActivity : public CuptiActivity<CUpti_ActivitySynchronization> {
-  explicit CudaSyncActivity(
-      const CUpti_ActivitySynchronization* activity,
-      const ITraceActivity* linked,
-      int32_t srcStream)
-      : CuptiActivity(activity, linked), srcStream_(srcStream) {}
-  int64_t correlationId() const override {return raw().correlationId;}
-  int64_t deviceId() const override;
-  int64_t resourceId() const override;
-  ActivityType type() const override {return ActivityType::CUDA_SYNC;}
-  bool flowStart() const override {return false;}
-  const std::string name() const override;
-  void log(ActivityLogger& logger) const override;
-  const std::string metadataJson() const override;
-  const CUpti_ActivitySynchronization& raw() const {return CuptiActivity<CUpti_ActivitySynchronization>::raw();}
-
- private:
-  const int32_t srcStream_;
-};
-
-
 // Base class for GPU activities.
 // Can also be instantiated directly.
 template<class T>

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -326,9 +326,6 @@ void CuptiActivityApi::enableCuptiActivities(
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION));
       externalCorrelationEnabled_ = true;
     }
-    if (activity == ActivityType::CUDA_SYNC) {
-      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
-    }
     if (activity == ActivityType::CUDA_RUNTIME) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_RUNTIME));
     }
@@ -362,9 +359,6 @@ void CuptiActivityApi::disableCuptiActivities(
     }
     if (activity == ActivityType::EXTERNAL_CORRELATION) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION));
-    }
-    if (activity == ActivityType::CUDA_SYNC) {
-      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
     }
     if (activity == ActivityType::CUDA_RUNTIME) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_RUNTIME));

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -11,12 +11,10 @@
 #include <fmt/format.h>
 #include <time.h>
 #include <atomic>
-#include <functional>
 #include <iomanip>
 #include <string>
 #include <thread>
 #include <type_traits>
-#include <unordered_map>
 #include <vector>
 #include <limits>
 
@@ -46,38 +44,6 @@
 
 using namespace std::chrono;
 using std::string;
-
-struct CtxEventPair {
-  uint32_t ctx = 0;
-  uint32_t eventId = 0;
-
-  bool operator==(const CtxEventPair& other) const {
-    return (this->ctx == other.ctx) && (this->eventId == other.eventId);
-  }
-};
-
-template<>
-struct std::hash<CtxEventPair> {
-	std::size_t operator()(const CtxEventPair& c) const {
-		return std::hash<uint32_t>()(c.ctx) ^ std::hash<uint32_t>()(c.eventId);
-	}
-};
-
-namespace {
-
-// Map (ctx, eventId) -> stream that recorded the cudaEvent
-std::unordered_map<CtxEventPair, uint32_t>& waitEventMap() {
-  static std::unordered_map<CtxEventPair, uint32_t> waitEventMap_;
-  return waitEventMap_;
-}
-
-// Map ctx -> deviceId
-std::unordered_map<uint32_t, uint32_t>& ctxToDeviceId() {
-  static std::unordered_map<uint32_t, uint32_t> ctxToDeviceId_;
-  return ctxToDeviceId_;
-};
-
-}
 
 namespace KINETO_NAMESPACE {
 
@@ -475,63 +441,6 @@ void CuptiActivityProfiler::handleOverheadActivity(
   overhead_activity.log(*logger);
 }
 
-
-int32_t getStreamForWaitEvent(uint32_t ctx, uint32_t eventId) {
-  auto key = CtxEventPair{ctx, eventId};
-  auto it = waitEventMap().find(key);
-  if (it != waitEventMap().end()) {
-    return it->second;
-  }
-  return -1;
-}
-
-void CuptiActivityProfiler::handleCudaEventActivity(
-    const CUpti_ActivityCudaEvent* activity) {
-  VLOG(2) << ": CUPTI_ACTIVITY_KIND_CUDA_EVENT"
-          << " corrId=" << activity->correlationId
-          << " eventId=" << activity->eventId
-          << " streamId=" << activity->streamId
-          << " contextId=" << activity->contextId;
-
-  // Update the stream the cudaEvent was last recorded on
-  auto key = CtxEventPair{activity->contextId, activity->eventId};
-  waitEventMap()[key] = activity->streamId;
-}
-
-void CuptiActivityProfiler::handleCudaSyncActivity(
-    const CUpti_ActivitySynchronization* activity,
-    ActivityLogger* logger) {
-  VLOG(2) << ": CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"
-          << " type=" << syncTypeString(activity->type)
-          << " corrId=" << activity->correlationId
-          << " streamId=" << activity->streamId
-          << " eventId=" << activity->cudaEventId
-          << " contextId=" << activity->contextId;
-
-  if(!config_->activitiesCudaSyncWaitEvents() && isEventSync(activity->type)) {
-    return;
-  }
-
-  if(int32_t(activity->streamId) != -1) {
-    recordStream(
-        contextIdtoDeviceId(activity->contextId), activity->streamId, "");
-  } else {
-    recordDevice(contextIdtoDeviceId(activity->contextId));
-  }
-
-  const ITraceActivity* linked =
-      linkedActivity(activity->correlationId, cpuCorrelationMap_);
-  int32_t src_stream = getStreamForWaitEvent(
-      activity->contextId, activity->cudaEventId);
-  const auto& cuda_sync_activity = traceBuffers_->addActivityWrapper(
-      CudaSyncActivity(activity, linked, src_stream));
-
-  if (outOfRange(cuda_sync_activity)) {
-    return;
-  }
-  cuda_sync_activity.log(*logger);
-}
-
 inline void CuptiActivityProfiler::updateGpuNetSpan(
     const ITraceActivity& gpuOp) {
   if (!gpuOp.linkedActivity()) {
@@ -629,19 +538,6 @@ inline void CuptiActivityProfiler::handleGpuActivity(
   handleGpuActivity(gpu_activity, logger);
 }
 
-
-template <class T>
-inline void updateCtxToDeviceId(const T* act) {
-  if (ctxToDeviceId().count(act->contextId) == 0) {
-    ctxToDeviceId()[act->contextId] = act->deviceId;
-  }
-}
-
-uint32_t contextIdtoDeviceId(uint32_t contextId) {
-  auto it = ctxToDeviceId().find(contextId);
-  return it != ctxToDeviceId().end() ? it->second : 0;
-}
-
 void CuptiActivityProfiler::handleCuptiActivity(
     const CUpti_Activity* record,
     ActivityLogger* logger) {
@@ -657,16 +553,6 @@ void CuptiActivityProfiler::handleCuptiActivity(
     case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL:
       handleGpuActivity(
           reinterpret_cast<const CUpti_ActivityKernel4*>(record), logger);
-      updateCtxToDeviceId(
-          reinterpret_cast<const CUpti_ActivityKernel4*>(record));
-      break;
-    case CUPTI_ACTIVITY_KIND_SYNCHRONIZATION:
-      handleCudaSyncActivity(
-          reinterpret_cast<const CUpti_ActivitySynchronization*>(record), logger);
-      break;
-    case CUPTI_ACTIVITY_KIND_CUDA_EVENT:
-      handleCudaEventActivity(
-          reinterpret_cast<const CUpti_ActivityCudaEvent*>(record));
       break;
     case CUPTI_ACTIVITY_KIND_MEMCPY:
       handleGpuActivity(

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -266,29 +266,14 @@ class CuptiActivityProfiler {
       libkineto::CpuTraceBuffer& cpuTrace,
       ActivityLogger& logger);
 
-  inline bool hasDeviceResource(int device, int id) {
-    return resourceInfo_.find({device, id}) != resourceInfo_.end();
-  }
-
   // Create resource names for streams
   inline void recordStream(int device, int id, const char* postfix) {
-    if (!hasDeviceResource(device, id)) {
+    if (resourceInfo_.find({device, id}) == resourceInfo_.end()) {
       resourceInfo_.emplace(
-        std::make_pair(device, id),
-        ResourceInfo(
-          device, id, id, fmt::format(
-            "stream {} {}", id, postfix)));
-    }
-  }
-
-  // Create resource names overall for device, id = -1
-  inline void recordDevice(int device) {
-    constexpr int id = -1;
-    if (!hasDeviceResource(device, id)) {
-      resourceInfo_.emplace(
-        std::make_pair(device, id),
-        ResourceInfo(
-          device, id, id, fmt::format("Device {}", device)));
+          std::make_pair(device, id),
+          ResourceInfo(
+              device, id, id, fmt::format(
+                  "stream {} {}", id, postfix)));
     }
   }
 
@@ -324,9 +309,6 @@ class CuptiActivityProfiler {
       const CUpti_ActivityAPI* activity, ActivityLogger* logger);
   void handleOverheadActivity(
       const CUpti_ActivityOverhead* activity, ActivityLogger* logger);
-  void handleCudaEventActivity(const CUpti_ActivityCudaEvent* activity);
-  void handleCudaSyncActivity(
-      const CUpti_ActivitySynchronization* activity, ActivityLogger* logger);
   void handleGpuActivity(const ITraceActivity& act,
       ActivityLogger* logger);
   template <class T>

--- a/libkineto/src/cupti_strings.cpp
+++ b/libkineto/src/cupti_strings.cpp
@@ -505,23 +505,4 @@ const char* runtimeCbidName(CUpti_CallbackId cbid) {
   return runtimeCbidNames[cbid];
 }
 
-// From https://docs.nvidia.com/cupti/modules.html#group__CUPTI__ACTIVITY__API_1g80e1eb47615e31021f574df8ebbe5d9a
-//   enum CUpti_ActivitySynchronizationType
-const char* syncTypeString(
-    CUpti_ActivitySynchronizationType kind) {
-  switch (kind) {
-    case CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_EVENT_SYNCHRONIZE:
-      return "Event Sync";
-    case CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT:
-      return "Stream Wait Event";
-    case CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_SYNCHRONIZE:
-      return "Stream Sync";
-    case CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_CONTEXT_SYNCHRONIZE:
-      return "Context Sync";
-    case CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_UNKNOWN:
-    default:
-      return "Unknown Sync";
-  }
-  return "<unknown>";
-}
 } // namespace libkineto

--- a/libkineto/src/cupti_strings.h
+++ b/libkineto/src/cupti_strings.h
@@ -16,6 +16,5 @@ const char* memoryKindString(CUpti_ActivityMemoryKind kind);
 const char* memcpyKindString(CUpti_ActivityMemcpyKind kind);
 const char* runtimeCbidName(CUpti_CallbackId cbid);
 const char* overheadKindString(CUpti_ActivityOverheadKind kind);
-const char* syncTypeString(CUpti_ActivitySynchronizationType kind);
 
 } // namespace libkineto


### PR DESCRIPTION
Summary:
This diff is reverting D42825031
D42825031: [wip] kineto add synchronization events in the trace by briancoutinho has been identified to be causing the following test or build failures:

Tests affected:
- [caffe2/caffe2:caffe2_test_gpu - GemmBatchedGPUTrans/GemmBatchedGPUTest.GemmBatchedGPUFloatTest/1](https://www.internalfb.com/intern/test/281475046984558/)

Here's the Multisect link:
https://www.internalfb.com/multisect/2245516
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Reviewed By: aaronenyeshi

Differential Revision: D46679602

