### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/tb_plugin_ci.yml
+++ b/.github/workflows/tb_plugin_ci.yml
@@ -24,9 +24,9 @@ jobs:
           echo $GITHUB_BASE_REF
           if [ $GITHUB_BASE_REF == "plugin/vnext" ]
           then
-            echo "::set-output name=matrix::{\"python-version\":[3.8], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\"]}"
+            echo "matrix={\"python-version\":[3.8], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\"]}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=matrix::{\"python-version\":[3.8], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\", \"2.0\", \"stable\"]}"
+            echo "matrix={\"python-version\":[3.8], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\", \"2.0\", \"stable\"]}" >> $GITHUB_OUTPUT
           fi
 
   build:

--- a/.github/workflows/tb_plugin_ci.yml
+++ b/.github/workflows/tb_plugin_ci.yml
@@ -24,9 +24,9 @@ jobs:
           echo $GITHUB_BASE_REF
           if [ $GITHUB_BASE_REF == "plugin/vnext" ]
           then
-            echo "matrix={\"python-version\":[3.8], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"python-version\":[3.8], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\"]}" >> "$GITHUB_OUTPUT"
           else
-            echo "matrix={\"python-version\":[3.8], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\", \"2.0\", \"stable\"]}" >> $GITHUB_OUTPUT
+            echo "matrix={\"python-version\":[3.8], \"cuda-version\":[\"cpu\"], \"pytorch-version\":[\"nightly\", \"2.0\", \"stable\"]}" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -40,14 +40,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: 'x64'
+          architecture: "x64"
       - name: Test
         env:
           CUDA_VERSION: ${{ matrix.cuda-version }}
           PYTORCH_VERSION: ${{ matrix.pytorch-version }}
           TORCH_PROFILER_LOG_LEVEL: DEBUG
           GRPC_VERBOSITY: DEBUG
-          GRPC_ENABLE_FORK_SUPPORT: 'False'
+          GRPC_ENABLE_FORK_SUPPORT: "False"
         run: |
           set -e
           cd tb_plugin


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter