### PR TITLE
Roctracer: Fix contention for high QPS cases and add upper limit for buffer size

### DIFF
--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -211,13 +211,16 @@ class RoctracerLogger {
   void endTracing();
 
   roctracer_pool_t *hccPool_{NULL};
+  static void insert_row_to_buffer(roctracerBase* row);
   static void api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg);
   static void activity_callback(const char* begin, const char* end, void* arg);
 
   ApiIdList loggedIds_;
 
   // Api callback data
-  std::deque<roctracerBase*> rows_;
+  uint32_t maxBufferSize_{1000000}; // 1M GPU runtime/kernel events.
+  std::vector<roctracerBase*> rows_;
+  std::mutex rowsMutex_;
   std::map<uint64_t,uint64_t> externalCorrelations_[CorrelationDomain::size];	// tracer -> ext
 
   bool externalCorrelationEnabled_{true};


### PR DESCRIPTION
Summary:
This diff fixes the crashing issue when number of samples is high.
- Adds a mutex for activity_callback and and api_callback when adding rows into buffer
- Adds a thread_local mutex and unordered_map in api_callback due to jemalloc SIGABRT, seems like contention on timestamp.
- Use a shared insert_row_to_buffer() function to lock when storing the row to buffer.

FIXME: We don't currently delete the rows in the buffer, since we need to keep them around until the chrome trace is created. We should fixed this by transferring ownership to CuptiActivityProfiler via Activity Buffer similar to Cupti Activity.

Reviewed By: houseroad, davidberard98

Differential Revision: D55341766

Pulled By: aaronenyeshi


