### PR TITLE
Re-word LOG message for Record Counters from Error info to Record counts

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -291,7 +291,7 @@ void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
     session->processTrace(logger);
   }
 
-  LOG(INFO) << "Error info: " << ecs_;
+  LOG(INFO) << "Record counts: " << ecs_;
 
   finalizeTrace(*config_, logger);
 }


### PR DESCRIPTION
Summary:
This LOG message has been causing a lot of confusion across production jobs. People are seeing the Error info message, and believe the profiler is breaking something. This is actually a harmless message, that shows detailed record counts.

The loggers also mark Error keyword line in red, making it stand out as an Error message.

Differential Revision: D51950718

Pulled By: aaronenyeshi


