### PR TITLE
Thread sanitizer fixes

### DIFF
--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -191,15 +191,20 @@ void ConfigLoader::handleOnDemandSignal() {
   }
 }
 
-const char* ConfigLoader::configFileName() {
-  if (!configFileName_) {
-    configFileName_ = getenv(kConfigFileEnvVar);
+namespace {
+
+const char* configFileName() {
+  static const char* configFileName__ = []() {
+    const char* configFileName_ = getenv(kConfigFileEnvVar);
     if (configFileName_ == nullptr) {
       configFileName_ = kConfigFile;
     }
-  }
-  return configFileName_;
+    return configFileName_;
+  }();
+  return configFileName__;
 }
+
+} // namespace
 
 IDaemonConfigLoader* ConfigLoader::daemonConfigLoader() {
   if (!daemonConfigLoader_ && daemonConfigLoaderFactory()) {

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -113,7 +113,6 @@ class ConfigLoader {
   ConfigLoader();
   ~ConfigLoader();
 
-  const char* configFileName();
   IDaemonConfigLoader* daemonConfigLoader();
 
   void startThread();
@@ -137,7 +136,6 @@ class ConfigLoader {
   const char* customConfigFileName();
 
   std::mutex configLock_;
-  std::atomic<const char*> configFileName_{nullptr};
   std::unique_ptr<Config> config_;
   std::unique_ptr<IDaemonConfigLoader> daemonConfigLoader_;
   std::map<ConfigKind, std::vector<ConfigHandler*>> handlers_;


### PR DESCRIPTION
Summary:
## About
Fix thread sanitizer issue, `configFileName()` initializes a string that is static, but there is a chance of a race there.
Fix this issue-

## Full output
```
WARNING: ThreadSanitizer: data race (pid=1780553)
  Write of size 8 at 0x7b1000f75028 by main thread:
    #0 operator delete(void*, unsigned long) <null> (caffe2_test_gpu+0x4c292e8)
    #1 facebook::jk::detail::BooleanKnob_NOT_THREAD_SAFE::~BooleanKnob_NOT_THREAD_SAFE() fbcode/justknobs/JustKnobProxy.h:81 (caffe2_test_gpu+0x13f21cb6)
    #2 void folly::threadlocal_detail::ElementWrapper::set<facebook::jk::detail::BooleanKnob_NOT_THREAD_SAFE*>(facebook::jk::detail::BooleanKnob_NOT_THREAD_SAFE*)::'lambda'(void*, folly::TLPDestructionMode)::__invoke(void*, folly::TLPDestructionMode) fbcode/folly/detail/ThreadLocalDetail.h:138 (caffe2_test_gpu+0x13f222a7)
    #3 folly::threadlocal_detail::StaticMetaBase::destroy(folly::threadlocal_detail::StaticMetaBase::EntryID*) fbcode/folly/detail/ThreadLocalDetail.h:114 (caffe2_test_gpu+0x10618e53)
    #4 facebook::jk::detail::TLKnob<facebook::jk::detail::BooleanKnob_NOT_THREAD_SAFE>::~TLKnob() fbcode/folly/ThreadLocal.h:429 (caffe2_test_gpu+0x14665649)
    #5 cxa_at_exit_wrapper(void*) <null> (caffe2_test_gpu+0x4c48190)

  Previous read of size 8 at 0x7b1000f75028 by thread T39 (mutexes: write M961090930684752176):
    #0 facebook::jk::detail::JustKnobProxy_NOT_THREAD_SAFE::maybeRefreshStaleKnobHandle() ./fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/shared_ptr_base.h:1356 (caffe2_test_gpu+0x13f24cb8)
    #1 facebook::jk::detail::BooleanKnob_NOT_THREAD_SAFE::operator()() fbcode/justknobs/JustKnobProxy.cpp:22 (caffe2_test_gpu+0x13f25069)
    #2 libkineto::cuda_sync_stream_wait_knob() fbcode/justknobs/JustKnobProxy.h:108 (caffe2_test_gpu+0x1bb3c0a3)
    #3 libkineto::FBConfig::FBConfig(libkineto::Config&) fbcode/kineto/libkineto/fb/FBConfig.cpp:148 (caffe2_test_gpu+0x1bb3bc9c)
    #4 std::_Function_handler<libkineto::AbstractConfig* (libkineto::Config&), libkineto::FBConfig::registerFactory()::$_0>::_M_invoke(std::_Any_data const&, libkineto::Config&) fbcode/kineto/libkineto/fb/FBConfig.cpp:327 (caffe2_test_gpu+0x1bb3ee6a)
    #5 libkineto::Config::Config() ./fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/std_function.h:560 (caffe2_test_gpu+0x135b45da)
    #6 libkineto::ConfigLoader::updateConfigThread() ./fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/unique_ptr.h:962 (caffe2_test_gpu+0x135a5981)
    #7 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (libkineto::ConfigLoader::*)(), libkineto::ConfigLoader*> > >::_M_run() ./fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/invoke.h:74 (caffe2_test_gpu+0x135a9f44)
    #8 execute_native_thread_routine /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/src/c++11/../../../.././libstdc++-v3/src/c++11/thread.cc:82:18 (libstdc++.so.6+0xdf4e4)

  Mutex M961090930684752176 is already destroyed.

```

Differential Revision: D46730102

