### PR TITLE
Add logger metadata on trace save() API as well

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -322,6 +322,14 @@ std::unique_ptr<ActivityTraceInterface> ActivityProfilerController::stopTrace() 
   profiler_->processTrace(*logger);
   // Will follow up with another patch for logging URLs when ActivityTrace is moved.
   UST_LOGGER_MARK_COMPLETED(kPostProcessingStage);
+
+  // Logger Metadata contains a map of LOGs collected in Kineto
+  //   logger_level -> List of log lines
+  // This will be added into the trace as metadata.
+  std::unordered_map<std::string, std::vector<std::string>>
+    loggerMD = profiler_->getLoggerMetadata();
+  logger->setLoggerMetadata(std::move(loggerMD));
+
   profiler_->reset();
   return std::make_unique<ActivityTrace>(std::move(logger), loggerFactory());
 }

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -201,6 +201,8 @@ class CuptiActivityProfiler {
     profilers_.push_back(std::move(profiler));
   }
 
+  std::unordered_map<std::string, std::vector<std::string>> getLoggerMetadata();
+
  protected:
 
   using CpuGpuSpanPair = std::pair<TraceSpan, TraceSpan>;

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -96,6 +96,11 @@ class MemoryTraceLogger : public ActivityLogger {
     logger.finalizeTrace(*config_, nullptr, endTime_, loggerMetadata_);
   }
 
+  void setLoggerMetadata(
+      std::unordered_map<std::string, std::vector<std::string>>&& lmd) {
+    loggerMetadata_ = std::move(lmd);
+  }
+
  private:
 
   std::unique_ptr<Config> config_;


### PR DESCRIPTION
Summary: Enable adding logs metdata in PyTorch trace save() path. This will help us get GLOG prints within traces collected using the PyTorch API.

Reviewed By: aaronenyeshi, davidberard98

Differential Revision: D50478555


