### PR TITLE
Change Default Chrome Trace Unit to be in Milliseconds

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -552,7 +552,7 @@ void ChromeTraceLogger::finalizeTrace(
 
   traceOf_ << fmt::format(R"JSON(
   "traceName": "{}",
-  "displayTimeUnit": "ns"
+  "displayTimeUnit": "ms"
 }})JSON", fileName_);
   // clang-format on
 


### PR DESCRIPTION
Summary: We have received comments stating that it would be easier to read tracings if they were back in millisecond format. For this reason, change the default back to milliseconds and if a user wants to read at nanosecond, they can just change the JSON manually.

Differential Revision: D56894110
