### PR TITLE
Make ipcfabric have a single definition

### DIFF
--- a/libkineto/src/IpcFabricConfigClient.h
+++ b/libkineto/src/IpcFabricConfigClient.h
@@ -8,17 +8,44 @@
 
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #ifdef __linux__
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 // include logger before to enable ipc fabric to access LOG() macros
 #ifdef ENABLE_IPC_FABRIC
-#include "Logger.h"
-#endif
 
+#include "Logger.h"
+
+// The following is required for LOG() macros to work below
+using namespace KINETO_NAMESPACE;
 // Include the IPC Fabric
 #include "FabricManager.h"
+
+#else
+
+// Adds an empty implementation so compilation works.
+namespace dynolog::ipcfabric {
+
+class FabricManager {
+ public:
+  FabricManager(const FabricManager&) = delete;
+  FabricManager& operator=(const FabricManager&) = delete;
+
+  static std::unique_ptr<FabricManager> factory(
+      std::string endpoint_name = "") {
+    return NULL;
+  }
+};
+
+} // namespace dynolog::ipcfabric
+
+#endif // ENABLE_IPC_FABRIC
 
 namespace KINETO_NAMESPACE {
 


### PR DESCRIPTION
Summary:
There is an ODR one definition rule violation that was causing a crash on sigrid
https://fb.workplace.com/groups/560979627394613/posts/2909061125919773/?comment_id=2909752389183980&reply_comment_id=2910102119149007
Sigrid includes both kineto and ipcfabric via dynolog, and on kineto the class is fused in internal. Also adding Logger.h caused a mess.

Tries to resolve this issue
Note ENABLE_IPC_FABRIC define is only used in open source kineto (and PyTorch) but not in internal fbcode

Differential Revision: D56577485
