### PR TITLE
Initialize BackwardNode with start_time, end_time and tid in torch_tb_profiler

### DIFF
--- a/tb_plugin/torch_tb_profiler/profiler/op_tree.py
+++ b/tb_plugin/torch_tb_profiler/profiler/op_tree.py
@@ -271,8 +271,8 @@ class OpTreeBuilder:
             return
 
         if isinstance(node, ModuleNode):
-            backward_node = BackwardNode(name=node.name + '.backward', start_time=None, end_time=None,
-                                         type='backward', tid=0)
+            backward_node = BackwardNode(name=node.name + '.backward', start_time=node.start_time,
+                                         end_time=node.end_time, type='backward', tid=node.tid)
             if parent is None:
                 result.append(backward_node)
             else:


### PR DESCRIPTION
Summary:

Currently when building backward modules in torch_tb_profiler, we initialize `start_time` and `end_time` to `None`, and `tid` to `0` and try to fill these three fields in a bottom–up manner. However, during this process if at least one of the leaf nodes is a `BackwardNode` and the initial values of `start_time` and `end_time` are `None`, we will encounter errors in `self.children.sort(key=lambda x: (x.start_time, -x.end_time))` when calling `fill_stats`. The parent's `tid` can also be set to 0. To fix this bug, this PR assigns a `BackwardNode` with initial values of `start_time`, `end_time`, `tid`. These values can be updated later when traversing the tree backwards.