### PR TITLE
Fix kineto sample programs, add build scripts and documentation.

### DIFF
--- a/libkineto/sample_programs/README.md
+++ b/libkineto/sample_programs/README.md
@@ -1,0 +1,12 @@
+
+# How to Run Sample Programs
+
+To run `kineto_playground.cpp` in the `sample_programs` folder, you can use the following steps: (Note: scripts below are hard-coded to a specific set of sample programs, you can modify them to work with a different program. TODO: make these scripts more flexible.)
+
+1. `./build-cu.sh`
+    - this generates `kplay-cu.o`
+2. `./build.sh`
+    - this generates binary called `main`
+3. Run `./main`
+    - runs your code defined in `kineto_playground.cpp`
+

--- a/libkineto/sample_programs/build-cu.sh
+++ b/libkineto/sample_programs/build-cu.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+nvcc -c kineto_playground.cu -o kplay_cu.o
+
+

--- a/libkineto/sample_programs/build.sh
+++ b/libkineto/sample_programs/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+g++ \
+  -g3 \
+  -O0 \
+  kineto_playground.cpp \
+  -o main \
+  -I/usr/local/cuda/include \
+  -I../third_party/fmt/include \
+  -I/usr/local/include/kineto \
+  -L/usr/local/lib \
+  -L/usr/local/cuda/lib64 \
+  -lpthread \
+  -lcuda \
+  -lcudart \
+  /usr/local/lib/libkineto.a \
+  kplay_cu.o

--- a/libkineto/sample_programs/kineto_cupti_profiler.cpp
+++ b/libkineto/sample_programs/kineto_cupti_profiler.cpp
@@ -11,11 +11,11 @@
 #include <string>
 #include <chrono>
 #include <thread>
+#include <iostream>
 
-#include <common/logging/logging.h>
 #include <libkineto.h>
 
-#include "kineto/libkineto/sample_programs/kineto_playground.cuh"
+#include "kineto_playground.cuh"
 
 using namespace kineto;
 
@@ -28,6 +28,9 @@ int main() {
   std::set<libkineto::ActivityType> types_cupti_prof = {
     libkineto::ActivityType::CUDA_PROFILER_RANGE,
   };
+
+  libkineto_init(false, true);
+  libkineto::api().initProfilerIfRegistered();
 
   // Use a special kineto__cuda_core_flop metric that counts individual
   // CUDA core floating point instructions by operation type (fma,fadd,fmul,dadd ...)
@@ -51,7 +54,7 @@ int main() {
   basicMemcpyFromDevice();
 
   auto trace = profiler.stopTrace();
-  LOG(INFO) << "Stopped and processed trace. Got " << trace->activities()->size() << " activities.";
+  std::cout << "Stopped and processed trace. Got " << trace->activities()->size() << " activities.";
   trace->save(kFileName);
   return 0;
 }

--- a/libkineto/sample_programs/kineto_playground.cpp
+++ b/libkineto/sample_programs/kineto_playground.cpp
@@ -9,11 +9,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <iostream>
 
-#include <common/logging/logging.h>
 #include <libkineto.h>
 
-#include "kineto/libkineto/sample_programs/kineto_playground.cuh"
+#include "kineto_playground.cuh"
 
 using namespace kineto;
 
@@ -26,9 +26,10 @@ int main() {
 
   // Empty types set defaults to all types
   std::set<libkineto::ActivityType> types;
+  libkineto_init(false, true);
+  libkineto::api().initProfilerIfRegistered();
 
   auto& profiler = libkineto::api().activityProfiler();
-  libkineto::api().initProfilerIfRegistered();
   profiler.prepareTrace(types);
 
   // Good to warm up after prepareTrace to get cupti initialization to settle
@@ -37,7 +38,7 @@ int main() {
   playground();
 
   auto trace = profiler.stopTrace();
-  LOG(INFO) << "Stopped and processed trace. Got " << trace->activities()->size() << " activities.";
+  std::cout << "Stopped and processed trace. Got " << trace->activities()->size() << " activities.";
   trace->save(kFileName);
   return 0;
 }


### PR DESCRIPTION
👋 Hello! I built libkineto + tried to run the sample programs, but after I figured out how to compile, I immediately got a segfault. This seemed to happen for others like in this issue https://github.com/pytorch/kineto/issues/445, and I found that a call to `libstreaming_init()` before `initProfilerIfRegistered()` was necessary to avoid a null pointer in the profiler object.

This patch fixes the issues in the sample programs, and makes it easier to run them by including a build script and instructions. See screenshots below for before/after of the changes:

## Run `kineto_playground.cpp` before code change, segfault
<img width="743" alt="kineto_playground_segfault_before" src="https://github.com/pytorch/kineto/assets/2456071/bb0934a1-1088-4cb9-bf40-d2815647e1ec">

## Run `kineto_playground.cpp` after code change, runs and outputs chrome trace
<img width="1832" alt="kineto_playground_after_fix" src="https://github.com/pytorch/kineto/assets/2456071/8d3e6a04-eb56-420c-b177-a5f7c3fafd19">
