### PR TITLE
Remove unused private from kineto/libkineto/include/libkineto.h

### DIFF
--- a/libkineto/include/libkineto.h
+++ b/libkineto/include/libkineto.h
@@ -153,7 +153,6 @@ class LibkinetoApi {
   ClientInterface* client_{};
   int32_t clientRegisterThread_{0};
 
-  bool isLoaded_{false};
   std::vector<ChildActivityProfilerFactory> childProfilerFactories_;
 };
 


### PR DESCRIPTION
Summary:
`-Wunused-private-field` has identified an unused private field. This diff removes it.

If the code compiles, this is safe to land.

Differential Revision: D51572497


