### PR TITLE
Fixed test_profiler_tree unit tests

### DIFF
--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -273,6 +273,7 @@ void RoctracerLogger::startLogging() {
     loggedIds_.add("hipModuleGetFunction");
     loggedIds_.add("hipEventCreateWithFlags");
     loggedIds_.add("hipGetDeviceCount");
+    loggedIds_.add("hipDevicePrimaryCtxGetState");
 
     // Enable API callbacks
     if (loggedIds_.invertMode() == true) {


### PR DESCRIPTION
Fixed below unit tests:
test_profiler_tree.py TestProfilerTree.test_profiler_experimental_tree
test_profiler_tree.py TestProfilerTree.test_profiler_experimental_tree_with_memory -v
test_profiler_tree.py TestProfilerTree.test_profiler_experimental_tree_with_record_function -v

Excluding this API to match Kineto profiling behavior, since the unit test mentioned looks for an exact match of profiling output.