### PR TITLE
Make CUPTI lazy init

### DIFF
--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -71,8 +71,9 @@ class CuptiCallbackApi {
   static std::shared_ptr<CuptiCallbackApi> singleton();
 
   void initCallbackApi();
+  void deinitCallbackApi();
 
-  bool initSuccess() const {
+  bool initStatus() const {
     return initSuccess_;
   }
 

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -28,7 +28,6 @@
 namespace KINETO_NAMESPACE {
 
 #ifdef HAS_CUPTI
-static bool initialized = false;
 static std::mutex initMutex;
 
 bool enableEventProfiler() {
@@ -46,25 +45,14 @@ static void initProfilers(
   VLOG(0) << "CUDA Context created";
   std::lock_guard<std::mutex> lock(initMutex);
 
-  if (!initialized) {
-    libkineto::api().initProfilerIfRegistered();
-    initialized = true;
-    VLOG(0) << "libkineto profilers activated";
-  }
-
-  if (!enableEventProfiler()) {
-    VLOG(0) << "Kineto EventProfiler disabled, skipping start";
-    return;
-  } else {
-    CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
-    CUcontext ctx = d->context;
-    ConfigLoader& config_loader = libkineto::api().configLoader();
-    config_loader.initBaseConfig();
-    auto config = config_loader.getConfigCopy();
-    if (config->eventProfilerEnabled()) {
-      EventProfilerController::start(ctx, config_loader);
-      LOG(INFO) << "Kineto EventProfiler started";
-    }
+  CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
+  CUcontext ctx = d->context;
+  ConfigLoader& config_loader = libkineto::api().configLoader();
+  config_loader.initBaseConfig();
+  auto config = config_loader.getConfigCopy();
+  if (config->eventProfilerEnabled()) {
+    EventProfilerController::start(ctx, config_loader);
+    LOG(INFO) << "Kineto EventProfiler started";
   }
 }
 
@@ -88,12 +76,10 @@ static void stopProfiler(
   VLOG(0) << "CUDA Context destroyed";
   std::lock_guard<std::mutex> lock(initMutex);
 
-  if (enableEventProfiler()) {
-    CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
-    CUcontext ctx = d->context;
-    EventProfilerController::stopIfEnabled(ctx);
-    LOG(INFO) << "Kineto EventProfiler stopped";
-  }
+  CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
+  CUcontext ctx = d->context;
+  EventProfilerController::stopIfEnabled(ctx);
+  LOG(INFO) << "Kineto EventProfiler stopped";
 }
 
 static std::unique_ptr<CuptiRangeProfilerInit> rangeProfilerInit;
@@ -124,31 +110,29 @@ void libkineto_init(bool cpuOnly, bool logOnError) {
 #endif
 
 #ifdef HAS_CUPTI
-  if (!cpuOnly) {
+  bool initRangeProfiler = false;
+  if (!cpuOnly && enableEventProfiler() ) {
     // libcupti will be lazily loaded on this call.
     // If it is not available (e.g. CUDA is not installed),
     // then this call will return an error and we just abort init.
     auto cbapi = CuptiCallbackApi::singleton();
-    cbapi->initCallbackApi();
     bool status = false;
-    bool initRangeProfiler = true;
+    initRangeProfiler = true;
 
-    if (cbapi->initSuccess()){
-      const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RESOURCE;
-      status = cbapi->registerCallback(
-          domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED, initProfilers);
-      status = status && cbapi->registerCallback(
-          domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED, stopProfiler);
+    const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RESOURCE;
+    status = cbapi->registerCallback(
+        domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED, initProfilers);
+    status = status && cbapi->registerCallback(
+        domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED, stopProfiler);
 
-      if (status) {
-        status = cbapi->enableCallback(
-            domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED);
-        status = status && cbapi->enableCallback(
-            domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED);
-      }
+    if (status) {
+      status = cbapi->enableCallback(
+          domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED);
+      status = status && cbapi->enableCallback(
+          domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED);
     }
 
-    if (!cbapi->initSuccess() || !status) {
+    if (!cbapi->initStatus() || !status) {
       initRangeProfiler = false;
       cpuOnly = true;
       if (logOnError) {
@@ -159,11 +143,13 @@ void libkineto_init(bool cpuOnly, bool logOnError) {
                   << "https://developer.nvidia.com/nvidia-development-tools-solutions-err-nvgpuctrperm-cupti";
       }
     }
+  } else {
+    VLOG(0) << "Kineto EventProfiler disabled, skipping it";
+  }
 
-    // initialize CUPTI Range Profiler API
-    if (initRangeProfiler) {
-      rangeProfilerInit = std::make_unique<CuptiRangeProfilerInit>();
-    }
+  // initialize CUPTI Range Profiler API
+  if (initRangeProfiler) {
+    rangeProfilerInit = std::make_unique<CuptiRangeProfilerInit>();
   }
 
   if (shouldPreloadCuptiInstrumentation()) {


### PR DESCRIPTION
Summary:
Make the Kineto profiler lazily initialize the CUPTI library.

The following will change:
- Only the legacy event profiler will register callbacks on RESOURCE_CONTEXT_CREATED and RESOURCE_CONTEXT_DESTROYED.
- Move the initialization of profiler (libkineto::api().initProfilerIfRegistered()) to be lazy when prepare profiler is called.
- Remove previous logic to init on fork (ie. ENABLE_KINETO_ON_FORK), also removing the use of calling pthread_atfork.
- Unsubscribe the CUPTI Subscriber after teardown.
- Clean up verbose logging

Differential Revision: D50471345


