### PR TITLE
Delay logging for stream wait event till end to ensure filtering is

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <deque>
 #include <condition_variable>
 #include <list>
 #include <map>
@@ -219,6 +220,14 @@ class CuptiActivityProfiler {
   static const CpuGpuSpanPair& defaultTraceSpan();
 
  private:
+  // Deferred logging of CUDA-event synchronization
+  struct DeferredLogEntry {
+    uint32_t device;
+    uint32_t stream;
+    std::function<void()> logMe;
+  };
+
+  std::deque<DeferredLogEntry> logQueue_;
 
   // Map of gpu activities to user defined events
   class GpuUserEventMap {
@@ -348,6 +357,7 @@ class CuptiActivityProfiler {
       const CUpti_ActivitySynchronization* activity, ActivityLogger* logger);
   template <class T>
   void handleGpuActivity(const T* act, ActivityLogger* logger);
+  void logDeferredEvents();
 #endif // HAS_CUPTI
 
 #ifdef HAS_ROCTRACER


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/kineto/issues/904

Today to avoid noisy "even sync" events we do some filtering such that if a kernel is not launched on a stream till now (in trace window) we do not emit these events. But this may be incorrect if a future kernel is present but we just did not see it yet in the events.

Fix: the idea is to not filter the CUDA event synchronizations on the fly. instead defer the logging of some of these events till all other events are processed. We then log these events only if a stream has some activity to avoid noise.

Differential Revision: D56198193


