### PR TITLE
fix: add libkineto missing public header

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -69,6 +69,7 @@ def get_libkineto_public_headers():
         "include/IActivityProfiler.h",
         "include/ILoggerObserver.h",
         "include/ITraceActivity.h",
+        "include/LoggingAPI.h",
         "include/TraceSpan.h",
         "include/ThreadUtil.h",
         "include/libkineto.h",


### PR DESCRIPTION
To fix build error:
```
root@pc:~/libkineto/sample_programs# ./build.sh
In file included from kineto_playground.cpp:14:
/usr/local/include/kineto/libkineto.h:32:10: fatal error: LoggingAPI.h: No such file or directory
   32 | #include "LoggingAPI.h"
      |          ^~~~~~~~~~~~~~
compilation terminated
```