### PR TITLE
Rework roctracer shutdown flushing

### DIFF
--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -176,6 +176,7 @@ class RoctracerLogger {
 
   std::unique_ptr<std::list<RoctracerActivityBuffer>> gpuTraceBuffers_;
   bool externalCorrelationEnabled_{true};
+  bool logging_{false};
 
   friend class onnxruntime::profiling::RocmProfiler;
   friend class libkineto::RoctracerActivityApi;


### PR DESCRIPTION
Reworked roctracer flush on shutdown.  Removing a race condition added while removing the original race condition. :)
Previous implementation had a deadlock in the case where the op buffer had filled and flushed on its own immediately before shutdown.

This new approach is simpler but has to continuously log correlation ids of completed async ops.  This is done on the roctracer supplied callback thread so it is not an overhead/performance issue.  Previous attempt was over-optimized at the cost of not working correctly.  Oops.
