### PR TITLE
Remove erroneous "include/ApproximateClock.h"

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -62,7 +62,6 @@ def get_libkineto_public_headers():
         "include/ActivityProfilerInterface.h",
         "include/ActivityTraceInterface.h",
         "include/ActivityType.h",
-        "include/ApproximateClock.h",
         "include/Config.h",
         "include/ClientInterface.h",
         "include/GenericTraceActivity.h",


### PR DESCRIPTION
Summary: In D56525885, we added an include that does not exist. We need to remove it to fix some of the builds.

Differential Revision: D56638448
