### PR TITLE
Collect more info on cuduEventRecord for stream wait sync events

### DIFF
--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -38,11 +38,16 @@ inline bool isEventSync(CUpti_ActivitySynchronizationType type) {
 }
 
 inline std::string eventSyncInfo(
-    const CUpti_ActivitySynchronization& act, int32_t srcStream) {
+    const CUpti_ActivitySynchronization& act,
+    int32_t srcStream,
+    int32_t srcCorrId
+    ) {
   return fmt::format(R"JSON(
       "wait_on_stream": {},
+      "wait_on_cuda_event_record_corr_id": {},
       "wait_on_cuda_event_id": {},)JSON",
       srcStream,
+      srcCorrId,
       act.cudaEventId
   );
 }
@@ -75,7 +80,7 @@ inline const std::string CudaSyncActivity::metadataJson() const {
       "stream": {}, "correlation": {},
       "device": {}, "context": {})JSON",
       syncTypeString(sync.type),
-      isEventSync(raw().type) ? eventSyncInfo(raw(), srcStream_) : "",
+      isEventSync(raw().type) ? eventSyncInfo(raw(), srcStream_, srcCorrId_) : "",
       sync.streamId, sync.correlationId,
       deviceId(), sync.contextId);
   // clang-format on

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -129,8 +129,11 @@ struct CudaSyncActivity : public CuptiActivity<CUpti_ActivitySynchronization> {
   explicit CudaSyncActivity(
       const CUpti_ActivitySynchronization* activity,
       const ITraceActivity* linked,
-      int32_t srcStream)
-      : CuptiActivity(activity, linked), srcStream_(srcStream) {}
+      int32_t srcStream,
+      int32_t srcCorrId)
+      : CuptiActivity(activity, linked),
+        srcStream_(srcStream),
+        srcCorrId_(srcCorrId) {}
   int64_t correlationId() const override {return raw().correlationId;}
   int64_t deviceId() const override;
   int64_t resourceId() const override;
@@ -143,6 +146,7 @@ struct CudaSyncActivity : public CuptiActivity<CUpti_ActivitySynchronization> {
 
  private:
   const int32_t srcStream_;
+  const int32_t srcCorrId_;
 };
 
 


### PR DESCRIPTION
Summary:
## Overview
To effectively understand synchronization due to CUDA events we also need to track CUDA event record calls and which CUDA event record call the sync occurss on.
Thus when an event synchronization occurs we track
1. We can figure out which cudaEventRecord() this sync took place on
2. Based on that we know which kernel/memcpy launch was recorded by the event, this will typically be the previous kernel/memcpy launch in runtime.


CUPTI' CUDA Event record tells us the correlation ID of the CUDA record [documentation](https://docs.nvidia.com/cupti/annotated.html#structCUpti__ActivityEvent)
```
uint32_t CUpti_ActivityEvent::correlationId [inherited]
The correlation ID of the event. Use of this ID is user-defined, but typically this ID value will equal the correlation ID of the kernel for which the event was gathered.
```

## In this change
* Enable logging cuda Event Record Runtime events (and event sychronize calls too).
* Track the correlation ID for CUPTI Event records as shown above.
* In the CUPTI Stream Wait event we emit the correlation

Reviewed By: anupambhatnagar, davidberard98

Differential Revision: D49694339


