### PR TITLE
Add Base Timestamp to Kineto Tracings

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -552,8 +552,9 @@ void ChromeTraceLogger::finalizeTrace(
 
   traceOf_ << fmt::format(R"JSON(
   "traceName": "{}",
-  "displayTimeUnit": "ms"
-}})JSON", fileName_);
+  "displayTimeUnit": "ms",
+  "baseTimeNanoseconds": {}
+}})JSON", fileName_, ChromeTraceBaseTime::singleton().get());
   // clang-format on
 
   traceOf_.close();


### PR DESCRIPTION
Summary: Because we use relative timestamps in Kineto tracings, other plugins that use stitching, like GPUSnoop, have began to fail. In order for events to be stitched properly, they will need the basetime to get a relative timestamp off of. We output this in our chrome trace JSON as "baseTimeNanoseconds"

Differential Revision: D57186263


