### PR TITLE
[TorchFix] Update old pretrained TorchVision API in tests 

### DIFF
--- a/tb_plugin/examples/resnet50_autograd_api.py
+++ b/tb_plugin/examples/resnet50_autograd_api.py
@@ -6,11 +6,11 @@ import torch.optim
 import torch.utils.data
 import torchvision
 import torchvision.transforms as T
-import torchvision.models as models
 
 from torch.autograd.profiler import profile
+from torchvision import models
 
-model = models.resnet50(pretrained=True)
+model = models.resnet50(weights=models.ResNet50_Weights.IMAGENET1K_V1)
 model.cuda()
 cudnn.benchmark = True
 

--- a/tb_plugin/examples/resnet50_ddp_profiler.py
+++ b/tb_plugin/examples/resnet50_ddp_profiler.py
@@ -9,20 +9,20 @@ import torch.optim
 import torch.profiler
 import torch.utils.data
 import torchvision
-import torchvision.models as models
 import torchvision.transforms as T
 from torch.nn.parallel import DistributedDataParallel as DDP
+from torchvision import models
 
 
 def example(rank, use_gpu=True):
     if use_gpu:
         torch.cuda.set_device(rank)
-        model = models.resnet50(pretrained=True).to(rank)
+        model = models.resnet50(weights=models.ResNet50_Weights.IMAGENET1K_V1).to(rank)
         model.cuda()
         cudnn.benchmark = True
         model = DDP(model, device_ids=[rank])
     else:
-        model = models.resnet50(pretrained=True)
+        model = models.resnet50(weights=models.ResNet50_Weights.IMAGENET1K_V1)
         model = DDP(model)
 
     # Use gradient compression to reduce communication

--- a/tb_plugin/examples/resnet50_profiler_api.py
+++ b/tb_plugin/examples/resnet50_profiler_api.py
@@ -5,11 +5,11 @@ import torch.optim
 import torch.utils.data
 import torchvision
 import torchvision.transforms as T
-import torchvision.models as models
 
 import torch.profiler
+from torchvision import models
 
-model = models.resnet50(pretrained=True)
+model = models.resnet50(weights=models.ResNet50_Weights.IMAGENET1K_V1)
 model.cuda()
 cudnn.benchmark = True
 

--- a/tb_plugin/test/test_compare_with_autograd.py
+++ b/tb_plugin/test/test_compare_with_autograd.py
@@ -9,9 +9,9 @@ import torch.optim
 import torch.utils.data
 import torchvision
 import torchvision.transforms as T
-import torchvision.models as models
 import torch_tb_profiler.io as io
 from torch_tb_profiler.profiler import RunLoader
+from torchvision import models
 
 
 def create_log_dir():
@@ -174,7 +174,7 @@ def get_plugin_result(run, record_shapes=False, with_stack=False):
 
 
 def get_train_func(use_gpu=True):
-    model = models.resnet50(pretrained=True)
+    model = models.resnet50(weights=models.ResNet50_Weights.IMAGENET1K_V1)
     if use_gpu:
         model.cuda()
     cudnn.benchmark = True


### PR DESCRIPTION
For TorchVision models, `pretrained` parameters have been deprecated in favor of "Multi-weight support API" - see https://pytorch.org/vision/0.15/models.html