### PR TITLE
Make Kineto Stage Log Level Lower

### DIFF
--- a/libkineto/include/ILoggerObserver.h
+++ b/libkineto/include/ILoggerObserver.h
@@ -28,8 +28,8 @@ enum LoggerOutputType {
   VERBOSE = 0,
   INFO = 1,
   WARNING = 2,
-  ERROR = 3,
-  STAGE = 4,
+  STAGE = 3,
+  ERROR = 4,
   ENUM_COUNT = 5
 };
 

--- a/libkineto/src/ILoggerObserver.cpp
+++ b/libkineto/src/ILoggerObserver.cpp
@@ -27,8 +27,8 @@ static constexpr std::array<LoggerTypeName, LoggerTypeCount + 1> LoggerMap{{
     {"VERBOSE", LoggerOutputType::VERBOSE},
     {"INFO", LoggerOutputType::INFO},
     {"WARNING", LoggerOutputType::WARNING},
-    {"ERROR", LoggerOutputType::ERROR},
     {"STAGE", LoggerOutputType::STAGE},
+    {"ERROR", LoggerOutputType::ERROR},
     {"???", LoggerOutputType::ENUM_COUNT}
 }};
 


### PR DESCRIPTION
Summary:
Users have complained that STAGE level logs are print by default. If a user is running many profiles it can certainly clutter STDOUT. Lower the STAGE level such that it is below the default.

Brought up by this issue https://github.com/pytorch/pytorch/issues/83383

Differential Revision: D56646009
