### PR TITLE
Roctracer: Implement reliable data flushing on stop

### DIFF
--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -367,7 +367,6 @@ void RoctracerActivityApi::clearActivities() {
   kernelNames_.clear();    
 }
 
-
 void RoctracerActivityApi::enableActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_ROCTRACER

--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -12,7 +12,6 @@
 #include <chrono>
 #include <time.h>
 #include <mutex>
-#include <condition_variable>
 #include <unistd.h>
 
 #include "ThreadUtil.h"
@@ -32,7 +31,6 @@ class Flush
 public:
   std::atomic<bool> doFlush_ {false};
   std::mutex mutex_;
-  std::condition_variable wait_;
   static thread_local uint64_t trip_;
   uint64_t correlationId_ {0};
 };

--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -35,7 +35,7 @@ public:
   uint64_t correlationId_ {0};
   void reportCorrelation(const uint64_t &cid) {
     uint64_t prev = maxCorrelationId_;
-    while (prev < cid && maxCorrelationId_.compare_exchange_weak(prev, cid))
+    while (prev < cid && !maxCorrelationId_.compare_exchange_weak(prev, cid))
       {}
   }
 };

--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -261,10 +261,6 @@ void RoctracerLogger::api_callback(uint32_t domain, uint32_t cid, const void* ca
           dis->externalCorrelations_[it][data->correlation_id] = t_externalIds[it].back();
         }
       }
-      // If we are stopping the tracer, implement reliable flushing
-      if (s_flush.doFlush_) {
-        s_flush.trip_ = data->correlation_id;
-      }
     }  // phase exit
   }
 }

--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -176,6 +176,7 @@ class RoctracerLogger {
 
   std::unique_ptr<std::list<RoctracerActivityBuffer>> gpuTraceBuffers_;
   bool externalCorrelationEnabled_{true};
+  bool logging_{false};
 
   friend class onnxruntime::profiling::RocmProfiler;
   friend class libkineto::RoctracerActivityApi;


### PR DESCRIPTION
When stopping and flushing with libroctracer there is no way to guarantee all completion notifications have been received and logged.   Torch.Profiler calls deviceSynchronize() on stopping the tracer but that ensures nothing.  It does add some delay, reducing the race.

I augmented the tracer stop procedure to enqueue an extra async op and delay until the notification for it is received.

This will fix many "flakey" unit tests that look for kernel executions that occur immediately before the end of a recording.