### PR TITLE
Roctracer: read kernel names from (NEW) union in the async op record

### DIFF
--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -39,7 +39,8 @@ typedef enum {
 
 typedef enum {
   HIP_OP_DISPATCH_KIND_UNKNOWN_ = 0,
-  HIP_OP_DISPATCH_KIND_KERNEL_ = 0x11F0
+  HIP_OP_DISPATCH_KIND_KERNEL_ = 0x11F0,
+  HIP_OP_DISPATCH_KIND_TASK_ = 0x11F1
 } hip_op_dispatch_kind_t_;
 
 typedef enum {
@@ -289,6 +290,7 @@ int RoctracerActivityApi::processActivities(
         a.activityType = ActivityType::GPU_MEMSET;
         break;
       case HIP_OP_DISPATCH_KIND_KERNEL_:
+      case HIP_OP_DISPATCH_KIND_TASK_:
       default:
         if (!isLogged(ActivityType::CONCURRENT_KERNEL))
           filtered = true;

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -235,27 +235,6 @@ int RoctracerActivityApi::processActivities(
       a.addMetadata("shared size", item.groupSegmentSize);
       a.addMetadataQuoted("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
 
-      // Stash launches to tie to the async ops
-      kernelLaunches_[a.id] = a;
-
-      // Stash kernel names to tie to the async ops
-      std::string name;
-      if (item.functionAddr != nullptr) {
-        name = demangle(hipKernelNameRefByPtr(item.functionAddr, item.stream));
-      }
-      else if (item.function != nullptr) {
-        name = demangle(hipKernelNameRef(item.function));
-      }
-      if (!name.empty()) {
-        uint32_t string_id = reverseStrings_[name];
-        if (string_id == 0) {
-          string_id = nextStringId_++;
-          reverseStrings_[name] = string_id;
-          strings_[string_id] = name;
-        }
-        kernelNames_[item.id] = string_id;
-      }
-
       logger.handleGenericActivity(a);
       ++count;
     }
@@ -263,99 +242,65 @@ int RoctracerActivityApi::processActivities(
 
   // Async Ops
 
-  for (auto& buffer : *d->gpuTraceBuffers_) {
-    const roctracer_record_t* record = (const roctracer_record_t*)(buffer.data_);
-    const roctracer_record_t* end_record = (const roctracer_record_t*)(buffer.data_ + buffer.validSize_);
+  for (auto &item : d->opRows_) {
+    if (!inRange(startTime, endTime, item.begin))
+          continue;
     GenericTraceActivity a;
 
-    while (record < end_record) {
-      if (record->domain == ACTIVITY_DOMAIN_HIP_API) {
-        const char *name = roctracer_op_string(record->domain, record->op, record->kind);
-        a.device = record->process_id;
-        a.resource = record->thread_id;
+    // Overlay launch metadata for kernels
+    auto kit = kernelLaunches_.find(item.id);
+    if (kit != kernelLaunches_.end()) {
+      a = (*kit).second;
+    }
 
-        a.startTime = (record->begin_ns + toffset) / 1000;
-        a.endTime = (record->end_ns + toffset) / 1000;
-        a.id = record->correlation_id;
+    const char *name = roctracer_op_string(item.domain, item.op, item.kind);
+    a.device = item.device;
+    a.resource = item.queue;
 
-        a.activityType = ActivityType::CUDA_RUNTIME;
-        a.activityName = std::string(name);
-        a.flow.id = record->correlation_id;
-        a.flow.type = kLinkAsyncCpuGpu;
-        a.flow.start = true;
+    a.startTime = (item.begin + toffset) / 1000;
+    a.endTime = (item.end + toffset) / 1000;
+    a.id = item.id;
 
-        auto it = externalCorrelations.find(a.id);
-        a.linked = linkedActivity(it == externalCorrelations.end() ? 0 : it->second);
+    a.activityType = ActivityType::CONCURRENT_KERNEL;
+    a.activityName = item.kernelName.length() > 0 ? item.kernelName : std::string(name);
+    a.flow.id = item.id;
+    a.flow.type = kLinkAsyncCpuGpu;
+    a.flow.start = false;
 
-        if (inRange(startTime, endTime, record->begin_ns)) {
-            logger.handleGenericActivity(a);
-            ++count;
-        }
-      }
-      else if (record->domain == ACTIVITY_DOMAIN_HCC_OPS) {
-        // Overlay launch metadata for kernels
-        auto kit = kernelLaunches_.find(record->correlation_id);
-        if (kit != kernelLaunches_.end()) {
-          a = (*kit).second;
-        }
+    auto eit = externalCorrelations.find(a.id);
+    a.linked = linkedActivity(eit == externalCorrelations.end() ? 0 : eit->second);
 
-        const char *name = roctracer_op_string(record->domain, record->op, record->kind);
-        a.device = record->device_id;
-        a.resource = record->queue_id;
+    bool filtered = false;
 
-        a.startTime = (record->begin_ns + toffset) / 1000;
-        a.endTime = (record->end_ns + toffset) / 1000;
-        a.id = record->correlation_id;
-
+    switch (item.kind) {
+      case HIP_OP_COPY_KIND_DEVICE_TO_HOST_:
+      case HIP_OP_COPY_KIND_HOST_TO_DEVICE_:
+      case HIP_OP_COPY_KIND_DEVICE_TO_DEVICE_:
+      case HIP_OP_COPY_KIND_DEVICE_TO_HOST_2D_:
+      case HIP_OP_COPY_KIND_HOST_TO_DEVICE_2D_:
+      case HIP_OP_COPY_KIND_DEVICE_TO_DEVICE_2D_:
+        if (!isLogged(ActivityType::GPU_MEMCPY))
+          filtered = true;
+        a.activityType = ActivityType::GPU_MEMCPY;
+        break;
+      case HIP_OP_COPY_KIND_FILL_BUFFER_:
+        if (!isLogged(ActivityType::GPU_MEMSET))
+          filtered = true;
+        a.activityType = ActivityType::GPU_MEMSET;
+        break;
+      case HIP_OP_DISPATCH_KIND_KERNEL_:
+      default:
+        if (!isLogged(ActivityType::CONCURRENT_KERNEL))
+          filtered = true;
+        if (item.op == HIP_OP_ID_BARRIER)  // Don't record barriers/markers
+          filtered = true;
         a.activityType = ActivityType::CONCURRENT_KERNEL;
-        a.activityName = std::string(name);
-        a.flow.id = record->correlation_id;
-        a.flow.type = kLinkAsyncCpuGpu;
-        a.flow.start = false;
+        break;
+    }
 
-        auto eit = externalCorrelations.find(a.id);
-        a.linked = linkedActivity(eit == externalCorrelations.end() ? 0 : eit->second);
-
-        auto it = kernelNames_.find(record->correlation_id);
-        if (it != kernelNames_.end()) {
-          a.activityName = strings_[it->second];
-        }
-
-        bool filtered = false;
-
-        switch (record->kind) {
-          case HIP_OP_COPY_KIND_DEVICE_TO_HOST_:
-          case HIP_OP_COPY_KIND_HOST_TO_DEVICE_:
-          case HIP_OP_COPY_KIND_DEVICE_TO_DEVICE_:
-          case HIP_OP_COPY_KIND_DEVICE_TO_HOST_2D_:
-          case HIP_OP_COPY_KIND_HOST_TO_DEVICE_2D_:
-          case HIP_OP_COPY_KIND_DEVICE_TO_DEVICE_2D_:
-            if (!isLogged(ActivityType::GPU_MEMCPY))
-              filtered = true;
-            a.activityType = ActivityType::GPU_MEMCPY;
-            break;
-          case HIP_OP_COPY_KIND_FILL_BUFFER_:
-            if (!isLogged(ActivityType::GPU_MEMSET))
-              filtered = true;
-            a.activityType = ActivityType::GPU_MEMSET;
-            break;
-          case HIP_OP_DISPATCH_KIND_KERNEL_:
-          default:
-            if (!isLogged(ActivityType::CONCURRENT_KERNEL))
-              filtered = true;
-            if (record->op == HIP_OP_ID_BARRIER)  // Don't record barriers/markers
-              filtered = true;
-            a.activityType = ActivityType::CONCURRENT_KERNEL;
-            break;
-        }
-
-        if (!filtered && inRange(startTime, endTime, record->begin_ns)) {
-            logger.handleGenericActivity(a);
-            ++count;
-        }
-      }
-
-      roctracer_next_record(record, &record);
+    if (!filtered && inRange(startTime, endTime, item.begin)) {
+        logger.handleGenericActivity(a);
+        ++count;
     }
   }
   return count;

--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -267,7 +267,8 @@ void RoctracerLogger::api_callback(uint32_t domain, uint32_t cid, const void* ca
 // Clone this here.  Static value that may not be present in earlier rocm headers
 typedef enum {
   HIP_OP_DISPATCH_KIND_UNKNOWN_ = 0,
-  HIP_OP_DISPATCH_KIND_KERNEL_ = 0x11F0
+  HIP_OP_DISPATCH_KIND_KERNEL_ = 0x11F0,
+  HIP_OP_DISPATCH_KIND_TASK_ = 0x11F1
 } hip_op_dispatch_kind_t_;
 
 void RoctracerLogger::activity_callback(const char* begin, const char* end, void* arg)
@@ -292,7 +293,8 @@ void RoctracerLogger::activity_callback(const char* begin, const char* end, void
                record->thread_id,
                record->begin_ns,
                record->end_ns,
-               (record->kind == HIP_OP_DISPATCH_KIND_KERNEL_)
+               ((record->kind == HIP_OP_DISPATCH_KIND_KERNEL_)
+                 || (record->kind == HIP_OP_DISPATCH_KIND_TASK_))
                  ? demangle(record->kernel_name)
                  : std::string()
              );

--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -16,6 +16,7 @@
 
 #include "Logger.h"
 #include "ThreadUtil.h"
+#include "Demangle.h"
 
 typedef uint64_t timestamp_t;
 
@@ -47,7 +48,6 @@ RoctracerLogger& RoctracerLogger::singleton() {
 }
 
 RoctracerLogger::RoctracerLogger() {
-  gpuTraceBuffers_ = std::make_unique<std::list<RoctracerActivityBuffer>>();
 }
 
 RoctracerLogger::~RoctracerLogger() {
@@ -78,7 +78,7 @@ void RoctracerLogger::clearLogs() {
   kernelRows_.clear();
   copyRows_.clear();
   mallocRows_.clear();
-  gpuTraceBuffers_->clear();
+  opRows_.clear();
   for (int i = 0; i < CorrelationDomain::size; ++i) {
     externalCorrelations_[i].clear();
   }
@@ -264,13 +264,15 @@ void RoctracerLogger::api_callback(uint32_t domain, uint32_t cid, const void* ca
   }
 }
 
+// Clone this here.  Static value that may not be present in earlier rocm headers
+typedef enum {
+  HIP_OP_DISPATCH_KIND_UNKNOWN_ = 0,
+  HIP_OP_DISPATCH_KIND_KERNEL_ = 0x11F0
+} hip_op_dispatch_kind_t_;
+
 void RoctracerLogger::activity_callback(const char* begin, const char* end, void* arg)
 {
-  size_t size = end - begin;
-  uint8_t *buffer = (uint8_t*) malloc(size);
-  auto &gpuTraceBuffers = singleton().gpuTraceBuffers_;
-  memcpy(buffer, begin, size);
-  gpuTraceBuffers->emplace_back(buffer, size);
+  RoctracerLogger *dis = &singleton();
 
   // Log latest completed correlation id.  Used to ensure we have flushed all data on stop
   std::unique_lock<std::mutex> lock(s_flush.mutex_);
@@ -281,6 +283,19 @@ void RoctracerLogger::activity_callback(const char* begin, const char* end, void
     if (record->correlation_id > s_flush.maxCompletedCorrelationId_) {
        s_flush.maxCompletedCorrelationId_ = record->correlation_id;
     }
+
+    dis->opRows_.emplace_back(record->correlation_id,
+               record->domain,
+               record->kind,
+               record->op,
+               record->process_id,
+               record->thread_id,
+               record->begin_ns,
+               record->end_ns,
+               (record->kind == HIP_OP_DISPATCH_KIND_KERNEL_)
+                 ? demangle(record->kernel_name)
+                 : std::string()
+             );
     roctracer_next_record(record, &record);
   }
 }

--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -130,6 +130,24 @@ struct mallocRow : public roctracerRow {
   size_t size;
 };
 
+struct roctracerOpRow {
+  roctracerOpRow(uint64_t id, uint32_t domain, uint32_t kind, uint32_t op
+               , uint32_t device, uint32_t queue, uint64_t begin
+               , uint64_t end, const std::string &kernelName)
+    : id(id), domain(domain), kind(kind), op(op), device(device)
+    , queue(queue), begin(begin), end(end), kernelName(kernelName) {}
+
+  uint64_t id;  // correlation_id
+  uint32_t domain;
+  uint32_t kind;
+  uint32_t op;
+  uint32_t device;
+  uint32_t queue;
+  uint64_t begin;
+  uint64_t end;
+  std::string kernelName;
+};
+
 
 class RoctracerLogger {
  public:
@@ -172,9 +190,9 @@ class RoctracerLogger {
   std::deque<kernelRow> kernelRows_;
   std::deque<copyRow> copyRows_;
   std::deque<mallocRow> mallocRows_;
+  std::deque<roctracerOpRow> opRows_;
   std::map<uint64_t,uint64_t> externalCorrelations_[CorrelationDomain::size];	// tracer -> ext
 
-  std::unique_ptr<std::list<RoctracerActivityBuffer>> gpuTraceBuffers_;
   bool externalCorrelationEnabled_{true};
   bool logging_{false};
 


### PR DESCRIPTION
Roctracer now writes kernelnames into the async op records so we no longer have to glean them from the hipLaunchKernel api calls.  This allows use to populate kernel names from graph playback.
Using this value means parsing the async records at collection time since the char* names are not valid past the callback duration.
Created a structure to hold the parsed data.  Same pattern as for the api records.