### PR TITLE
TB_Plugin_CI bug fix: add mpmath==1.3.0 to fix missing attribute rational

### DIFF
--- a/tb_plugin/ci_scripts/install_env.sh
+++ b/tb_plugin/ci_scripts/install_env.sh
@@ -20,7 +20,8 @@ set -ex
 
 
 # install pytorch
-pip install numpy tensorboard typing-extensions pillow pytest
+# bug fix: added mpmath=1.3.0 due to AttributeError: module 'mpmath' has no attribute 'rational'
+pip install numpy tensorboard typing-extensions pillow pytest mpmath==1.3.0
 if [ "$PYTORCH_VERSION" = "nightly" ]; then
     pip install --pre torch -f "https://download.pytorch.org/whl/nightly/$CUDA_VERSION/torch_nightly.html"
     pip install --pre torchvision --no-deps -f "https://download.pytorch.org/whl/nightly/$CUDA_VERSION/torch_nightly.html"


### PR DESCRIPTION
Summary: mpmath released a new version 1.4.0 on Feb 23. This version causes TB CI to have an error: `AttributeError: module 'mpmath' has no attribute 'rational'`. To fix the CI issue, we need to downgrade to an older version of mpmath 1.3.0.

Fixes: https://github.com/pytorch/kineto/issues/878

Differential Revision: D54262113


