### PR TITLE
Re-land "D50471345: [Kineto] Make CUPTI lazy init"

### DIFF
--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -37,6 +37,7 @@ extern "C" {
   void suppressLibkinetoLogMessages();
   int InitializeInjection(void);
   void libkineto_init(bool cpuOnly, bool logOnError);
+  bool hasTestEnvVar();
 }
 
 namespace libkineto {

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -165,16 +165,40 @@ std::shared_ptr<CuptiCallbackApi> CuptiCallbackApi::singleton() {
 
 void CuptiCallbackApi::initCallbackApi() {
 #ifdef HAS_CUPTI
+  if (initSuccess_) {
+    return;
+  }
+
   lastCuptiStatus_ = CUPTI_ERROR_UNKNOWN;
   lastCuptiStatus_ = CUPTI_CALL_NOWARN(
     cuptiSubscribe(&subscriber_,
       (CUpti_CallbackFunc)callback_switchboard,
       nullptr));
   if (lastCuptiStatus_ != CUPTI_SUCCESS) {
-    VLOG(1)  << "Failed cuptiSubscribe, status: " << lastCuptiStatus_;
+    LOG(WARNING) << "Failed cuptiSubscribe, status: " << lastCuptiStatus_;
+    LOG(WARNING) << "CUPTI initialization failed - "
+                 << "CUDA profiler activities will be missing";
+    if (lastCuptiStatus_ == CUPTI_ERROR_INSUFFICIENT_PRIVILEGES) {
+      LOG(INFO) << "For CUPTI_ERROR_INSUFFICIENT_PRIVILEGES, refer to "
+                << "https://developer.nvidia.com/nvidia-development-tools-solutions-err-nvgpuctrperm-cupti";
+    }
   }
 
   initSuccess_ = (lastCuptiStatus_ == CUPTI_SUCCESS);
+#endif
+}
+
+void CuptiCallbackApi::deinitCallbackApi() {
+#ifdef HAS_CUPTI
+  if (!initSuccess_) {
+    return;
+  }
+  lastCuptiStatus_ = CUPTI_CALL_NOWARN(
+    cuptiUnsubscribe(subscriber_));
+  if (lastCuptiStatus_ != CUPTI_SUCCESS) {
+    LOG(WARNING) << "Failed cuptiUnsubscribe, status: " << lastCuptiStatus_;
+  }
+  initSuccess_ = false;
 #endif
 }
 
@@ -262,6 +286,7 @@ bool CuptiCallbackApi::deleteCallback(
 bool CuptiCallbackApi::enableCallback(
     CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
 #ifdef HAS_CUPTI
+  initCallbackApi();
   if (initSuccess_) {
     lastCuptiStatus_ = CUPTI_CALL_NOWARN(
         cuptiEnableCallback(1, subscriber_, domain, cbid));
@@ -288,6 +313,7 @@ bool CuptiCallbackApi::disableCallback(
 bool CuptiCallbackApi::enableCallbackDomain(
     CUpti_CallbackDomain domain) {
 #ifdef HAS_CUPTI
+  initCallbackApi();
   if (initSuccess_) {
     lastCuptiStatus_ = CUPTI_CALL_NOWARN(
         cuptiEnableDomain(1, subscriber_, domain));
@@ -313,6 +339,7 @@ bool CuptiCallbackApi::disableCallbackDomain(
 
 bool CuptiCallbackApi::reenableCallbacks() {
 #ifdef HAS_CUPTI
+  initCallbackApi();
   if (initSuccess_) {
     for (auto& cbpair : enabledCallbacks_) {
       if ((uint32_t)cbpair.second == MAX_CUPTI_CALLBACK_ID_ALL) {

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -72,8 +72,9 @@ class CuptiCallbackApi {
   static std::shared_ptr<CuptiCallbackApi> singleton();
 
   void initCallbackApi();
+  void deinitCallbackApi();
 
-  bool initSuccess() const {
+  bool initStatus() const {
     return initSuccess_;
   }
 

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -185,10 +185,16 @@ int InitializeInjection(void) {
   return 1;
 }
 
+bool hasTestEnvVar() {
+  return getenv("GTEST_OUTPUT") != nullptr || getenv("FB_TEST") != nullptr
+     || getenv("PYTORCH_TEST") != nullptr || getenv("TEST_PILOT") != nullptr;
+}
+
 void suppressLibkinetoLogMessages() {
   // Only suppress messages if explicit override wasn't provided
   const char* logLevelEnv = getenv("KINETO_LOG_LEVEL");
-  if (!logLevelEnv || !*logLevelEnv) {
+  // For unit tests, don't suppress log verbosity.
+  if (!hasTestEnvVar() && (!logLevelEnv || !*logLevelEnv)) {
     SET_LOG_SEVERITY_LEVEL(ERROR);
   }
 }

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -28,7 +28,6 @@
 namespace KINETO_NAMESPACE {
 
 #ifdef HAS_CUPTI
-static bool initialized = false;
 static std::mutex initMutex;
 
 bool enableEventProfiler() {
@@ -46,25 +45,14 @@ static void initProfilers(
   VLOG(0) << "CUDA Context created";
   std::lock_guard<std::mutex> lock(initMutex);
 
-  if (!initialized) {
-    libkineto::api().initProfilerIfRegistered();
-    initialized = true;
-    VLOG(0) << "libkineto profilers activated";
-  }
-
-  if (!enableEventProfiler()) {
-    VLOG(0) << "Kineto EventProfiler disabled, skipping start";
-    return;
-  } else {
-    CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
-    CUcontext ctx = d->context;
-    ConfigLoader& config_loader = libkineto::api().configLoader();
-    config_loader.initBaseConfig();
-    auto config = config_loader.getConfigCopy();
-    if (config->eventProfilerEnabled()) {
-      EventProfilerController::start(ctx, config_loader);
-      LOG(INFO) << "Kineto EventProfiler started";
-    }
+  CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
+  CUcontext ctx = d->context;
+  ConfigLoader& config_loader = libkineto::api().configLoader();
+  config_loader.initBaseConfig();
+  auto config = config_loader.getConfigCopy();
+  if (config->eventProfilerEnabled()) {
+    EventProfilerController::start(ctx, config_loader);
+    LOG(INFO) << "Kineto EventProfiler started";
   }
 }
 
@@ -88,12 +76,10 @@ static void stopProfiler(
   VLOG(0) << "CUDA Context destroyed";
   std::lock_guard<std::mutex> lock(initMutex);
 
-  if (enableEventProfiler()) {
-    CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
-    CUcontext ctx = d->context;
-    EventProfilerController::stopIfEnabled(ctx);
-    LOG(INFO) << "Kineto EventProfiler stopped";
-  }
+  CUpti_ResourceData* d = (CUpti_ResourceData*)cbInfo;
+  CUcontext ctx = d->context;
+  EventProfilerController::stopIfEnabled(ctx);
+  LOG(INFO) << "Kineto EventProfiler stopped";
 }
 
 static std::unique_ptr<CuptiRangeProfilerInit> rangeProfilerInit;
@@ -124,31 +110,29 @@ void libkineto_init(bool cpuOnly, bool logOnError) {
 #endif
 
 #ifdef HAS_CUPTI
-  if (!cpuOnly) {
+  bool initRangeProfiler = false;
+  if (!cpuOnly && enableEventProfiler() ) {
     // libcupti will be lazily loaded on this call.
     // If it is not available (e.g. CUDA is not installed),
     // then this call will return an error and we just abort init.
     auto cbapi = CuptiCallbackApi::singleton();
-    cbapi->initCallbackApi();
     bool status = false;
-    bool initRangeProfiler = true;
+    initRangeProfiler = true;
 
-    if (cbapi->initSuccess()){
-      const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RESOURCE;
-      status = cbapi->registerCallback(
-          domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED, initProfilers);
-      status = status && cbapi->registerCallback(
-          domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED, stopProfiler);
+    const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RESOURCE;
+    status = cbapi->registerCallback(
+        domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED, initProfilers);
+    status = status && cbapi->registerCallback(
+        domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED, stopProfiler);
 
-      if (status) {
-        status = cbapi->enableCallback(
-            domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED);
-        status = status && cbapi->enableCallback(
-            domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED);
-      }
+    if (status) {
+      status = cbapi->enableCallback(
+          domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED);
+      status = status && cbapi->enableCallback(
+          domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED);
     }
 
-    if (!cbapi->initSuccess() || !status) {
+    if (!cbapi->initStatus() || !status) {
       initRangeProfiler = false;
       cpuOnly = true;
       if (logOnError) {
@@ -159,11 +143,13 @@ void libkineto_init(bool cpuOnly, bool logOnError) {
                   << "https://developer.nvidia.com/nvidia-development-tools-solutions-err-nvgpuctrperm-cupti";
       }
     }
+  } else {
+    VLOG(0) << "Kineto EventProfiler disabled, skipping it";
+  }
 
-    // initialize CUPTI Range Profiler API
-    if (initRangeProfiler) {
-      rangeProfilerInit = std::make_unique<CuptiRangeProfilerInit>();
-    }
+  // initialize CUPTI Range Profiler API
+  if (initRangeProfiler) {
+    rangeProfilerInit = std::make_unique<CuptiRangeProfilerInit>();
   }
 
   if (shouldPreloadCuptiInstrumentation()) {


### PR DESCRIPTION
Summary: This diff was reverted due to failures related to lazy init causing suppressed log messages. D51431805 should fix that issue by avoiding suppressed log messages for unit tests. Re-land this diff to make CUPTI lazy init, see D50471345 for specifics.

Differential Revision: D51432016

Pulled By: aaronenyeshi


