### PR TITLE
Remove Hardcoding of opt/rocm in CMakeLists.txt

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -265,9 +265,11 @@ else()
 endif()
 
 if(NOT LIBKINETO_NOROCTRACER)
-  find_library(ROCTRACER_LIBRARY NAMES libroctracer64.so HINTS /opt/rocm/lib)
+  find_library(ROCTRACER_LIBRARY NAMES libroctracer64.so HINTS
+    ${ROCM_SOURCE_DIR}/lib)
   target_link_libraries(kineto "${ROCTRACER_LIBRARY}")
-  find_library(KINETO_HIP_LIBRARY NAMES libamdhip64.so HINTS /opt/rocm/lib)
+  find_library(KINETO_HIP_LIBRARY NAMES libamdhip64.so HINTS
+    ${ROCM_SOURCE_DIR}/lib)
   target_link_libraries(kineto "${KINETO_HIP_LIBRARY}")
 endif()
 


### PR DESCRIPTION
Summary: In https://github.com/pytorch/kineto/issues/838, suranap points out that we should not be using hardcoded paths for the rocm source

Differential Revision: D56319191


