### PR TITLE
Fix GPU User Annotations overlapping with associated GPU ops

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -309,9 +309,9 @@ void ChromeTraceLogger::handleActivity(
     // The GPU user annotations start at the same time as the
     // first associated GPU op. Since they appear later
     // in the trace file, this causes a visualization issue in Chrome.
-    // Make it start one us earlier.
-    ts--;
-    duration++; // Still need it to end at the orginal point
+    // Make it start one us (1000 ns) earlier.
+    ts-=1000;
+    duration+=1500; // Still need it to end at the original point rounded up.
   }
 
   std::string arg_values = "";


### PR DESCRIPTION
Summary: Since we transitioned the profiler events to store ns timestamps, there are overlapping gpu_user_annotation and gpu kernel events. The overlap was previously fixed by making the gpu_user_annotations start slightly earlier than associated kernels, but it seems that 1ns is not enough for Chrome Trace Viewer. Switch it to 1000ns, which was 1us equivalent to before.

Differential Revision: D56401601

Pulled By: aaronenyeshi


