### PR TITLE
Roctracer: Device ID is off by 2, manually start from 0

### DIFF
--- a/libkineto/src/RoctracerActivity.h
+++ b/libkineto/src/RoctracerActivity.h
@@ -93,7 +93,10 @@ struct GpuActivity : public RoctracerActivity<roctracerAsyncRow> {
     }
   }
   int64_t correlationId() const override {return activity_.id;}
-  int64_t deviceId() const override {return activity_.device;}
+  // roctracer reports int device_id always off by 2.
+  // Device 0 becomes device 2, and device 7 becomes device 9.
+  // Opened Github Issue: https://github.com/ROCm/roctracer/issues/98.
+  int64_t deviceId() const override {return activity_.device - 2;}
   int64_t resourceId() const override {return  activity_.queue;}
   ActivityType type() const override {return type_;};
   bool flowStart() const override {return false;}


### PR DESCRIPTION
Summary:
Although hipGetDeviceProperties shows 8 devices enumerating from 0 to 7, when using roctracer_record_t, the record->device_id enumerates from 2 to 9.

Manually enumerate from 0-7 by subtracting 2, and opened a bug report in ROCm/roctracer: https://github.com/ROCm/roctracer/issues/98.

Differential Revision: D56951239


