### PR TITLE
avoid illegal chars for cupti profiler logging

### DIFF
--- a/libkineto/src/CuptiRangeProfiler.cpp
+++ b/libkineto/src/CuptiRangeProfiler.cpp
@@ -106,7 +106,7 @@ CuptiRangeProfilerSession::CuptiRangeProfilerSession(
 
   int max_ranges = cupti_config.cuptiProfilerMaxRanges();
   for (const auto& m : cupti_metrics) {
-    LOG(INFO) << "\t" << m;
+    LOG(INFO) << "    " << m;
   }
 
   CuptiRangeProfilerOptions opts;
@@ -116,7 +116,7 @@ CuptiRangeProfilerSession::CuptiRangeProfilerSession(
   opts.numNestingLevels = 1;
   opts.cuContext = nullptr;
   opts.unitTest = false;
-  
+
   for (auto device_id : CuptiRBProfilerSession::getActiveDevices()) {
     LOG(INFO) << "Init CUPTI range profiler on gpu = " << device_id
               << " max ranges = " << max_ranges;

--- a/libkineto/src/CuptiRangeProfilerApi.cpp
+++ b/libkineto/src/CuptiRangeProfilerApi.cpp
@@ -363,7 +363,7 @@ CuptiRBProfilerSession::CuptiRBProfilerSession(
     return;
   }
 
-  LOG(INFO) << "Size of structs\n"
+  LOG(INFO) << "Size of structs"
             << " config image size = " << configImage.size()  << " B"
             << " counter data image prefix = "
             << counterDataImagePrefix.size()  << " B"


### PR DESCRIPTION
Summary:
when using cupti profiler, resulted trace file cannot be parsed in json correctly due to the newline char in info logging.

Similar to https://fb.workplace.com/groups/ai.efficiency.tools.users/permalink/1648240802328058/

Differential Revision: D53067845


