### PR TITLE
Fix for cudaEventSynchronize() in CUDA  sync activity tracer

### DIFF
--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -31,6 +31,10 @@ inline ActivityType GpuActivity<CUpti_ActivityKernel4>::type() const {
   return ActivityType::CONCURRENT_KERNEL;
 }
 
+inline bool isWaitEventSync(CUpti_ActivitySynchronizationType type) {
+  return (type == CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT);
+}
+
 inline bool isEventSync(CUpti_ActivitySynchronizationType type) {
   return (
     type == CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_EVENT_SYNCHRONIZE ||

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -538,15 +538,16 @@ void CuptiActivityProfiler::handleCudaSyncActivity(
           << " eventId=" << activity->cudaEventId
           << " contextId=" << activity->contextId;
 
-  if (!config_->activitiesCudaSyncWaitEvents() && isEventSync(activity->type)) {
+  if (!config_->activitiesCudaSyncWaitEvents() &&
+      isWaitEventSync(activity->type)) {
     return;
   }
 
   auto device_id = contextIdtoDeviceId(activity->contextId);
 
-  // Event Sync events tend to be noisy, only pass these events if
+  // Stream Wait Events tend to be noisy, only pass these events if
   // there was some GPU kernel/memcopy/memset observed on it till now.
-  if (isEventSync(activity->type) &&
+  if (isWaitEventSync(activity->type) &&
       (seenDeviceStreams_.find({device_id, activity->streamId}) ==
        seenDeviceStreams_.end())) {
     VLOG(2) << "Skipping Event Sync (corrId=" << activity->correlationId


### PR DESCRIPTION
Summary:
With cuda event sync we were missing one type of "Event Sync" operation due to some existing filtering logic we added earlier.
There are four types of synchronization CUDA supports
1. Context/Device Sync - CPU waits for GPU  (cudaDeviceSynchronize)
2. Stream Sync- CPU waits for GPU stream   (cudaStreamSynchronize)
3. Event Sync- CPU waits for GPU CUDA event  (cudaEventSynchronize)
4. Stream Wait for Event - Inter GPU stream sync  (cudaStreamWaitEvent)

{F1429132758} 
{F1429133328} 
We were not logging (3) above correctly. Stream Wait events were ending up being too noisy so we added filtering for them. But this inadvertently removed Cuda Event Sync events.
The changes include
1.  Adding a new function `isWaitEventSync` to determine whether an activity is a wait event synchronization specifically.
2. Modifying the `CuptiActivityProfiler::handleCudaSyncActivity()` method to not filter out Event Syncs
3. Updated test case.

Reviewed By: chaekit

Differential Revision: D53330874


