### PR TITLE
Enable CUDA synchronization events by default

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -31,9 +31,9 @@ enum class ActivityType {
     OVERHEAD, // CUPTI induced overhead events sampled from its overhead API.
     MTIA_RUNTIME, // host side MTIA runtime events
     MTIA_CCP_EVENTS, // MTIA ondevice CCP events
+    CUDA_SYNC, // synchronization events between runtime and kernels
 
     // Optional Activity types
-    CUDA_SYNC, // synchronization events between runtime and kernels
     GLOW_RUNTIME, // host side glow runtime events
     CUDA_PROFILER_RANGE, // CUPTI Profiler range for performance metrics
     HPU_OP, // HPU host side runtime event
@@ -41,7 +41,7 @@ enum class ActivityType {
     COLLECTIVE_COMM, // collective communication
 
     ENUM_COUNT, // This is to add buffer and not used for any profiling logic. Add your new type before it.
-    OPTIONAL_ACTIVITY_TYPE_START = CUDA_SYNC,
+    OPTIONAL_ACTIVITY_TYPE_START = GLOW_RUNTIME,
 };
 
 const char* toString(ActivityType t);

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -97,6 +97,7 @@ TEST(ParseTest, ActivityTypes) {
                             ActivityType::OVERHEAD,
                             ActivityType::CUDA_RUNTIME,
                             ActivityType::CUDA_DRIVER,
+                            ActivityType::CUDA_SYNC,
                             ActivityType::MTIA_RUNTIME,
                             ActivityType::MTIA_CCP_EVENTS}));
 


### PR DESCRIPTION
Summary:
This diff enables CUDA synchronization events by default in PyTorch's Kineto profiler. The CUDA Sync events have been enabled at Meta for 6 months without any reliability issues or user reports.

We now enable synchronization events for 1) on-demand workflows 2) open source PyTorch users.

Differential Revision: D53583783


