### PR TITLE
Populate collective metadata from CPU op to GPU kernel

### DIFF
--- a/libkineto/include/ITraceActivity.h
+++ b/libkineto/include/ITraceActivity.h
@@ -48,6 +48,11 @@ struct ITraceActivity {
   // Return json formatted metadata
   // FIXME: Return iterator to dynamic type map here instead
   virtual const std::string metadataJson() const = 0;
+  // Return the metadata value in string format with key
+  // @lint-ignore CLANGTIDY: clang-diagnostic-unused-parameter
+  virtual const std::string getMetadataValue(const std::string& key) const {
+    return "";
+  }
 
   static int64_t nsToUs(int64_t ns) {
     // It's important that this conversion is the same everywhere.


### PR DESCRIPTION
Summary:
This diff populates specific collective metadata from CPU op to GPU kernel, for easier NCCL bandwidth calculation.
1. Added a new method `getMetadataValue` to get the metadata value in string format;
2. Refactored the `addMetadata` and `metadataJson` to make the newly added function `getMetadataValue` easier.
3. Populated the NCCL collective metadata from CPU op to the GPU kernel as asked by customer.

Differential Revision: D50539352


