### PR TITLE
Support roctracer external correlations

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -355,6 +355,10 @@ class CuptiActivityProfiler {
   void handleRoctracerActivity(
     const roctracerBase* record,
     ActivityLogger* logger);
+  void handleCorrelationActivity(
+    uint64_t correlationId,
+    uint64_t externalId,
+    RoctracerLogger::CorrelationDomain externalKind);
   // Process specific GPU activity types
   template <class T>
   void handleRuntimeActivity(

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -53,7 +53,9 @@ class RoctracerActivityApi {
   void clearActivities();
   void teardownContext() {}
 
-  int processActivities(std::function<void(const roctracerBase*)> handler);
+  int processActivities(
+    std::function<void(const roctracerBase*)> handler,
+    std::function<void(uint64_t, uint64_t, RoctracerLogger::CorrelationDomain)> correlationHandler);
 
   void setMaxBufferSize(int size);
 

--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -287,7 +287,7 @@ void RoctracerLogger::api_callback(uint32_t domain, uint32_t cid, const void* ca
       for (int it = CorrelationDomain::begin; it < CorrelationDomain::end; ++it) {
         if (t_externalIds[it].size() > 0) {
           std::lock_guard<std::mutex> lock(dis->externalCorrelationsMutex_);
-          dis->externalCorrelations_[it][data->correlation_id] = t_externalIds[it].back();
+          dis->externalCorrelations_[it].emplace_back(data->correlation_id, t_externalIds[it].back());
         }
       }
     }  // phase exit

--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -222,7 +222,11 @@ class RoctracerLogger {
   uint32_t maxBufferSize_{1000000}; // 1M GPU runtime/kernel events.
   std::vector<roctracerBase*> rows_;
   std::mutex rowsMutex_;
-  std::map<uint64_t,uint64_t> externalCorrelations_[CorrelationDomain::size];	// tracer -> ext
+
+  // This vector collects pairs of correlationId and their respective
+  // externalCorrelationId for each CorrelationDomain. This will be used
+  // to populate the Correlation maps during post processing.
+  std::vector<std::pair<uint64_t, uint64_t>> externalCorrelations_[CorrelationDomain::size];
   std::mutex externalCorrelationsMutex_;
 
   bool externalCorrelationEnabled_{true};


### PR DESCRIPTION
Summary:
Since the recent refactor of roctracer logic, the external correlations are not properly set up. With this diff, user annotations will be populated on the GPU side as well.

This diff intends to:
1) Collect the correlationId and externalId pairs in an array of vector of pairs. Switched from a map to a vector, which will populate cpuCorrelationMap_ and userCorrelationMap_ in CuptiActivityProfiler.cpp.
2) Added handleCorrelationActivity function passed into roctracer's processActivities. The function handle will be used to populate the maps in CuptiActivityProfiler. This aligns closely with Cupti implementation.
3) Process correlation/external ids first, so that linked TraceActivities will populate roctracer events.

Reviewed By: 842974287

Differential Revision: D56025484

Pulled By: aaronenyeshi


