### PR TITLE
add libkineto/test/CMakeLists.txt 

### DIFF
--- a/.github/workflows/libkineto_ci.yml
+++ b/.github/workflows/libkineto_ci.yml
@@ -44,7 +44,7 @@ jobs:
         set -e
         mkdir build_static
         cd build_static
-        cmake -DKINETO_LIBRARY_TYPE=static ../libkineto/
+        cmake  -DKINETO_BUILD_TESTS=OFF -DKINETO_LIBRARY_TYPE=static ../libkineto/
         make -j
 
     - name: Build shared lib
@@ -52,5 +52,5 @@ jobs:
         set -e
         mkdir build_shared
         cd build_shared
-        cmake -DKINETO_LIBRARY_TYPE=shared ../libkineto/
+        cmake  -DKINETO_BUILD_TESTS=OFF -DKINETO_LIBRARY_TYPE=shared ../libkineto/
         make -j

--- a/.github/workflows/libkineto_cuda.yml
+++ b/.github/workflows/libkineto_cuda.yml
@@ -61,9 +61,9 @@ jobs:
           echo "Container name: ${container_name}"
           docker exec -t -w "/" "${container_name}" bash -c "sudo chown -R runner /kineto; sudo chgrp -R runner /kineto"
           docker exec -t -w "/kineto" "${container_name}" bash -c "set -e; mkdir build_static; mkdir build_shared"
-          docker exec -t -w "/kineto/build_static" "${container_name}" bash -c "cmake -DKINETO_LIBRARY_TYPE=static ../libkineto/; make -j"
-          docker exec -t -w "/kineto/build_shared" "${container_name}" bash -c "cmake -DKINETO_LIBRARY_TYPE=shared ../libkineto/; make -j"
-          docker exec -t -w "/kineto/build_static" "${container_name}" bash -c "make test"
+          docker exec -t -w "/kineto/build_static" "${container_name}" bash -c ". /workspace/setup_instance.sh; cmake -DKINETO_LIBRARY_TYPE=static ../libkineto/; make -j"
+          docker exec -t -w "/kineto/build_shared" "${container_name}" bash -c ". /workspace/setup_instance.sh; cmake -DKINETO_LIBRARY_TYPE=shared ../libkineto/; make -j"
+          docker exec -t -w "/kineto/build_static" "${container_name}" bash -c ". /workspace/setup_instance.sh; make test"
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
         if: always()

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "libkineto/third_party/dynolog"]
 	path = libkineto/third_party/dynolog
 	url = https://github.com/facebookincubator/dynolog.git
+[submodule "libkineto/third_party/folly"]
+	path = libkineto/third_party/folly
+	url = https://github.com/facebook/folly.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "libkineto/third_party/dynolog"]
 	path = libkineto/third_party/dynolog
 	url = https://github.com/facebookincubator/dynolog.git
-[submodule "libkineto/third_party/folly"]
-	path = libkineto/third_party/folly
-	url = https://github.com/facebook/folly.git

