### PR TITLE
Make Kineto traces export ns granularity for finer timestamps

### DIFF
--- a/libkineto/include/ITraceActivity.h
+++ b/libkineto/include/ITraceActivity.h
@@ -27,9 +27,9 @@ struct ITraceActivity {
   virtual int64_t resourceId() const = 0;
   // s/w thread
   virtual int32_t getThreadId() const = 0;
-  // Start timestamp in mucrosecond
+  // Start timestamp in nanoseconds
   virtual int64_t timestamp() const = 0;
-  // Duration in microseconds
+  // Duration in nanoseconds
   virtual int64_t duration() const = 0;
   // Used to link up async activities
   virtual int64_t correlationId() const = 0;

--- a/libkineto/include/time_since_epoch.h
+++ b/libkineto/include/time_since_epoch.h
@@ -11,11 +11,19 @@
 #include <chrono>
 
 namespace libkineto {
-
+/* [Note: Temp Libkineto Nanosecond]
+This is a temporary hack to support nanosecond time units in Libkineto.
+After pytorch changes are made to support nanosecond precision, this
+can be removed.
+*/
 template <class ClockT>
 inline int64_t timeSinceEpoch(
       const std::chrono::time_point<ClockT>& t) {
+#ifdef TMP_LIBKINETO_NANOSECOND
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+#else
     return std::chrono::duration_cast<std::chrono::microseconds>(
+#endif
                t.time_since_epoch())
         .count();
 }

--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -111,6 +111,7 @@ inline const std::string GpuActivity<CUpti_ActivityKernel4>::metadataJson() cons
   float warpsPerSmVal = warpsPerSm(kernel);
 
   // clang-format off
+  // see [Note: Temp Libkineto Nanosecond]
   return fmt::format(R"JSON(
       "queued": {}, "device": {}, "context": {},
       "stream": {}, "correlation": {},
@@ -121,7 +122,11 @@ inline const std::string GpuActivity<CUpti_ActivityKernel4>::metadataJson() cons
       "grid": [{}, {}, {}],
       "block": [{}, {}, {}],
       "est. achieved occupancy %": {})JSON",
+#ifdef TMP_LIBKINETO_NANOSECOND
+      kernel.queued, kernel.deviceId, kernel.contextId,
+#else
       us(kernel.queued), kernel.deviceId, kernel.contextId,
+#endif
       kernel.streamId, kernel.correlationId,
       kernel.registersPerThread,
       kernel.staticSharedMemory + kernel.dynamicSharedMemory,

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -35,11 +35,22 @@ template<class T>
 struct CuptiActivity : public ITraceActivity {
   explicit CuptiActivity(const T* activity, const ITraceActivity* linked)
       : activity_(*activity), linked_(linked) {}
+  // see [Note: Temp Libkineto Nanosecond]
   int64_t timestamp() const override {
+#ifdef TMP_LIBKINETO_NANOSECOND
+    return activity_.start;
+#else
     return nsToUs(activity_.start);
+#endif
   }
+
+  // see [Note: Temp Libkineto Nanosecond]
   int64_t duration() const override {
+#ifdef TMP_LIBKINETO_NANOSECOND
+    return activity_.end - activity_.start;
+#else
     return nsToUs(activity_.end - activity_.start);
+#endif
   }
   // TODO(T107507796): Deprecate ITraceActivity
   int64_t correlationId() const override {return 0;}
@@ -103,11 +114,21 @@ struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
       int32_t threadId=0)
       : CuptiActivity(activity, linked), threadId_(threadId) {}
 
+  // see [Note: Temp Libkineto Nanosecond]
   int64_t timestamp() const override {
+#ifdef TMP_LIBKINETO_NANOSECOND
+    return activity_.start;
+#else
     return nsToUs(activity_.start);
+#endif
   }
+  // see [Note: Temp Libkineto Nanosecond]
   int64_t duration() const override {
+#ifdef TMP_LIBKINETO_NANOSECOND
+    return activity_.end - activity_.start;
+#else
     return nsToUs(activity_.end - activity_.start);
+#endif
   }
   // TODO: Update this with PID ordering
   int64_t deviceId() const override {return -1;}

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -112,6 +112,34 @@ void ChromeTraceLogger::handleDeviceInfo(
   // M is for metadata
   // process_name needs a pid and a name arg
   // clang-format off
+  // see [Note: Temp Libkineto Nanosecond]
+#ifdef TMP_LIBKINETO_NANOSECOND
+  traceOf_ << fmt::format(R"JSON(
+  {{
+    "name": "process_name", "ph": "M", "ts": {}.{}, "pid": {}, "tid": 0,
+    "args": {{
+      "name": "{}"
+    }}
+  }},
+  {{
+    "name": "process_labels", "ph": "M", "ts": {}.{}, "pid": {}, "tid": 0,
+    "args": {{
+      "labels": "{}"
+    }}
+  }},
+  {{
+    "name": "process_sort_index", "ph": "M", "ts": {}.{}, "pid": {}, "tid": 0,
+    "args": {{
+      "sort_index": {}
+    }}
+  }},)JSON",
+      time/1000, time%1000, info.id,
+      info.name,
+      time/1000, time%1000, info.id,
+      info.label,
+      time/1000, time%1000, info.id,
+      info.id < 8 ? info.id + 0x1000000ll : info.id);
+#else
   traceOf_ << fmt::format(R"JSON(
   {{
     "name": "process_name", "ph": "M", "ts": {}, "pid": {}, "tid": 0,
@@ -137,6 +165,7 @@ void ChromeTraceLogger::handleDeviceInfo(
       info.label,
       time, info.id,
       info.id < 8 ? info.id + 0x1000000ll : info.id);
+#endif
   // clang-format on
 }
 
@@ -150,6 +179,26 @@ void ChromeTraceLogger::handleResourceInfo(
   // M is for metadata
   // thread_name needs a pid and a name arg
   // clang-format off
+  // see [Note: Temp Libkineto Nanosecond]
+#ifdef TMP_LIBKINETO_NANOSECOND
+  traceOf_ << fmt::format(R"JSON(
+  {{
+    "name": "thread_name", "ph": "M", "ts": {}.{}, "pid": {}, "tid": {},
+    "args": {{
+      "name": "{}"
+    }}
+  }},
+  {{
+    "name": "thread_sort_index", "ph": "M", "ts": {}.{}, "pid": {}, "tid": {},
+    "args": {{
+      "sort_index": {}
+    }}
+  }},)JSON",
+      time/1000, time%1000, info.deviceId, info.id,
+      info.name,
+      time/1000, time%1000, info.deviceId, info.id,
+      info.sortIndex);
+#else
   traceOf_ << fmt::format(R"JSON(
   {{
     "name": "thread_name", "ph": "M", "ts": {}, "pid": {}, "tid": {},
@@ -167,6 +216,7 @@ void ChromeTraceLogger::handleResourceInfo(
       info.name,
       time, info.deviceId, info.id,
       info.sortIndex);
+#endif
   // clang-format on
 }
 
@@ -180,6 +230,26 @@ void ChromeTraceLogger::handleOverheadInfo(
   // TOOD: reserve pid = -1 for overhead but we need to rethink how to scale this for
   // other metadata
   // clang-format off
+  // see [Note: Temp Libkineto Nanosecond]
+#ifdef TMP_LIBKINETO_NANOSECOND
+  traceOf_ << fmt::format(R"JSON(
+  {{
+    "name": "process_name", "ph": "M", "ts": {}.{}, "pid": -1, "tid": 0,
+    "args": {{
+      "name": "{}"
+    }}
+  }},
+  {{
+    "name": "process_sort_index", "ph": "M", "ts": {}.{}, "pid": -1, "tid": 0,
+    "args": {{
+      "sort_index": {}
+    }}
+  }},)JSON",
+      time/1000, time%1000,
+      info.name,
+      time/1000, time%1000,
+      0x100000All);
+#else
   traceOf_ << fmt::format(R"JSON(
   {{
     "name": "process_name", "ph": "M", "ts": {}, "pid": -1, "tid": 0,
@@ -197,6 +267,7 @@ void ChromeTraceLogger::handleOverheadInfo(
       info.name,
       time,
       0x100000All);
+#endif
   // clang-format on
 }
 
@@ -204,8 +275,36 @@ void ChromeTraceLogger::handleTraceSpan(const TraceSpan& span) {
   if (!traceOf_) {
     return;
   }
+  // see [Note: Temp Libkineto Nanosecond]
+#ifdef TMP_LIBKINETO_NANOSECOND
+  uint64_t start = span.startTime;
+  uint64_t dur = span.endTime - span.startTime;
 
   // clang-format off
+  traceOf_ << fmt::format(R"JSON(
+  {{
+    "ph": "X", "cat": "Trace", "ts": {}.{}, "dur": {}.{},
+    "pid": "Spans", "tid": "{}",
+    "name": "{}{} ({})",
+    "args": {{
+      "Op count": {}
+    }}
+  }},
+  {{
+    "name": "process_sort_index", "ph": "M", "ts": {}.{},
+    "pid": "Spans", "tid": 0,
+    "args": {{
+      "sort_index": {}
+    }}
+  }},)JSON",
+      start/1000, start%1000, dur/1000, dur%1000,
+      span.name,
+      span.prefix, span.name, span.iteration,
+      span.opCount,
+      start/1000, start%1000,
+      // Large sort index to appear at the bottom
+      0x20000000ll);
+#else
   traceOf_ << fmt::format(R"JSON(
   {{
     "ph": "X", "cat": "Trace", "ts": {}, "dur": {},
@@ -229,6 +328,7 @@ void ChromeTraceLogger::handleTraceSpan(const TraceSpan& span) {
       span.startTime,
       // Large sort index to appear at the bottom
       0x20000000ll);
+#endif
   // clang-format on
 
   addIterationMarker(span);
@@ -240,6 +340,16 @@ void ChromeTraceLogger::addIterationMarker(const TraceSpan& span) {
   }
 
   // clang-format off
+  // see [Note: Temp Libkineto Nanosecond]
+#ifdef TMP_LIBKINETO_NANOSECOND
+  traceOf_ << fmt::format(R"JSON(
+  {{
+    "name": "Iteration Start: {}", "ph": "i", "s": "g",
+    "pid": "Traces", "tid": "Trace {}", "ts": {}.{}
+  }},)JSON",
+      span.name,
+      span.name, span.startTime/1000, span.startTime%1000);
+#else
   traceOf_ << fmt::format(R"JSON(
   {{
     "name": "Iteration Start: {}", "ph": "i", "s": "g",
@@ -247,6 +357,7 @@ void ChromeTraceLogger::addIterationMarker(const TraceSpan& span) {
   }},)JSON",
       span.name,
       span.name, span.startTime);
+#endif
   // clang-format on
 }
 
@@ -255,7 +366,20 @@ void ChromeTraceLogger::handleGenericInstantEvent(
   if (!traceOf_) {
     return;
   }
-
+  // see [Note: Temp Libkineto Nanosecond]
+#ifdef TMP_LIBKINETO_NANOSECOND
+  traceOf_ << fmt::format(R"JSON(
+  {{
+    "ph": "i", "cat": "{}", "s": "t", "name": "{}",
+    "pid": {}, "tid": {},
+    "ts": {}.{},
+    "args": {{
+      {}
+    }}
+  }},)JSON",
+      toString(op.type()), op.name(), op.deviceId(), op.resourceId(),
+      op.timestamp()/1000, op.timestamp()%1000, op.metadataJson());
+#else
   traceOf_ << fmt::format(R"JSON(
   {{
     "ph": "i", "cat": "{}", "s": "t", "name": "{}",
@@ -267,6 +391,7 @@ void ChromeTraceLogger::handleGenericInstantEvent(
   }},)JSON",
       toString(op.type()), op.name(), op.deviceId(), op.resourceId(),
       op.timestamp(), op.metadataJson());
+#endif
 }
 
 void ChromeTraceLogger::handleActivity(
@@ -382,6 +507,16 @@ void ChromeTraceLogger::handleActivity(
   sanitizeStrForJSON(op_name);
 
   // clang-format off
+  // see [Note: Temp Libkineto Nanosecond]
+#ifdef TMP_LIBKINETO_NANOSECOND
+  traceOf_ << fmt::format(R"JSON(
+  {{
+    "ph": "X", "cat": "{}", "name": "{}", "pid": {}, "tid": {},
+    "ts": {}.{}, "dur": {}.{}{}
+  }},)JSON",
+          toString(op.type()), op_name, device, resource,
+          ts/1000, ts %1000, duration/1000, duration %1000, args);
+#else
   traceOf_ << fmt::format(R"JSON(
   {{
     "ph": "X", "cat": "{}", "name": "{}", "pid": {}, "tid": {},
@@ -389,6 +524,7 @@ void ChromeTraceLogger::handleActivity(
   }},)JSON",
           toString(op.type()), op_name, device, resource,
           ts, duration, args);
+#endif
   // clang-format on
   if (op.flowId() > 0) {
     handleGenericLink(op);
@@ -438,12 +574,22 @@ void ChromeTraceLogger::handleLink(
   // Flow start automatically sets binding point to enclosing slice.
   const auto binding = (type == kFlowEnd) ? ", \"bp\": \"e\"" : "";
   // clang-format off
+  // see [Note: Temp Libkineto Nanosecond]
+#ifdef TMP_LIBKINETO_NANOSECOND
+  traceOf_ << fmt::format(R"JSON(
+  {{
+    "ph": "{}", "id": {}, "pid": {}, "tid": {}, "ts": {}.{},
+    "cat": "{}", "name": "{}"{}
+  }},)JSON",
+      type, id, e.deviceId(), e.resourceId(), e.timestamp()/1000, e.timestamp()%1000, name, name, binding);
+#else
   traceOf_ << fmt::format(R"JSON(
   {{
     "ph": "{}", "id": {}, "pid": {}, "tid": {}, "ts": {},
     "cat": "{}", "name": "{}"{}
   }},)JSON",
       type, id, e.deviceId(), e.resourceId(), e.timestamp(), name, name, binding);
+#endif
   // clang-format on
 }
 
@@ -459,6 +605,16 @@ void ChromeTraceLogger::finalizeTrace(
   sanitizeStrForJSON(fileName_);
   LOG(INFO) << "Chrome Trace written to " << fileName_;
   // clang-format off
+  // see [Note: Temp Libkineto Nanosecond]
+#ifdef TMP_LIBKINETO_NANOSECOND
+  traceOf_ << fmt::format(R"JSON(
+  {{
+    "name": "Record Window End", "ph": "i", "s": "g",
+    "pid": "", "tid": "", "ts": {}.{}
+  }}
+  ],)JSON",
+      endTime/1000, endTime %1000);
+#else
   traceOf_ << fmt::format(R"JSON(
   {{
     "name": "Record Window End", "ph": "i", "s": "g",
@@ -466,6 +622,7 @@ void ChromeTraceLogger::finalizeTrace(
   }}
   ],)JSON",
       endTime);
+#endif
 
 #if !USE_GOOGLE_LOG
   std::unordered_map<std::string, std::string> PreparedMetadata;
@@ -494,9 +651,17 @@ void ChromeTraceLogger::finalizeTrace(
 #endif // !USE_GOOGLE_LOG
 
   // Putting this here because the last entry MUST not end with a comma.
+  // see [Note: Temp Libkineto Nanosecond]
+#ifdef TMP_LIBKINETO_NANOSECOND
+  traceOf_ << fmt::format(R"JSON(
+  "traceName": "{}",
+  "displayTimeUnit": "ns"
+}})JSON", fileName_);
+#else
   traceOf_ << fmt::format(R"JSON(
   "traceName": "{}"
 }})JSON", fileName_);
+#endif
   // clang-format on
 
   traceOf_.close();


### PR DESCRIPTION
Summary: Kineto traces use microsecond level granularity because of chrome tracing defaults to that precision. Fix by removing ns to us conversions and adding field to json to specify ns timeUnit for chrome tracing. This diff contains libkineto only. Will have a follow up diff with compile flags and pytorch implementation

Reviewed By: aaronenyeshi, davidberard98

Differential Revision: D54964435


