### PR TITLE
Avoid suppressing log messages for unit tests

### DIFF
--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -37,6 +37,7 @@ extern "C" {
   void suppressLibkinetoLogMessages();
   int InitializeInjection(void);
   void libkineto_init(bool cpuOnly, bool logOnError);
+  bool hasTestEnvVar();
 }
 
 namespace libkineto {

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -185,10 +185,16 @@ int InitializeInjection(void) {
   return 1;
 }
 
+bool hasTestEnvVar() {
+  return getenv("GTEST_OUTPUT") != nullptr || getenv("FB_TEST") != nullptr
+     || getenv("PYTORCH_TEST") != nullptr || getenv("TEST_PILOT") != nullptr;
+}
+
 void suppressLibkinetoLogMessages() {
   // Only suppress messages if explicit override wasn't provided
   const char* logLevelEnv = getenv("KINETO_LOG_LEVEL");
-  if (!logLevelEnv || !*logLevelEnv) {
+  // For unit tests, don't suppress log verbosity.
+  if (!hasTestEnvVar() && (!logLevelEnv || !*logLevelEnv)) {
     SET_LOG_SEVERITY_LEVEL(ERROR);
   }
 }


### PR DESCRIPTION
Summary: There are unit tests in APS trainer that require parsing the log messages to verify that there are GPU records being saved. We should keep log messages at least at INFO level for unit tests.

Reviewed By: davidberard98

Differential Revision: D51431805

Pulled By: aaronenyeshi


