### PR TITLE
Fix deprecated use of 0/NULL in kineto/libkineto/src/CuptiCallbackApi.cpp + 5

### DIFF
--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -100,7 +100,7 @@ void CuptiCallbackApi::__callback_switchboard(
           CUPTI_CALL(cuptiUnsubscribe(subscriber_));
           CUPTI_CALL(cuptiFinalize());
           initSuccess_ = false;
-          subscriber_ = 0;
+          subscriber_ = nullptr;
           CuptiActivityApi::singleton().teardownCupti_ = 0;
           CuptiActivityApi::singleton().finalizeCond_.notify_all();
           return;

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -152,7 +152,7 @@ class CuptiCallbackApi {
   ReaderWriterLock callbackLock_;
 #ifdef HAS_CUPTI
   CUptiResult lastCuptiStatus_;
-  CUpti_SubscriberHandle subscriber_ {0};
+  CUpti_SubscriberHandle subscriber_ {nullptr};
 #endif
 };
 

--- a/libkineto/src/CuptiRangeProfilerApi.h
+++ b/libkineto/src/CuptiRangeProfilerApi.h
@@ -62,7 +62,7 @@ struct CuptiRangeProfilerOptions {
   int deviceId = 0;
   int maxRanges = 1;
   int numNestingLevels = 1;
-  CUcontext cuContext = 0;
+  CUcontext cuContext = nullptr;
   bool unitTest = false;
 };
 


### PR DESCRIPTION
Summary:
`nullptr` is typesafe. `0` and `NULL` are not. In the future, only `nullptr` will be allowed.

This diff helps us embrace the future _now_ in service of enabling `-Wzero-as-null-pointer-constant`.

Differential Revision: D55559751


