### PR TITLE
Remove CUPTI Overhead track from AMD Traces

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1245,11 +1245,13 @@ void CuptiActivityProfiler::finalizeTrace(const Config& config, ActivityLogger& 
     }
   }
 
+#ifdef HAS_CUPTI
   // Overhead info
   overheadInfo_.push_back(ActivityLogger::OverheadInfo("CUPTI Overhead"));
   for(const auto& info : overheadInfo_) {
     logger.handleOverheadInfo(info, captureWindowStartTime_);
   }
+#endif // HAS_CUPTI
 
   gpuUserEventMap_.logEvents(&logger);
 


### PR DESCRIPTION
Summary: Remove CUPTI Overhead track from AMD Traces. We don't collect CUPTI overhead for Roctracer.

Differential Revision: D56947649

Pulled By: aaronenyeshi


