### PR TITLE
Make MTIA activities default in Kineto

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -29,13 +29,13 @@ enum class ActivityType {
     CPU_INSTANT_EVENT, // host side point-like events
     PYTHON_FUNCTION,
     OVERHEAD, // CUPTI induced overhead events sampled from its overhead API.
+    MTIA_RUNTIME, // host side MTIA runtime events
+    MTIA_CCP_EVENTS, // MTIA ondevice CCP events
 
     // Optional Activity types
     CUDA_SYNC, // synchronization events between runtime and kernels
     GLOW_RUNTIME, // host side glow runtime events
-    MTIA_RUNTIME, // host side MTIA runtime events
     CUDA_PROFILER_RANGE, // CUPTI Profiler range for performance metrics
-    MTIA_CCP_EVENTS, // MTIA ondevice CCP events
     HPU_OP, // HPU host side runtime event
     XPU_RUNTIME, // host side xpu runtime events
 

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -30,11 +30,11 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
     {"python_function", ActivityType::PYTHON_FUNCTION},
     {"overhead", ActivityType::OVERHEAD},
+    {"mtia_runtime", ActivityType::MTIA_RUNTIME},
+    {"mtia_ccp_events", ActivityType::MTIA_CCP_EVENTS},
     {"cuda_sync", ActivityType::CUDA_SYNC},
     {"glow_runtime", ActivityType::GLOW_RUNTIME},
-    {"mtia_runtime", ActivityType::MTIA_RUNTIME},
     {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
-    {"mtia_ccp_events", ActivityType::MTIA_CCP_EVENTS},
     {"hpu_op", ActivityType::HPU_OP},
     {"xpu_runtime", ActivityType::XPU_RUNTIME},
     {"ENUM_COUNT", ActivityType::ENUM_COUNT}

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -96,7 +96,9 @@ TEST(ParseTest, ActivityTypes) {
                             ActivityType::EXTERNAL_CORRELATION,
                             ActivityType::OVERHEAD,
                             ActivityType::CUDA_RUNTIME,
-                            ActivityType::CUDA_DRIVER}));
+                            ActivityType::CUDA_DRIVER,
+                            ActivityType::MTIA_RUNTIME,
+                            ActivityType::MTIA_CCP_EVENTS}));
 
   Config cfg2;
   EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES=gpu_memcpy,gpu_MeMsEt,kernel"));


### PR DESCRIPTION
Summary: Unitrace uses default activity types for kineto. For integration with MTIA, we need to make MTIA activity types default in kineto

Differential Revision: D51353262


