### PR TITLE
Fixed CUPTI on Windows

### DIFF
--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -15,7 +15,6 @@
 #include <chrono>
 #include <algorithm>
 #include <mutex>
-#include <shared_mutex>
 
 #ifdef HAS_CUPTI
 #include "cupti_call.h"
@@ -31,13 +30,6 @@ constexpr size_t MAX_CB_FNS_PER_CB = 8;
 // Use this value in enabledCallbacks_ set, when all cbids in a domain
 // is enabled, not a specific cbid.
 constexpr uint32_t MAX_CUPTI_CALLBACK_ID_ALL = 0xffffffff;
-
-// Reader Writer lock types
-using ReaderWriterLock = std::shared_timed_mutex;
-using ReaderLockGuard = std::shared_lock<ReaderWriterLock>;
-using WriteLockGuard = std::unique_lock<ReaderWriterLock>;
-
-static ReaderWriterLock callbackLock_;
 
 /* Callback Table :
  *  Overall goal of the design is to optimize the lookup of function

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -16,6 +16,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <set>
 
 // TODO(T90238193)
@@ -143,6 +144,12 @@ class CuptiCallbackApi {
   // As an implementation detail, cbid == 0xffffffff means enable the domain.
   std::set<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>> enabledCallbacks_;
 
+
+  // Reader Writer lock types
+  using ReaderWriterLock = std::shared_timed_mutex;
+  using ReaderLockGuard = std::shared_lock<ReaderWriterLock>;
+  using WriteLockGuard = std::unique_lock<ReaderWriterLock>;
+  ReaderWriterLock callbackLock_;
 #ifdef HAS_CUPTI
   CUptiResult lastCuptiStatus_;
   CUpti_SubscriberHandle subscriber_ {0};

--- a/libkineto/src/CuptiRangeProfiler.cpp
+++ b/libkineto/src/CuptiRangeProfiler.cpp
@@ -109,14 +109,14 @@ CuptiRangeProfilerSession::CuptiRangeProfilerSession(
     LOG(INFO) << "\t" << m;
   }
 
-  CuptiRangeProfilerOptions opts{
-    .metricNames = cupti_metrics,
-    .deviceId = 0,
-    .maxRanges = max_ranges,
-    .numNestingLevels = 1,
-    .cuContext = nullptr,
-    .unitTest = false};
-
+  CuptiRangeProfilerOptions opts;
+  opts.metricNames = cupti_metrics;
+  opts.deviceId = 0;
+  opts.maxRanges = max_ranges;
+  opts.numNestingLevels = 1;
+  opts.cuContext = nullptr;
+  opts.unitTest = false;
+  
   for (auto device_id : CuptiRBProfilerSession::getActiveDevices()) {
     LOG(INFO) << "Init CUPTI range profiler on gpu = " << device_id
               << " max ranges = " << max_ranges;

--- a/libkineto/src/CuptiRangeProfilerConfig.cpp
+++ b/libkineto/src/CuptiRangeProfilerConfig.cpp
@@ -10,7 +10,6 @@
 #include <Logger.h>
 
 #include <stdlib.h>
-#include <unistd.h>
 
 #include <fmt/format.h>
 #include <ostream>


### PR DESCRIPTION
Fixed 2 compiling errors on Windows.
Changed callbackLock_ from static to member of the class since on Windows Release in Pytorch CuptiCallbackApi::initCallbackApi gets called before the static initialisation of the mutex so it crashes. 