### PR TITLE
tie kernel launch to the async ops

### DIFF
--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -167,6 +167,9 @@ int RoctracerActivityApi::processActivities(
         a.addMetadata("size", item.size);
       }
 
+      // Stash launches to tie to the async ops
+      kernelLaunches_[a.id] = a;
+
       logger.handleGenericActivity(a);
       ++count;
     }
@@ -197,6 +200,9 @@ int RoctracerActivityApi::processActivities(
       if ((item.cid == HIP_API_ID_hipMemcpyAsync) || (item.cid == HIP_API_ID_hipMemcpyWithStream)) {
         a.addMetadataQuoted("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
       }
+
+      // Stash launches to tie to the async ops
+      kernelLaunches_[a.id] = a;
 
       logger.handleGenericActivity(a);
       ++count;
@@ -235,6 +241,9 @@ int RoctracerActivityApi::processActivities(
       a.addMetadata("block dim", fmt::format("[{}, {}, {}]", item.workgroupX, item.workgroupY, item.workgroupZ));
       a.addMetadata("shared size", item.groupSegmentSize);
       a.addMetadataQuoted("stream", fmt::format("{}", reinterpret_cast<void*>(item.stream)));
+
+      // Stash launches to tie to the async ops
+      kernelLaunches_[a.id] = a;
 
       logger.handleGenericActivity(a);
       ++count;
@@ -311,7 +320,7 @@ int RoctracerActivityApi::processActivities(
 void RoctracerActivityApi::clearActivities() {
   d->clearLogs();
   kernelLaunches_.clear();
-  kernelNames_.clear();    
+  kernelNames_.clear();
 }
 
 


### PR DESCRIPTION
Summary:
since the refactor in D52127872 (https://github.com/pytorch/kineto/pull/850), the kernel metadata overlay https://fburl.com/code/780k82cu does not work properly because the kernel launch is no longer stored.    
```
// Overlay launch metadata for kernels
    auto kit = kernelLaunches_.find(item.id);
    if (kit != kernelLaunches_.end()) {
      a = (*kit).second;
    }
```

Reviewed By: aaronenyeshi

Differential Revision: D54009677


