### PR TITLE
clearing cached data, causing memory leak

### DIFF
--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -363,6 +363,8 @@ int RoctracerActivityApi::processActivities(
 
 void RoctracerActivityApi::clearActivities() {
   d->clearLogs();
+  kernelLaunches_.clear();
+  kernelNames_.clear();    
 }
 
 


### PR DESCRIPTION
This will fix the test test_cuda.py::TestCuda::test_cuda_memory_leak_detection failure.

