### PR TITLE
Revert D50471345: Multisect successfully blamed "D50471345: [Kineto] Make CUPTI lazy init" for test or build failures

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -41,13 +41,19 @@ inline bool cuptiLazyInit_() {
 
 inline void reenableCuptiCallbacks_(std::shared_ptr<CuptiCallbackApi>& cbapi_) {
   // Re-enable callbacks from the past if they exist.
-  VLOG(1) << "Re-enable previous CUPTI callbacks - Starting";
-  bool status = cbapi_->reenableCallbacks();
-  LOG(INFO) << "  CUPTI subscriber after enable:" << cbapi_->getCuptiSubscriber();
-  if (!status) {
-    LOG(WARNING) << "Re-enable previous CUPTI callbacks - Failed to reenableCallbacks";
+  LOG(INFO) << "Re-enable previous CUPTI callbacks - Starting";
+  VLOG(1) << "  CUPTI subscriber before reinit:" << cbapi_->getCuptiSubscriber();
+  cbapi_->initCallbackApi();
+  if (cbapi_->initSuccess()) {
+    VLOG(1) << "  CUPTI subscriber after reinit:" << cbapi_->getCuptiSubscriber();
+    bool status = cbapi_->reenableCallbacks();
+    if (!status) {
+      LOG(WARNING) << "Re-enable previous CUPTI callbacks - Failed to reenableCallbacks";
+    } else {
+      LOG(INFO) << "Re-enable previous CUPTI callbacks - Successful";
+    }
   } else {
-    VLOG(1) << "Re-enable previous CUPTI callbacks - Successful";
+    LOG(WARNING) << "Re-enable previous CUPTI callbacks - Failed to initCallbackApi";
   }
 }
 #endif
@@ -300,13 +306,10 @@ void CuptiActivityApi::bufferCompleted(
 void CuptiActivityApi::enableCuptiActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_CUPTI
+  // Lazily support re-init of CUPTI Callbacks, if they were finalized before.
   auto cbapi_ = CuptiCallbackApi::singleton();
-  if (!tracingEnabled_ && !cbapi_->initStatus()) {
-    cbapi_->initCallbackApi();
-    // Lazily support init of CUPTI Callbacks.
-    if (cuptiLazyInit_()) {
-      reenableCuptiCallbacks_(cbapi_);
-    }
+  if (!tracingEnabled_ && !cbapi_->initSuccess() && cuptiLazyInit_()) {
+    reenableCuptiCallbacks_(cbapi_);
   }
   cbapi_.reset();
 
@@ -393,6 +396,13 @@ void CuptiActivityApi::teardownContext() {
     // PyTorch Profiler is synchronous, so teardown needs to be run async in this thread.
     std::thread teardownThread([&] {
       auto cbapi_ = CuptiCallbackApi::singleton();
+      if (!cbapi_->initSuccess()) {
+        cbapi_->initCallbackApi();
+        if (!cbapi_->initSuccess()) {
+          LOG(WARNING) << "CUPTI Callback failed to init, skipping teardown";
+          return;
+        }
+      }
       // Subscribe callbacks to call cuptiFinalize in the exit callback of these APIs
       bool status = cbapi_->enableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);
       status = status && cbapi_->enableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
@@ -404,7 +414,7 @@ void CuptiActivityApi::teardownContext() {
       // Force Flush before finalize
       CUPTI_CALL(cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
 
-      VLOG(1) << "  CUPTI subscriber before finalize:" << cbapi_->getCuptiSubscriber();
+      LOG(INFO) << "  CUPTI subscriber before finalize:" << cbapi_->getCuptiSubscriber();
       teardownCupti_ = 1;
       std::unique_lock<std::mutex> lck(finalizeMutex_);
       finalizeCond_.wait(lck, [&]{return teardownCupti_ == 0;});
@@ -417,7 +427,6 @@ void CuptiActivityApi::teardownContext() {
       // Remove the callbacks used specifically for cuptiFinalize
       cbapi_->disableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);
       cbapi_->disableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
-      cbapi_->deinitCallbackApi();
 
       // Re-init CUPTI Callbacks if Lazy Re-init is not enabled.
       if (!cuptiLazyInit_()) {

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -165,40 +165,16 @@ std::shared_ptr<CuptiCallbackApi> CuptiCallbackApi::singleton() {
 
 void CuptiCallbackApi::initCallbackApi() {
 #ifdef HAS_CUPTI
-  if (initSuccess_) {
-    return;
-  }
-
   lastCuptiStatus_ = CUPTI_ERROR_UNKNOWN;
   lastCuptiStatus_ = CUPTI_CALL_NOWARN(
     cuptiSubscribe(&subscriber_,
       (CUpti_CallbackFunc)callback_switchboard,
       nullptr));
   if (lastCuptiStatus_ != CUPTI_SUCCESS) {
-    LOG(WARNING) << "Failed cuptiSubscribe, status: " << lastCuptiStatus_;
-    LOG(WARNING) << "CUPTI initialization failed - "
-                 << "CUDA profiler activities will be missing";
-    if (lastCuptiStatus_ == CUPTI_ERROR_INSUFFICIENT_PRIVILEGES) {
-      LOG(INFO) << "For CUPTI_ERROR_INSUFFICIENT_PRIVILEGES, refer to "
-                << "https://developer.nvidia.com/nvidia-development-tools-solutions-err-nvgpuctrperm-cupti";
-    }
+    VLOG(1)  << "Failed cuptiSubscribe, status: " << lastCuptiStatus_;
   }
 
   initSuccess_ = (lastCuptiStatus_ == CUPTI_SUCCESS);
-#endif
-}
-
-void CuptiCallbackApi::deinitCallbackApi() {
-#ifdef HAS_CUPTI
-  if (!initSuccess_) {
-    return;
-  }
-  lastCuptiStatus_ = CUPTI_CALL_NOWARN(
-    cuptiUnsubscribe(subscriber_));
-  if (lastCuptiStatus_ != CUPTI_SUCCESS) {
-    LOG(WARNING) << "Failed cuptiUnsubscribe, status: " << lastCuptiStatus_;
-  }
-  initSuccess_ = false;
 #endif
 }
 
@@ -286,7 +262,6 @@ bool CuptiCallbackApi::deleteCallback(
 bool CuptiCallbackApi::enableCallback(
     CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
 #ifdef HAS_CUPTI
-  initCallbackApi();
   if (initSuccess_) {
     lastCuptiStatus_ = CUPTI_CALL_NOWARN(
         cuptiEnableCallback(1, subscriber_, domain, cbid));
@@ -313,7 +288,6 @@ bool CuptiCallbackApi::disableCallback(
 bool CuptiCallbackApi::enableCallbackDomain(
     CUpti_CallbackDomain domain) {
 #ifdef HAS_CUPTI
-  initCallbackApi();
   if (initSuccess_) {
     lastCuptiStatus_ = CUPTI_CALL_NOWARN(
         cuptiEnableDomain(1, subscriber_, domain));
@@ -339,7 +313,6 @@ bool CuptiCallbackApi::disableCallbackDomain(
 
 bool CuptiCallbackApi::reenableCallbacks() {
 #ifdef HAS_CUPTI
-  initCallbackApi();
   if (initSuccess_) {
     for (auto& cbpair : enabledCallbacks_) {
       if ((uint32_t)cbpair.second == MAX_CUPTI_CALLBACK_ID_ALL) {

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -72,9 +72,8 @@ class CuptiCallbackApi {
   static std::shared_ptr<CuptiCallbackApi> singleton();
 
   void initCallbackApi();
-  void deinitCallbackApi();
 
-  bool initStatus() const {
+  bool initSuccess() const {
     return initSuccess_;
   }
 


### PR DESCRIPTION
Summary:
This diff is reverting D50471345
D50471345: [Kineto] Make CUPTI lazy init by aaronenyeshi has been identified to be causing the following test or build failures:

Differential Revision: D51382925


