### PR TITLE
Disable tb_plugin CI for python 3.9 and 3.10 due to failures

### DIFF
--- a/.github/workflows/tb_plugin_ci.yml
+++ b/.github/workflows/tb_plugin_ci.yml
@@ -24,9 +24,9 @@ jobs:
           echo $GITHUB_BASE_REF
           if [ $GITHUB_BASE_REF == "plugin/vnext" ]
           then
-            echo "::set-output name=matrix::{\"python-version\":[3.8, 3.9, \"3.10\"], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\"]}"
+            echo "::set-output name=matrix::{\"python-version\":[3.8], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\"]}"
           else
-            echo "::set-output name=matrix::{\"python-version\":[3.8, 3.9, \"3.10\"], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\", \"2.0\", \"stable\"]}"
+            echo "::set-output name=matrix::{\"python-version\":[3.8], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\", \"2.0\", \"stable\"]}"
           fi
 
   build:


### PR DESCRIPTION
Summary: The tb_plugin CI is broken for python 3.9 and 3.10. Only works on python 3.8. We are reaching out to MFST to take a look into the issue. Let's disable this for now to unblock diffs.

Reviewed By: davidberard98

Differential Revision: D47601090

Pulled By: aaronenyeshi

