### PR TITLE
Fix missing #include <mutex> in RoctracerLogger.h

### DIFF
--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #include <deque>
 #include <atomic>
+#include <mutex>
 
 #include <roctracer.h>
 #include <roctracer_hip.h>


### PR DESCRIPTION
Summary: For ROCM builds in PyTorch, we need to include header <mutex> which defines the std::mutex used in RoctracerLogger.h.

Differential Revision: D55876676

Pulled By: aaronenyeshi


