### PR TITLE
[kineto] Suppress warning about GenericTraceActivity destructor not being marked as `override`

### DIFF
--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -103,7 +103,7 @@ class GenericTraceActivity : public ITraceActivity {
     return fmt::format("{}", fmt::join(metadata_, ", "));
   }
 
-  virtual ~GenericTraceActivity() {};
+  virtual ~GenericTraceActivity() override {};
 
   int64_t startTime{0};
   int64_t endTime{0};


### PR DESCRIPTION
This warning shows up in the pytorch logs. Adding `override` will make the pytorch build logs slightly easier to read.