### PR TITLE
Back out "Roctracer: Implement reliable data flushing on stop"

### DIFF
--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -367,6 +367,7 @@ void RoctracerActivityApi::clearActivities() {
   kernelNames_.clear();    
 }
 
+
 void RoctracerActivityApi::enableActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_ROCTRACER

--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -176,7 +176,6 @@ class RoctracerLogger {
 
   std::unique_ptr<std::list<RoctracerActivityBuffer>> gpuTraceBuffers_;
   bool externalCorrelationEnabled_{true};
-  bool logging_{false};
 
   friend class onnxruntime::profiling::RocmProfiler;
   friend class libkineto::RoctracerActivityApi;


### PR DESCRIPTION
Summary:
Revert due to profiling breakage on amd;

`while (s_flush.correlationId_ != 0) ` loops indefinitely, and I don't see `s_flush.correlationId_` being decremented anywhere so that is likely the issue.

Reviewed By: xw285cornell

Differential Revision: D51185531