--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -285,5 +285,4 @@ install(EXPORT kinetoLibraryConfig DESTINATION share/cmake/kineto
 if(KINETO_BUILD_TESTS)
   add_subdirectory(test)
   add_subdirectory("${LIBKINETO_THIRDPARTY_DIR}/googletest")
-  add_subdirectory("${LIBKINETO_THIRDPARTY_DIR}/folly")
 endif()

--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -54,6 +54,11 @@ endif()
 
 if (KINETO_BUILD_TESTS)
   enable_testing()
+  if (NOT CUDA_SOURCE_DIR)
+    set(CUDA_SOURCE_DIR "$ENV{CUDA_HOME}")
+    message(INFO " CUDA_SOURCE_DIR = ${CUDA_SOURCE_DIR}")
+  endif()
+
   if (NOT CUPTI_INCLUDE_DIR)
     find_path(CUPTI_INCLUDE_DIR cupti.h PATHS
         ${CUDA_SOURCE_DIR}/extras/CUPTI/include

--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -30,6 +30,7 @@ set(KINETO_LIBRARY_TYPE "default" CACHE STRING
 set_property(CACHE KINETO_LIBRARY_TYPE PROPERTY STRINGS default shared)
 option(KINETO_BUILD_TESTS "Build kineto unit tests" ON)
 
+set(LIBKINETO_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(LIBKINETO_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(LIBKINETO_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 set(LIBKINETO_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -49,6 +50,72 @@ endif()
 if (NOT ROCM_SOURCE_DIR)
     set(ROCM_SOURCE_DIR "$ENV{ROCM_SOURCE_DIR}")
     message(INFO " ROCM_SOURCE_DIR = ${ROCM_SOURCE_DIR}")
+endif()
+
+if (KINETO_BUILD_TESTS)
+  enable_testing()
+  if (NOT CUPTI_INCLUDE_DIR)
+    find_path(CUPTI_INCLUDE_DIR cupti.h PATHS
+        ${CUDA_SOURCE_DIR}/extras/CUPTI/include
+        ${CUDA_INCLUDE_DIRS}
+        ${CUDA_SOURCE_DIR}
+        ${CUDA_SOURCE_DIR}/include
+        NO_DEFAULT_PATH)
+  endif()
+
+  if (NOT CUDA_cupti_LIBRARY)
+    if(NOT MSVC)
+      set(CUPTI_LIB_NAME "libcupti.so")
+    else()
+      set(CUPTI_LIB_NAME "cupti.lib")
+    endif()
+    find_library(CUPTI_LIBRARY_PATH ${CUPTI_LIB_NAME} PATHS
+        ${CUDA_SOURCE_DIR}
+        ${CUDA_SOURCE_DIR}/extras/CUPTI/lib64
+        ${CUDA_SOURCE_DIR}/lib
+        ${CUDA_SOURCE_DIR}/lib64
+        NO_DEFAULT_PATH)
+  endif()
+
+  if (NOT CUDA_nvperf_host_LIBRARY)
+    set(CUDA_NVPERF_HOST_LIB_NAME "libnvperf_host.so")
+    find_library(CUDA_NVPERF_HOST_LIB_PATH ${CUDA_NVPERF_HOST_LIB_NAME} PATHS
+        ${CUDA_SOURCE_DIR}
+        ${CUDA_SOURCE_DIR}/extras/CUPTI/lib64
+        ${CUDA_SOURCE_DIR}/lib
+        ${CUDA_SOURCE_DIR}/lib64
+        NO_DEFAULT_PATH)
+  endif()
+
+  if (NOT CUDA_cudart_LIBRARY)
+    set(CUDA_CUDART_LIB_NAME "libcudart.so")
+    find_library(CUDA_CUDART_LIB_PATH ${CUDA_CUDART_LIB_NAME} PATHS
+        ${CUDA_SOURCE_DIR}
+        ${CUDA_SOURCE_DIR}/lib
+        ${CUDA_SOURCE_DIR}/lib64
+        NO_DEFAULT_PATH)
+  endif()
+
+  if(CUDA_NVPERF_HOST_LIB_PATH)
+    set(CUDA_nvperf_host_LIBRARY ${CUDA_NVPERF_HOST_LIB_PATH})
+    message(INFO "  CUDA_nvperf_host_LIBRARY = ${CUDA_nvperf_host_LIBRARY}")
+  endif()
+
+  if(CUDA_CUDART_LIB_PATH)
+    set(CUDA_cudart_LIBRARY ${CUDA_CUDART_LIB_PATH})
+    message(INFO "  CUDA_cudart_LIBRARY = ${CUDA_cudart_LIBRARY}")
+  endif()
+
+  if(CUPTI_LIBRARY_PATH AND CUPTI_INCLUDE_DIR)
+    message(INFO "  CUPTI_INCLUDE_DIR = ${CUPTI_INCLUDE_DIR}")
+    set(CUDA_cupti_LIBRARY ${CUPTI_LIBRARY_PATH})
+    message(INFO "  CUDA_cupti_LIBRARY = ${CUDA_cupti_LIBRARY}")
+    message(INFO "Found CUPTI")
+    set(LIBKINETO_NOCUPTI OFF CACHE STRING "" FORCE)
+  else()
+    message(STATUS "Could not find CUPTI library")
+    set(LIBKINETO_NOCUPTI ON CACHE STRING "" FORCE)
+  endif()
 endif()
 
 # Set LIBKINETO_NOCUPTI to explicitly disable CUPTI
@@ -217,4 +284,6 @@ install(EXPORT kinetoLibraryConfig DESTINATION share/cmake/kineto
 
 if(KINETO_BUILD_TESTS)
   add_subdirectory(test)
+  add_subdirectory("${LIBKINETO_THIRDPARTY_DIR}/googletest")
+  add_subdirectory("${LIBKINETO_THIRDPARTY_DIR}/folly")
 endif()

--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -253,8 +253,10 @@ elseif(KINETO_LIBRARY_TYPE STREQUAL "static")
     $<TARGET_OBJECTS:kineto_api>)
 elseif(KINETO_LIBRARY_TYPE STREQUAL "shared")
   add_library(kineto SHARED
-    $<TARGET_OBJECTS:kineto_base>)
+    $<TARGET_OBJECTS:kineto_base>
+    $<TARGET_OBJECTS:kineto_api>)
   set_property(TARGET kineto_base PROPERTY POSITION_INDEPENDENT_CODE ON)
+  set_property(TARGET kineto_api PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_target_properties(kineto PROPERTIES
     CXX_VISIBILITY_PRESET hidden)
 else()

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -4,6 +4,141 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+include(GoogleTest)
 
-# TODO
+# ConfigTest
+add_executable(ConfigTest ConfigTest.cpp)
+target_compile_options(ConfigTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(ConfigTest PRIVATE gtest_main kineto)
+target_include_directories(ConfigTest PRIVATE "${LIBKINETO_DIR}")
+gtest_discover_tests(ConfigTest)
+
+# CuptiActivityProfilerTest
+add_executable(CuptiActivityProfilerTest CuptiActivityProfilerTest.cpp MockActivitySubProfiler.cpp)
+target_compile_options(CuptiActivityProfilerTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(CuptiActivityProfilerTest PRIVATE
+    gtest_main
+    gmock
+    kineto
+    folly
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiActivityProfilerTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src"
+    "${CUDA_SOURCE_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
+gtest_discover_tests(CuptiActivityProfilerTest)
+
+# CuptiCallbackApiTest
+add_executable(CuptiCallbackApiTest CuptiCallbackApiTest.cpp)
+target_compile_options(CuptiCallbackApiTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(CuptiCallbackApiTest PRIVATE
+    gtest_main
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiCallbackApiTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}"
+    "${CUDA_SOURCE_DIR}/include")
+gtest_discover_tests(CuptiCallbackApiTest)
+
+# CuptiRangeProfilerApiTest
+add_executable(CuptiRangeProfilerApiTest CuptiRangeProfilerApiTest.cpp)
+target_compile_options(CuptiRangeProfilerApiTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(CuptiRangeProfilerApiTest PRIVATE
+    gtest_main
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiRangeProfilerApiTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src"
+    "${CUDA_SOURCE_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
+gtest_discover_tests(CuptiRangeProfilerApiTest)
+
+# CuptiRangeProfilerConfigTest
+add_executable(CuptiRangeProfilerConfigTest CuptiRangeProfilerConfigTest.cpp)
+target_compile_options(CuptiRangeProfilerConfigTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(CuptiRangeProfilerConfigTest PRIVATE
+    gtest_main
+    kineto)
+target_include_directories(CuptiRangeProfilerConfigTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include")
+gtest_discover_tests(CuptiRangeProfilerConfigTest)
+
+# CuptiRangeProfilerTest
+add_executable(CuptiRangeProfilerTest CuptiRangeProfilerTest.cpp)
+target_compile_options(CuptiRangeProfilerTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(CuptiRangeProfilerTest PRIVATE
+    gtest_main
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiRangeProfilerTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src"
+    "${CUDA_SOURCE_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
+gtest_discover_tests(CuptiRangeProfilerTest)
+
+# CuptiStringsTest
+add_executable(CuptiStringsTest CuptiStringsTest.cpp)
+target_compile_options(CuptiStringsTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(CuptiStringsTest PRIVATE gtest_main kineto)
+target_include_directories(CuptiStringsTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${CUDA_SOURCE_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
+gtest_discover_tests(CuptiStringsTest)
+
+# EventProfilerTest
+add_executable(EventProfilerTest EventProfilerTest.cpp)
+target_compile_options(EventProfilerTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(EventProfilerTest PRIVATE
+    gtest_main
+    gmock
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(EventProfilerTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${CUDA_SOURCE_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
+gtest_discover_tests(EventProfilerTest)
+
+# LoggerObserverTest
+add_executable(LoggerObserverTest LoggerObserverTest.cpp)
+target_compile_options(LoggerObserverTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(LoggerObserverTest PRIVATE gtest_main kineto)
+target_include_directories(LoggerObserverTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src")
+gtest_discover_tests(LoggerObserverTest)
+
+# PidInfoTest
+add_executable(PidInfoTest PidInfoTest.cpp)
+target_compile_options(PidInfoTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(PidInfoTest PRIVATE gtest_main kineto)
+target_include_directories(PidInfoTest PRIVATE "${LIBKINETO_DIR}")
+gtest_discover_tests(PidInfoTest)
+
+# CuptiProfilerApiTest
+enable_language(CUDA)
+add_executable(CuptiProfilerApiTest CuptiProfilerApiTest.cu)
+target_compile_options(CuptiProfilerApiTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(CuptiProfilerApiTest PRIVATE
+    kineto
+    gtest_main
+    cuda
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiProfilerApiTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
+#add_test(NAME CuptiProfilerApiTest_ COMMAND CuptiProfilerApiTest)

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -15,13 +15,13 @@ target_include_directories(ConfigTest PRIVATE "${LIBKINETO_DIR}")
 gtest_discover_tests(ConfigTest)
 
 # CuptiActivityProfilerTest
+#[[
 add_executable(CuptiActivityProfilerTest CuptiActivityProfilerTest.cpp MockActivitySubProfiler.cpp)
 target_compile_options(CuptiActivityProfilerTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_link_libraries(CuptiActivityProfilerTest PRIVATE
     gtest_main
     gmock
     kineto
-    folly
     "${CUDA_cudart_LIBRARY}")
 target_include_directories(CuptiActivityProfilerTest PRIVATE
     "${LIBKINETO_DIR}"
@@ -30,7 +30,7 @@ target_include_directories(CuptiActivityProfilerTest PRIVATE
     "${CUDA_SOURCE_DIR}/include"
     "${CUPTI_INCLUDE_DIR}")
 gtest_discover_tests(CuptiActivityProfilerTest)
-
+]]
 # CuptiCallbackApiTest
 add_executable(CuptiCallbackApiTest CuptiCallbackApiTest.cpp)
 target_compile_options(CuptiCallbackApiTest PRIVATE "${KINETO_COMPILE_OPTIONS}")

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -10,7 +10,10 @@ include(GoogleTest)
 # ConfigTest
 add_executable(ConfigTest ConfigTest.cpp)
 target_compile_options(ConfigTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
-target_link_libraries(ConfigTest PRIVATE gtest_main kineto)
+target_link_libraries(ConfigTest PRIVATE
+    gtest_main
+    kineto
+    "${CUDA_cudart_LIBRARY}")
 target_include_directories(ConfigTest PRIVATE "${LIBKINETO_DIR}")
 gtest_discover_tests(ConfigTest)
 
@@ -65,7 +68,8 @@ add_executable(CuptiRangeProfilerConfigTest CuptiRangeProfilerConfigTest.cpp)
 target_compile_options(CuptiRangeProfilerConfigTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_link_libraries(CuptiRangeProfilerConfigTest PRIVATE
     gtest_main
-    kineto)
+    kineto
+    "${CUDA_cudart_LIBRARY}")
 target_include_directories(CuptiRangeProfilerConfigTest PRIVATE
     "${LIBKINETO_DIR}"
     "${LIBKINETO_DIR}/include")
@@ -89,7 +93,10 @@ gtest_discover_tests(CuptiRangeProfilerTest)
 # CuptiStringsTest
 add_executable(CuptiStringsTest CuptiStringsTest.cpp)
 target_compile_options(CuptiStringsTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
-target_link_libraries(CuptiStringsTest PRIVATE gtest_main kineto)
+target_link_libraries(CuptiStringsTest PRIVATE
+    gtest_main
+    kineto
+    "${CUDA_cudart_LIBRARY}")
 target_include_directories(CuptiStringsTest PRIVATE
     "${LIBKINETO_DIR}"
     "${CUDA_SOURCE_DIR}/include"
@@ -114,7 +121,10 @@ gtest_discover_tests(EventProfilerTest)
 # LoggerObserverTest
 add_executable(LoggerObserverTest LoggerObserverTest.cpp)
 target_compile_options(LoggerObserverTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
-target_link_libraries(LoggerObserverTest PRIVATE gtest_main kineto)
+target_link_libraries(LoggerObserverTest PRIVATE
+    gtest_main
+    kineto
+    "${CUDA_cudart_LIBRARY}")
 target_include_directories(LoggerObserverTest PRIVATE
     "${LIBKINETO_DIR}"
     "${LIBKINETO_DIR}/include"
@@ -124,7 +134,10 @@ gtest_discover_tests(LoggerObserverTest)
 # PidInfoTest
 add_executable(PidInfoTest PidInfoTest.cpp)
 target_compile_options(PidInfoTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
-target_link_libraries(PidInfoTest PRIVATE gtest_main kineto)
+target_link_libraries(PidInfoTest PRIVATE
+    gtest_main
+    kineto
+    "${CUDA_cudart_LIBRARY}")
 target_include_directories(PidInfoTest PRIVATE "${LIBKINETO_DIR}")
 gtest_discover_tests(PidInfoTest)
 

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -494,7 +494,7 @@ TEST_F(CuptiActivityProfilerTest, SyncTrace) {
   profiler.processTrace(*logger);
 
   // Profiler can be reset at this point - logger owns the activities
-  profiler_->reset();
+  profiler.reset();
 
   // Wrapper that allows iterating over the activities
   ActivityTrace trace(std::move(logger), loggerFactory);
@@ -625,6 +625,9 @@ TEST_F(CuptiActivityProfilerTest, GpuNCCLCollectiveTest) {
   profiler.processTrace(*logger);
   profiler.setLogger(logger.get());
 
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
   // Check the content of GPU event and we should see extra
   // collective fields get populated from CPU event.
   ActivityTrace trace(std::move(logger), loggerFactory);
@@ -719,6 +722,9 @@ TEST_F(CuptiActivityProfilerTest, GpuUserAnnotationTest) {
   auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
   profiler.processTrace(*logger);
 
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
+
   ActivityTrace trace(std::move(logger), loggerFactory);
   std::map<std::string, int> counts;
   for (auto& activity : *trace.activities()) {
@@ -795,6 +801,9 @@ TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
   auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
   profiler.processTrace(*logger);
   profiler.setLogger(logger.get());
+
+  // Profiler can be reset at this point - logger owns the activities
+  profiler.reset();
 
   ActivityTrace trace(std::move(logger), loggerFactory);
   trace.save(filename);

--- a/libkineto/test/CuptiRangeProfilerApiTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerApiTest.cpp
@@ -74,8 +74,11 @@ TEST(CuptiRangeProfilerApiTest, asyncLaunchUserRange) {
   simulateCudaContextCreate(ctx0, 0 /*device_id*/);
 
   CuptiRangeProfilerOptions opts{
+    .metricNames = {"metricNames"},
     .deviceId = 0,
-    .cuContext = ctx0};
+    .maxRanges = 1,
+    .numNestingLevels = 1,
+    .cuContext = ctx0 };
 
   std::unique_ptr<CuptiRBProfilerSession> session_ = mfactory.make(opts);
   auto session = mfactory.asDerived(session_.get());
@@ -108,8 +111,11 @@ TEST(CuptiRangeProfilerApiTest, asyncLaunchAutoRange) {
   simulateCudaContextCreate(ctx0, 0 /*device_id*/);
 
   CuptiRangeProfilerOptions opts{
+    .metricNames = {"metricNames"},
     .deviceId = 0,
-    .cuContext = ctx0};
+    .maxRanges = 1,
+    .numNestingLevels = 1,
+    .cuContext = ctx0 };
 
   std::unique_ptr<CuptiRBProfilerSession> session_ = mfactory.make(opts);
   auto session = mfactory.asDerived(session_.get());

--- a/libkineto/test/CuptiStringsTest.cpp
+++ b/libkineto/test/CuptiStringsTest.cpp
@@ -24,7 +24,7 @@ TEST(CuptiStringsTest, Valid) {
   ASSERT_STREQ(
       runtimeCbidName(CUPTI_RUNTIME_TRACE_CBID_cudaStreamSetAttribute_ptsz_v11000),
       "cudaStreamSetAttribute_ptsz");
-#if defined(CUPTI_API_VERSION) && CUPTI_API_VERSION >= 17
+#if defined(CUPTI_API_VERSION) && CUPTI_API_VERSION >= 18
   ASSERT_STREQ(
       runtimeCbidName(CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060),
       "cudaLaunchKernelExC");


### PR DESCRIPTION
Finished CMakeLists.txt in the test folder and added folly repo needed by CuptiActivityProfilerTest. But still had some problems:

- ConfigTest :  

    Through gtest passed, the log show "ERROR" as below:
    log:  ERROR:2024-02-15 20:45:30 1682464:1682464 AbstractConfig.cpp:145] Invalid config line: 

- CuptiProfilerApiTest :

    show "Aborted (core dumped)"

- LoggerObserverTest: 

    Through gtest passed, the log show "ERROR"


**system info:**
os: Ubuntu 20.04.5 LTS
cuda version: cuda 11.7

**test result:**
```
$ make test
Running tests...
Test project /kineto/libkineto/build
      Start  1: ParseTest.Whitespace
 1/47 Test  #1: ParseTest.Whitespace ..................................   Passed    0.00 sec
      Start  2: ParseTest.Comment
 2/47 Test  #2: ParseTest.Comment .....................................   Passed    0.00 sec
      Start  3: ParseTest.Format
 3/47 Test  #3: ParseTest.Format ......................................   Passed    0.00 sec
      Start  4: ParseTest.DefaultActivityTypes
 4/47 Test  #4: ParseTest.DefaultActivityTypes ........................   Passed    0.00 sec
      Start  5: ParseTest.ActivityTypes
 5/47 Test  #5: ParseTest.ActivityTypes ...............................   Passed    0.00 sec
      Start  6: ParseTest.SamplePeriod
 6/47 Test  #6: ParseTest.SamplePeriod ................................   Passed    0.00 sec
      Start  7: ParseTest.MultiplexPeriod
 7/47 Test  #7: ParseTest.MultiplexPeriod .............................   Passed    0.00 sec
      Start  8: ParseTest.ReportPeriod
 8/47 Test  #8: ParseTest.ReportPeriod ................................   Passed    0.00 sec
      Start  9: ParseTest.SamplesPerReport
 9/47 Test  #9: ParseTest.SamplesPerReport ............................   Passed    0.00 sec
      Start 10: ParseTest.EnableSigUsr2
10/47 Test #10: ParseTest.EnableSigUsr2 ...............................   Passed    0.00 sec
      Start 11: ParseTest.DeviceMask
11/47 Test #11: ParseTest.DeviceMask ..................................   Passed    0.00 sec
      Start 12: ParseTest.RequestTime
12/47 Test #12: ParseTest.RequestTime .................................   Passed    0.00 sec
      Start 13: ParseTest.ProfileStartTime
13/47 Test #13: ParseTest.ProfileStartTime ............................   Passed    0.00 sec
      Start 14: CuptiActivityProfiler.AsyncTrace
14/47 Test #14: CuptiActivityProfiler.AsyncTrace ......................   Passed    0.72 sec
      Start 15: CuptiActivityProfiler.AsyncTraceUsingIter
15/47 Test #15: CuptiActivityProfiler.AsyncTraceUsingIter .............   Passed    0.70 sec
      Start 16: CuptiActivityProfilerTest.SyncTrace
16/47 Test #16: CuptiActivityProfilerTest.SyncTrace ...................   Passed    0.75 sec
      Start 17: CuptiActivityProfilerTest.GpuNCCLCollectiveTest
17/47 Test #17: CuptiActivityProfilerTest.GpuNCCLCollectiveTest .......   Passed    0.75 sec
      Start 18: CuptiActivityProfilerTest.GpuUserAnnotationTest
18/47 Test #18: CuptiActivityProfilerTest.GpuUserAnnotationTest .......   Passed    0.74 sec
      Start 19: CuptiActivityProfilerTest.SubActivityProfilers
19/47 Test #19: CuptiActivityProfilerTest.SubActivityProfilers ........   Passed    0.72 sec
      Start 20: CuptiActivityProfilerTest.BufferSizeLimitTestWarmup
20/47 Test #20: CuptiActivityProfilerTest.BufferSizeLimitTestWarmup ...   Passed    0.74 sec
      Start 21: CuptiCallbackApiTest.SimpleTest
21/47 Test #21: CuptiCallbackApiTest.SimpleTest .......................   Passed    0.00 sec
      Start 22: CuptiCallbackApiTest.AllCallbacks
22/47 Test #22: CuptiCallbackApiTest.AllCallbacks .....................   Passed    0.00 sec
      Start 23: CuptiCallbackApiTest.ContentionTest
23/47 Test #23: CuptiCallbackApiTest.ContentionTest ...................   Passed    0.91 sec
      Start 24: CuptiCallbackApiTest.Bechmark
24/47 Test #24: CuptiCallbackApiTest.Bechmark .........................   Passed    0.00 sec
      Start 25: CuptiRangeProfilerApiTest.contextTracking
25/47 Test #25: CuptiRangeProfilerApiTest.contextTracking .............   Passed    0.01 sec
      Start 26: CuptiRangeProfilerApiTest.asyncLaunchUserRange
26/47 Test #26: CuptiRangeProfilerApiTest.asyncLaunchUserRange ........   Passed    0.00 sec
      Start 27: CuptiRangeProfilerApiTest.asyncLaunchAutoRange
27/47 Test #27: CuptiRangeProfilerApiTest.asyncLaunchAutoRange ........   Passed    0.00 sec
      Start 28: CuptiRangeProfilerConfigTest.ConfigureProfiler
28/47 Test #28: CuptiRangeProfilerConfigTest.ConfigureProfiler ........   Passed    0.00 sec
      Start 29: CuptiRangeProfilerConfigTest.RangesDefaults
29/47 Test #29: CuptiRangeProfilerConfigTest.RangesDefaults ...........   Passed    0.00 sec
      Start 30: CuptiRangeProfilerTest.BasicTest
30/47 Test #30: CuptiRangeProfilerTest.BasicTest ......................   Passed    0.00 sec
      Start 31: CuptiRangeProfilerTest.UserRangeTest
31/47 Test #31: CuptiRangeProfilerTest.UserRangeTest ..................   Passed    0.01 sec
      Start 32: CuptiRangeProfilerTest.AutoRangeTest
32/47 Test #32: CuptiRangeProfilerTest.AutoRangeTest ..................   Passed    0.00 sec
      Start 33: CuptiStringsTest.Valid
33/47 Test #33: CuptiStringsTest.Valid ................................   Passed    0.00 sec
      Start 34: CuptiStringsTest.Invalid
34/47 Test #34: CuptiStringsTest.Invalid ..............................   Passed    0.00 sec
      Start 35: PercentileTest.Create
35/47 Test #35: PercentileTest.Create .................................   Passed    0.00 sec
      Start 36: PercentileTest.Normalize
36/47 Test #36: PercentileTest.Normalize ..............................   Passed    0.00 sec
      Start 37: EventTest.SumSamples
37/47 Test #37: EventTest.SumSamples ..................................   Passed    0.00 sec
      Start 38: EventTest.Percentiles
38/47 Test #38: EventTest.Percentiles .................................   Passed    0.00 sec
      Start 39: MetricTest.Calculate
39/47 Test #39: MetricTest.Calculate ..................................   Passed    0.00 sec
      Start 40: EventGroupSetTest.CollectSample
40/47 Test #40: EventGroupSetTest.CollectSample .......................   Passed    0.00 sec
      Start 41: EventProfilerTest.ConfigureFailure
41/47 Test #41: EventProfilerTest.ConfigureFailure ....................   Passed    0.00 sec
      Start 42: EventProfilerTest.ConfigureBase
42/47 Test #42: EventProfilerTest.ConfigureBase .......................   Passed    0.00 sec
      Start 43: EventProfilerTest.ConfigureOnDemand
43/47 Test #43: EventProfilerTest.ConfigureOnDemand ...................   Passed    0.00 sec
      Start 44: EventProfilerTest.ReportSample
44/47 Test #44: EventProfilerTest.ReportSample ........................   Passed    0.00 sec
      Start 45: LoggerObserverTest.SingleCollectorObserver
45/47 Test #45: LoggerObserverTest.SingleCollectorObserver ............   Passed    0.00 sec
      Start 46: LoggerObserverTest.FourCollectorObserver
46/47 Test #46: LoggerObserverTest.FourCollectorObserver ..............   Passed    0.05 sec
      Start 47: ThreadNameTest.setAndGet
47/47 Test #47: ThreadNameTest.setAndGet ..............................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 47

Total Test time (real) =   6.21 sec

```
