### PR TITLE
Add sortIndex to fix ordering of roctracer GPU id tracks

### DIFF
--- a/libkineto/include/IActivityProfiler.h
+++ b/libkineto/include/IActivityProfiler.h
@@ -40,12 +40,19 @@ enum class TraceStatus {
 };
 
 /* DeviceInfo:
- *   Can be used to specify process name, PID and device label
+ *   Can be used to specify process name, sort order, PID and device label.
+ *   The sort order is determined by the sortIndex field to handle ordering of
+ *   processes and gpu rows in the trace viewer.
  */
 struct DeviceInfo {
-  DeviceInfo(int64_t id, const std::string& name, const std::string& label)
-      : id(id), name(name), label(label) {}
+  DeviceInfo(
+      int64_t id,
+      int64_t sortIndex,
+      const std::string& name,
+      const std::string& label)
+      : id(id), sortIndex(sortIndex), name(name), label(label) {}
   int64_t id;               // process id
+  int64_t sortIndex;        // position in trace view
   const std::string name;   // process name
   const std::string label;  // device label
 };

--- a/libkineto/include/output_base.h
+++ b/libkineto/include/output_base.h
@@ -29,6 +29,11 @@ namespace libkineto {
 
 using namespace KINETO_NAMESPACE;
 
+// Used by sortIndex to put GPU tracks at the bottom
+// of the trace timelines. The largest valid CPU PID is 4,194,304,
+// so 5000000 is enough to guarantee that GPU tracks are sorted after CPU.
+constexpr int64_t kExceedMaxPid = 5000000;
+
 class ActivityLogger {
  public:
 

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -154,7 +154,7 @@ void ChromeTraceLogger::handleDeviceInfo(
       time/1000, time%1000, info.id,
       info.label,
       time/1000, time%1000, info.id,
-      info.id < 8 ? info.id + 0x1000000ll : info.id);
+      info.sortIndex);
   // clang-format on
 }
 


### PR DESCRIPTION
Summary:
Although hipGetDeviceProperties shows 8 devices enumerating from 0 to 7, when using roctracer_record_t, the record->device_id enumerates from 2 to 9. This is because roctracer considers id 0 and 1 as CPU sockets.

So we can expect up to 4 CPU sockets, and 8 GPUs, up to a total count of 12. Which would mean the enumeration will be 0 - 11. This will help put the GPU tracks in order and at the bottom of the chrome trace.

Original Bug report in ROCm/roctracer: https://github.com/ROCm/roctracer/issues/98. We can just show the device id that is given by roctracer.

Differential Revision: D57067065

Pulled By: aaronenyeshi

## Test Plan:
Before:
![image](https://github.com/pytorch/kineto/assets/17602366/716c118c-0c2f-48e7-943a-1fa519695a8e)

After:
![image](https://github.com/pytorch/kineto/assets/17602366/467a1186-9ac6-4027-9433-02f85d1b37ee)


