### PR TITLE
Add deviceProperties for AMD devices to trace's metadata

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -11,7 +11,6 @@ def get_libkineto_api_srcs():
 
 def get_libkineto_cupti_srcs(with_api = True):
     return [
-        "src/CudaDeviceProperties.cpp",
         "src/CudaUtil.cpp",
         "src/CuptiActivityApi.cpp",
         "src/CuptiCallbackApi.cpp",
@@ -22,6 +21,7 @@ def get_libkineto_cupti_srcs(with_api = True):
         "src/CuptiRangeProfilerConfig.cpp",
         "src/CuptiNvPerfMetric.cpp",
         "src/Demangle.cpp",
+        "src/DeviceProperties.cpp",
         "src/EventProfiler.cpp",
         "src/EventProfilerController.cpp",
         "src/WeakSymbols.cpp",

--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -10,8 +10,8 @@
 
 #include <fmt/format.h>
 
-#include "CudaDeviceProperties.h"
 #include "Demangle.h"
+#include "DeviceProperties.h"
 #include "output_base.h"
 
 namespace KINETO_NAMESPACE {

--- a/libkineto/src/DeviceProperties.h
+++ b/libkineto/src/DeviceProperties.h
@@ -11,11 +11,19 @@
 #include <stdint.h>
 #include <string>
 
+#ifdef HAS_CUPTI
 #include <cupti.h>
+#endif
 
 namespace KINETO_NAMESPACE {
 
+// Return compute properties for each device as a json string
+const std::string& devicePropertiesJson();
+
 int smCount(uint32_t deviceId);
+
+// TODO: Implement the below for HAS_ROCTRACER
+#ifdef HAS_CUPTI
 float blocksPerSm(const CUpti_ActivityKernel4& kernel);
 float warpsPerSm(const CUpti_ActivityKernel4& kernel);
 
@@ -30,8 +38,6 @@ float kernelOccupancy(
     int32_t blockY,
     int32_t blockZ,
     float blocks_per_sm);
-
-// Return compute properties for each device as a json string
-const std::string& devicePropertiesJson();
+#endif
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -14,9 +14,7 @@
 #include <map>
 
 #include "Config.h"
-#ifdef HAS_CUPTI
-#include "CudaDeviceProperties.h"
-#endif // HAS_CUPTI
+#include "DeviceProperties.h"
 #include "TraceSpan.h"
 
 #include "Logger.h"
@@ -92,11 +90,9 @@ void ChromeTraceLogger::handleTraceStart(
 {{
   "schemaVersion": {},)JSON", kSchemaVersion);
 
-#ifdef HAS_CUPTI
   traceOf_ << fmt::format(R"JSON(
   "deviceProperties": [{}
   ],)JSON", devicePropertiesJson());
-#endif
 
   metadataToJSON(metadata);
   traceOf_ << R"JSON(


### PR DESCRIPTION
Summary:
Similar to CUDA, save the device properties to the metadata of Roctracer GPU traces.
- Renamed CudaDeviceProperties files to DeviceProperties, and changed TARGETS' cpp_library to device_properties
- Added gpu agnostic definitions so we can re-use existing DeviceProperties functions to return a valid devicePropertiesJson() string for AMD. Return "" for any non-CUDA or non-AMD.
- Used ifdef for a few device properties specific to CUPTI: regsPerMultiprocessor, sharedMemPerBlockOptin, sharedMemPerMultiprocessor.
- Clean up the TARGETS, only need 1 library and include it.

Differential Revision: D56901553

Pulled By: aaronenyeshi
