### PR TITLE
Remove extra semi colon from kineto/libkineto/src/IpcFabricConfigClient.cpp

### DIFF
--- a/libkineto/src/IpcFabricConfigClient.cpp
+++ b/libkineto/src/IpcFabricConfigClient.cpp
@@ -50,7 +50,7 @@ std::string generate_uuid_v4() {
   ss << "-";
   for (i = 0; i < 12; i++) {
       ss << dis(gen);
-  };
+  }
   return ss.str();
 }
 }


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: aaronenyeshi

Differential Revision: D52965961


