### PR TITLE
Remove TMP_LIBKINETO_NANOSECOND Note

### DIFF
--- a/libkineto/include/time_since_epoch.h
+++ b/libkineto/include/time_since_epoch.h
@@ -11,11 +11,6 @@
 #include <chrono>
 
 namespace libkineto {
-/* [Note: Temp Libkineto Nanosecond]
-This is a temporary hack to support nanosecond time units in Libkineto.
-After pytorch changes are made to support nanosecond precision, this
-can be removed.
-*/
 template <class ClockT>
 inline int64_t timeSinceEpoch(
       const std::chrono::time_point<ClockT>& t) {

--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -111,7 +111,7 @@ inline const std::string GpuActivity<CUpti_ActivityKernel4>::metadataJson() cons
   float warpsPerSmVal = warpsPerSm(kernel);
 
   // clang-format off
-  // see [Note: Temp Libkineto Nanosecond]
+
   return fmt::format(R"JSON(
       "queued": {}, "device": {}, "context": {},
       "stream": {}, "correlation": {},

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -35,12 +35,11 @@ template<class T>
 struct CuptiActivity : public ITraceActivity {
   explicit CuptiActivity(const T* activity, const ITraceActivity* linked)
       : activity_(*activity), linked_(linked) {}
-  // see [Note: Temp Libkineto Nanosecond]
+
   int64_t timestamp() const override {
     return activity_.start;
   }
 
-  // see [Note: Temp Libkineto Nanosecond]
   int64_t duration() const override {
     return activity_.end - activity_.start;
   }
@@ -106,11 +105,11 @@ struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
       int32_t threadId=0)
       : CuptiActivity(activity, linked), threadId_(threadId) {}
 
-  // see [Note: Temp Libkineto Nanosecond]
+
   int64_t timestamp() const override {
     return activity_.start;
   }
-  // see [Note: Temp Libkineto Nanosecond]
+
   int64_t duration() const override {
     return activity_.end - activity_.start;
   }
@@ -151,7 +150,6 @@ struct CudaSyncActivity : public CuptiActivity<CUpti_ActivitySynchronization> {
   const int32_t srcStream_;
   const int32_t srcCorrId_;
 };
-
 
 // Base class for GPU activities.
 // Can also be instantiated directly.

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -133,7 +133,6 @@ void ChromeTraceLogger::handleDeviceInfo(
   // M is for metadata
   // process_name needs a pid and a name arg
   // clang-format off
-  // see [Note: Temp Libkineto Nanosecond]
   time = transToRelativeTime(time);
   traceOf_ << fmt::format(R"JSON(
   {{
@@ -173,7 +172,6 @@ void ChromeTraceLogger::handleResourceInfo(
   // M is for metadata
   // thread_name needs a pid and a name arg
   // clang-format off
-  // see [Note: Temp Libkineto Nanosecond]
   time = transToRelativeTime(time);
   traceOf_ << fmt::format(R"JSON(
   {{
@@ -205,7 +203,6 @@ void ChromeTraceLogger::handleOverheadInfo(
   // TOOD: reserve pid = -1 for overhead but we need to rethink how to scale this for
   // other metadata
   // clang-format off
-  // see [Note: Temp Libkineto Nanosecond]
   time = transToRelativeTime(time);
   traceOf_ << fmt::format(R"JSON(
   {{
@@ -231,7 +228,7 @@ void ChromeTraceLogger::handleTraceSpan(const TraceSpan& span) {
   if (!traceOf_) {
     return;
   }
-  // see [Note: Temp Libkineto Nanosecond]
+
   uint64_t start = transToRelativeTime(span.startTime);
   uint64_t dur = span.endTime - span.startTime;
 
@@ -270,7 +267,6 @@ void ChromeTraceLogger::addIterationMarker(const TraceSpan& span) {
   }
 
   // clang-format off
-  // see [Note: Temp Libkineto Nanosecond]
   uint64_t start = transToRelativeTime(span.startTime);
 
   traceOf_ << fmt::format(R"JSON(
@@ -288,7 +284,7 @@ void ChromeTraceLogger::handleGenericInstantEvent(
   if (!traceOf_) {
     return;
   }
-  // see [Note: Temp Libkineto Nanosecond]
+
   uint64_t ts = transToRelativeTime(op.timestamp());
   traceOf_ << fmt::format(R"JSON(
   {{
@@ -432,7 +428,6 @@ void ChromeTraceLogger::handleActivity(
   sanitizeStrForJSON(op_name);
 
   // clang-format off
-  // see [Note: Temp Libkineto Nanosecond]
   ts = transToRelativeTime(ts);
   traceOf_ << fmt::format(R"JSON(
   {{
@@ -490,7 +485,6 @@ void ChromeTraceLogger::handleLink(
   // Flow start automatically sets binding point to enclosing slice.
   const auto binding = (type == kFlowEnd) ? ", \"bp\": \"e\"" : "";
   // clang-format off
-  // see [Note: Temp Libkineto Nanosecond]
   uint64_t ts = transToRelativeTime(e.timestamp());
   traceOf_ << fmt::format(R"JSON(
   {{
@@ -519,7 +513,6 @@ void ChromeTraceLogger::finalizeTrace(
   sanitizeStrForJSON(fileName_);
   LOG(INFO) << "Chrome Trace written to " << fileName_;
   // clang-format off
-  // see [Note: Temp Libkineto Nanosecond]
   endTime = transToRelativeTime(endTime);
   traceOf_ << fmt::format(R"JSON(
   {{
@@ -556,7 +549,6 @@ void ChromeTraceLogger::finalizeTrace(
 #endif // !USE_GOOGLE_LOG
 
   // Putting this here because the last entry MUST not end with a comma.
-  // see [Note: Temp Libkineto Nanosecond]
 
   traceOf_ << fmt::format(R"JSON(
   "traceName": "{}",


### PR DESCRIPTION
Summary: In Kineto we removed all instances of TMP_LIBKINETO_NANOSECOND but we did not remove the note stating why it was in

Reviewed By: aaronenyeshi

Differential Revision: D56480889


