### PR TITLE
Fix roctracer crash when number of samples too high

### DIFF
--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -223,6 +223,7 @@ class RoctracerLogger {
   std::vector<roctracerBase*> rows_;
   std::mutex rowsMutex_;
   std::map<uint64_t,uint64_t> externalCorrelations_[CorrelationDomain::size];	// tracer -> ext
+  std::mutex externalCorrelationsMutex_;
 
   bool externalCorrelationEnabled_{true};
   bool logging_{false};


### PR DESCRIPTION
Summary:
There is a map access at the bottom of the `api_callback()` function that is storing the correlation id and external correlation id relation. This map is shared between threads, and is causing a SIGSEGV crash during RBTree insert_and_rebalance.

To fix this, we add a mutex for the map. This is likely why the previous thread_local mutex was fixing crashes, due to delayed timing, so we can remove the thread_local mutex now.

Resolves: https://github.com/pytorch/kineto/issues/894

Differential Revision: D56017970

Pulled By: aaronenyeshi


