### PR TITLE
Enable CUPTI Range Profiler on H100

### DIFF
--- a/libkineto/sample_programs/kineto_cupti_profiler.cpp
+++ b/libkineto/sample_programs/kineto_cupti_profiler.cpp
@@ -30,7 +30,7 @@ int main() {
     libkineto::ActivityType::CUDA_PROFILER_RANGE,
   };
 
-  libkineto_init(false, true);
+  //libkineto_init(false, true);
   libkineto::api().initProfilerIfRegistered();
 
   // Use a special kineto__cuda_core_flop metric that counts individual

--- a/libkineto/sample_programs/kineto_playground.cpp
+++ b/libkineto/sample_programs/kineto_playground.cpp
@@ -21,23 +21,27 @@ using namespace kineto;
 static const std::string kFileName = "/tmp/kineto_playground_trace.json";
 
 int main() {
+  std::cout << "Warm up " << std::endl;
   warmup();
 
   // Kineto config
 
   // Empty types set defaults to all types
   std::set<libkineto::ActivityType> types;
-  libkineto_init(false, true);
-  libkineto::api().initProfilerIfRegistered();
 
   auto& profiler = libkineto::api().activityProfiler();
+  libkineto::api().initProfilerIfRegistered();
   profiler.prepareTrace(types);
 
   // Good to warm up after prepareTrace to get cupti initialization to settle
+  std::cout << "Warm up " << std::endl;
   warmup();
+  std::cout << "Start trace" << std::endl;
   profiler.startTrace();
+  std::cout << "Start playground" << std::endl;
   playground();
 
+  std::cout << "Stop Trace" << std::endl;
   auto trace = profiler.stopTrace();
   std::cout << "Stopped and processed trace. Got " << trace->activities()->size() << " activities.";
   trace->save(kFileName);

--- a/libkineto/sample_programs/kineto_playground.cu
+++ b/libkineto/sample_programs/kineto_playground.cu
@@ -76,6 +76,9 @@ __global__ void square(float* A, int N) {
 
 void playground(void) {
   // Add your experimental CUDA implementation here.
+  basicMemcpyFromDevice();
+  compute();
+  basicMemcpyFromDevice();
 }
 
 void compute(void) {

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -888,16 +888,21 @@ void CuptiActivityProfiler::configureChildProfilers() {
           derivedConfig_->profileStartTime().time_since_epoch())
           .count();
   for (auto& profiler : profilers_) {
-    LOG(INFO) << "Evaluating whether to run child profiler = " << profiler->name();
+    LOG(INFO) << "[Profiler = " << profiler->name() << "] "
+              << "Evaluating whether to run child profiler." ;
     auto session = profiler->configure(
         start_time_ms,
         derivedConfig_->profileDuration().count(),
         derivedConfig_->profileActivityTypes(),
         *config_);
     if (session) {
-      LOG(INFO) << "Running child profiler " << profiler->name() << " for "
+      LOG(INFO) << "[Profiler = " << profiler->name() << "] "
+                << "Running child profiler " << profiler->name() << " for "
                 << derivedConfig_->profileDuration().count() << " ms";
       sessions_.push_back(std::move(session));
+    } else {
+      LOG(INFO) << "[Profiler = " << profiler->name() << "] "
+                << "Not running child profiler.";
     }
   }
 }

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -77,7 +77,7 @@ void CuptiCallbackApi::__callback_switchboard(
    CUpti_CallbackDomain domain,
    CUpti_CallbackId cbid,
    const CUpti_CallbackData* cbInfo) {
-  VLOG(0) << "Callback: domain = " << domain << ", cbid = " << cbid;
+  LOG(INFO) << "Callback: domain = " << domain << ", cbid = " << cbid;
   CallbackList *cblist = nullptr;
 
   switch (domain) {
@@ -89,6 +89,12 @@ void CuptiCallbackApi::__callback_switchboard(
           cblist = &callbacks_.runtime[
             CUDA_LAUNCH_KERNEL - __RUNTIME_CB_DOMAIN_START];
           break;
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 11080)
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060:
+          cblist = &callbacks_.runtime[
+            CUDA_LAUNCH_KERNEL_EXC - __RUNTIME_CB_DOMAIN_START];
+          break;
+#endif
         default:
           break;
       }
@@ -171,7 +177,7 @@ void CuptiCallbackApi::initCallbackApi() {
       (CUpti_CallbackFunc)callback_switchboard,
       nullptr));
   if (lastCuptiStatus_ != CUPTI_SUCCESS) {
-    VLOG(1)  << "Failed cuptiSubscribe, status: " << lastCuptiStatus_;
+    LOG(INFO) << "Failed cuptiSubscribe, status: " << lastCuptiStatus_;
   }
 
   initSuccess_ = (lastCuptiStatus_ == CUPTI_SUCCESS);

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -28,6 +28,7 @@ namespace KINETO_NAMESPACE {
 using namespace libkineto;
 
 
+
 /* CuptiCallbackApi : Provides an abstraction over CUPTI callback
  *  interface. This enables various callback functions to be registered
  *  with this class. The class registers a global callback handler that
@@ -54,6 +55,7 @@ class CuptiCallbackApi {
     // can possibly support more callback ids per domain
     //
     __RUNTIME_CB_DOMAIN_START = CUDA_LAUNCH_KERNEL,
+    CUDA_LAUNCH_KERNEL_EXC,  // Used in H100
 
     // Callbacks under Resource CB domain
     RESOURCE_CONTEXT_CREATED,

--- a/libkineto/src/CuptiCallbackApiMock.h
+++ b/libkineto/src/CuptiCallbackApiMock.h
@@ -17,6 +17,10 @@ enum CUpti_CallbackDomain {
 };
 enum CUpti_CallbackId {
   CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 11080)
+  CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,
+#endif
   CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
   CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
 };

--- a/libkineto/src/CuptiRangeProfilerApi.cpp
+++ b/libkineto/src/CuptiRangeProfilerApi.cpp
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include "ILoggerObserver.h"
 #ifdef HAS_CUPTI
 #include <cupti.h>
 #include <nvperf_host.h>
@@ -19,9 +20,9 @@
 #include "cupti_call.h"
 #endif
 
-#include "time_since_epoch.h"
-#include "Logger.h"
 #include "Demangle.h"
+#include "Logger.h"
+#include "time_since_epoch.h"
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
@@ -39,8 +40,7 @@ TraceSpan CuptiRBProfilerSession::getProfilerTraceSpan() {
   return TraceSpan(
       timeSinceEpoch(profilerStartTs_),
       timeSinceEpoch(profilerStopTs_),
-      "__cupti_profiler__"
-  );
+      "__cupti_profiler__");
 }
 
 #if HAS_CUPTI_RANGE_PROFILER
@@ -57,7 +57,7 @@ std::unordered_map<uint32_t, bool> disable_flag;
 std::mutex contextMutex_;
 std::unordered_map<CUcontext, int> ctx_to_dev;
 std::set<uint32_t> active_devices;
-}
+} // namespace
 
 // forward declarations
 void __trackCudaCtx(CUcontext ctx, uint32_t device_id, CUpti_CallbackId cbid);
@@ -110,7 +110,8 @@ inline uint32_t getDevID(CUcontext ctx) {
 //   1. Track cuda contexts and maintain a list of active GPUs to profile
 //   2. Callbacks on kernel launches to track the name of automatic
 //      ranges that correspond to names of kernels
-//   3. Lastly CUPTI range profiler has to be enabled on the same thread executing
+//   3. Lastly CUPTI range profiler has to be enabled on the same thread
+//   executing
 //      the CUDA kernels. We use Callbacks to enable the profiler
 //      asynchronously from another thread.
 
@@ -120,7 +121,7 @@ void trackCudaCtx(
     CUpti_CallbackDomain /*domain*/,
     CUpti_CallbackId cbid,
     const CUpti_CallbackData* cbInfo) {
-  auto *d = reinterpret_cast<const CUpti_ResourceData*>(cbInfo);
+  auto* d = reinterpret_cast<const CUpti_ResourceData*>(cbInfo);
   auto ctx = d->context;
   uint32_t device_id = getDevID(ctx);
 
@@ -134,14 +135,14 @@ void trackCudaCtx(
 void __trackCudaCtx(CUcontext ctx, uint32_t device_id, CUpti_CallbackId cbid) {
   std::lock_guard<std::mutex> g(contextMutex_);
   if (cbid == CUPTI_CBID_RESOURCE_CONTEXT_CREATED) {
-    VLOG(0) << "CUPTI Profiler observed CUDA Context created = "
-            << ctx << " device id = " << device_id;
+    VLOG(0) << "CUPTI Profiler observed CUDA Context created = " << ctx
+            << " device id = " << device_id;
     active_devices.insert(device_id);
     ctx_to_dev[ctx] = device_id;
 
   } else if (cbid == CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING) {
-    VLOG(0) << "CUPTI Profiler observed CUDA Context destroyed = "
-            << ctx << " device id = " << device_id;
+    VLOG(0) << "CUPTI Profiler observed CUDA Context destroyed = " << ctx
+            << " device id = " << device_id;
     auto it = active_devices.find(device_id);
     if (it != active_devices.end()) {
       active_devices.erase(it);
@@ -155,7 +156,7 @@ void trackCudaKernelLaunch(
     CUpti_CallbackId /*cbid*/,
     const CUpti_CallbackData* cbInfo) {
   VLOG(1) << " Trace : Callback name = "
-          << (cbInfo->symbolName ?  cbInfo->symbolName: "")
+          << (cbInfo->symbolName ? cbInfo->symbolName : "")
           << " context ptr = " << cbInfo->context;
   auto ctx = cbInfo->context;
   // should be in CUPTI_API_ENTER call site
@@ -165,9 +166,7 @@ void trackCudaKernelLaunch(
   __trackCudaKernelLaunch(ctx, cbInfo->symbolName);
 }
 
-void __trackCudaKernelLaunch(
-    CUcontext ctx,
-    const char* kernelName) {
+void __trackCudaKernelLaunch(CUcontext ctx, const char* kernelName) {
   VLOG(0) << " Tracking kernel name = " << (kernelName ? kernelName : "")
           << " context ptr = " << ctx;
 
@@ -218,27 +217,43 @@ void __trackCudaKernelLaunch(
 
 void enableKernelCallbacks() {
   auto cbapi = CuptiCallbackApi::singleton();
+
   bool status = cbapi->enableCallback(
       CUPTI_CB_DOMAIN_RUNTIME_API,
       CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000);
+// cudaLaunchKernelExC() used from H100 onwards.
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 11080)
+  status &= cbapi->enableCallback(
+    CUPTI_CB_DOMAIN_RUNTIME_API,
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060);
+#endif
+
   if (!status) {
     LOG(WARNING) << "CUPTI Range Profiler unable to "
-                 << "enable cuda kernel launch callback";
-    return;
+                  << "enable cuda kernel launch callback.";
   }
+
   LOG(INFO) << "CUPTI Profiler kernel callbacks enabled";
 }
 
 void disableKernelCallbacks() {
   auto cbapi = CuptiCallbackApi::singleton();
+
   bool status = cbapi->disableCallback(
       CUPTI_CB_DOMAIN_RUNTIME_API,
       CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000);
+#if defined(CUDA_VERSION) && (CUDA_VERSION >= 11080)
+  status &= cbapi->disableCallback(
+    CUPTI_CB_DOMAIN_RUNTIME_API,
+    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060);
+#endif
+
   if (!status) {
     LOG(WARNING) << "CUPTI Range Profiler unable to "
-                 << "disable cuda kernel launch callback";
+                  << "disable cuda kernel launch callback.";
     return;
   }
+
   LOG(INFO) << "CUPTI Profiler kernel callbacks disabled";
 }
 
@@ -255,8 +270,8 @@ bool CuptiRBProfilerSession::initCupti() {
   // when you plan to use CUPTI range profiler
   CUpti_Profiler_Initialize_Params profilerInitializeParams = {
       CUpti_Profiler_Initialize_Params_STRUCT_SIZE, nullptr};
-  CUptiResult status = CUPTI_CALL_NOWARN(
-      cuptiProfilerInitialize(&profilerInitializeParams));
+  CUptiResult status =
+      CUPTI_CALL_NOWARN(cuptiProfilerInitialize(&profilerInitializeParams));
   return (status == CUPTI_SUCCESS);
 }
 
@@ -274,12 +289,14 @@ bool CuptiRBProfilerSession::staticInit() {
   CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RESOURCE;
   bool status = cbapi->registerCallback(
       domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED, trackCudaCtx);
-  status = status && cbapi->registerCallback(
-      domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED, trackCudaCtx);
-  status = status && cbapi->enableCallback(
-      domain, CUPTI_CBID_RESOURCE_CONTEXT_CREATED);
-  status = status && cbapi->enableCallback(
-      domain, CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING);
+  status = status &&
+      cbapi->registerCallback(
+          domain, CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED, trackCudaCtx);
+  status = status &&
+      cbapi->enableCallback(domain, CUPTI_CBID_RESOURCE_CONTEXT_CREATED);
+  status = status &&
+      cbapi->enableCallback(
+          domain, CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING);
 
   if (!status) {
     LOG(WARNING) << "CUPTI Range Profiler unable to attach cuda context "
@@ -291,6 +308,11 @@ bool CuptiRBProfilerSession::staticInit() {
   domain = CUPTI_CB_DOMAIN_RUNTIME_API;
   status = cbapi->registerCallback(
       domain, CuptiCallbackApi::CUDA_LAUNCH_KERNEL, trackCudaKernelLaunch);
+  status = status &&
+      cbapi->registerCallback(
+          domain,
+          CuptiCallbackApi::CUDA_LAUNCH_KERNEL_EXC,
+          trackCudaKernelLaunch);
 
   if (!status) {
     LOG(WARNING) << "CUPTI Range Profiler unable to attach cuda kernel "
@@ -306,7 +328,6 @@ std::vector<uint8_t>& CuptiRBProfilerSession::counterAvailabilityImage() {
   static std::vector<uint8_t> counterAvailabilityImage_;
   return counterAvailabilityImage_;
 }
-
 
 // Setup the profiler sessions
 CuptiRBProfilerSession::CuptiRBProfilerSession(
@@ -330,8 +351,8 @@ CuptiRBProfilerSession::CuptiRBProfilerSession(
     return;
   }
 
-  LOG(INFO) << "Initializing CUPTI range profiler session : device = " << deviceId_
-            << " chip = " << chipName_;
+  LOG(INFO) << "Initializing CUPTI range profiler session : device = "
+            << deviceId_ << " chip = " << chipName_;
   /* Generate configuration for metrics, this can also be done offline*/
   NVPW_InitializeHost_Params initializeHostParams = {
       NVPW_InitializeHost_Params_STRUCT_SIZE, nullptr};
@@ -347,9 +368,7 @@ CuptiRBProfilerSession::CuptiRBProfilerSession(
       return;
     }
     if (!nvperf::getCounterDataPrefixImage(
-            chipName_,
-            metricNames_,
-            counterDataImagePrefix)) {
+            chipName_, metricNames_, counterDataImagePrefix)) {
       LOG(ERROR) << "Failed to create counterDataImagePrefix";
       return;
     }
@@ -364,13 +383,13 @@ CuptiRBProfilerSession::CuptiRBProfilerSession(
   }
 
   LOG(INFO) << "Size of structs"
-            << " config image size = " << configImage.size()  << " B"
-            << " counter data image prefix = "
-            << counterDataImagePrefix.size()  << " B"
+            << " config image size = " << configImage.size() << " B"
+            << " counter data image prefix = " << counterDataImagePrefix.size()
+            << " B"
             << " counter data image size = " << counterDataImage.size() / 1024
             << " KB"
-            << " counter sb image size = "
-            << counterDataScratchBuffer.size()  << " B";
+            << " counter sb image size = " << counterDataScratchBuffer.size()
+            << " B";
 
   beginPassParams_ = {CUpti_Profiler_BeginPass_Params_STRUCT_SIZE, nullptr, {}};
   beginPassParams_.ctx = cuContext_;
@@ -415,7 +434,8 @@ void CuptiRBProfilerSession::startInternal(
   beginSessionParams.pCounterDataImage = counterDataImage.data();
   beginSessionParams.counterDataScratchBufferSize =
       counterDataScratchBuffer.size();
-  beginSessionParams.pCounterDataScratchBuffer = counterDataScratchBuffer.data();
+  beginSessionParams.pCounterDataScratchBuffer =
+      counterDataScratchBuffer.data();
   beginSessionParams.range = profilerRange;
   beginSessionParams.replayMode = profilerReplayMode;
   beginSessionParams.maxRangesPerPass = maxRanges_;
@@ -426,6 +446,8 @@ void CuptiRBProfilerSession::startInternal(
     LOG(WARNING) << "Failed to start CUPTI range profiler";
     initSuccess_ = false;
     return;
+  } else {
+    LOG(INFO) << "Successfully started CUPTI range profiler";
   }
 
   // Set counter configuration
@@ -588,9 +610,7 @@ void CuptiRBProfilerSession::asyncDisableAndStop() {
   disable_flag[deviceId_] = true;
 }
 
-
-CuptiProfilerResult CuptiRBProfilerSession::evaluateMetrics(
-    bool verbose) {
+CuptiProfilerResult CuptiRBProfilerSession::evaluateMetrics(bool verbose) {
   if (!initSuccess_) {
     LOG(WARNING) << "Profiling failed, no results to return";
     return {};
@@ -639,54 +659,57 @@ bool CuptiRBProfilerSession::createCounterDataImage() {
 
   // Calculate size of counter data image
   CUpti_Profiler_CounterDataImage_CalculateSize_Params calculateSizeParams = {
-      CUpti_Profiler_CounterDataImage_CalculateSize_Params_STRUCT_SIZE, nullptr};
+      CUpti_Profiler_CounterDataImage_CalculateSize_Params_STRUCT_SIZE,
+      nullptr};
   calculateSizeParams.pOptions = &counterDataImageOptions;
   calculateSizeParams.sizeofCounterDataImageOptions =
       CUpti_Profiler_CounterDataImageOptions_STRUCT_SIZE;
 
-  CUPTI_CALL(
-      cuptiProfilerCounterDataImageCalculateSize(&calculateSizeParams));
+  CUPTI_CALL(cuptiProfilerCounterDataImageCalculateSize(&calculateSizeParams));
   counterDataImage.resize(calculateSizeParams.counterDataImageSize);
 
   // Initialize counter data image
   CUpti_Profiler_CounterDataImage_Initialize_Params initializeParams = {
-    CUpti_Profiler_CounterDataImage_Initialize_Params_STRUCT_SIZE, nullptr};
+      CUpti_Profiler_CounterDataImage_Initialize_Params_STRUCT_SIZE, nullptr};
   initializeParams.sizeofCounterDataImageOptions =
-    CUpti_Profiler_CounterDataImageOptions_STRUCT_SIZE;
+      CUpti_Profiler_CounterDataImageOptions_STRUCT_SIZE;
   initializeParams.pOptions = &counterDataImageOptions;
   initializeParams.counterDataImageSize =
-    calculateSizeParams.counterDataImageSize;
+      calculateSizeParams.counterDataImageSize;
   initializeParams.pCounterDataImage = counterDataImage.data();
   CUPTI_CALL(cuptiProfilerCounterDataImageInitialize(&initializeParams));
 
   // Calculate counter Scratch Buffer size
   CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params
-    scratchBufferSizeParams = {
-          CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params_STRUCT_SIZE, nullptr};
+      scratchBufferSizeParams = {
+          CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params_STRUCT_SIZE,
+          nullptr};
 
   scratchBufferSizeParams.counterDataImageSize =
-    calculateSizeParams.counterDataImageSize;
+      calculateSizeParams.counterDataImageSize;
   scratchBufferSizeParams.pCounterDataImage =
-    initializeParams.pCounterDataImage;
+      initializeParams.pCounterDataImage;
   CUPTI_CALL(cuptiProfilerCounterDataImageCalculateScratchBufferSize(
-    &scratchBufferSizeParams));
+      &scratchBufferSizeParams));
 
   counterDataScratchBuffer.resize(
       scratchBufferSizeParams.counterDataScratchBufferSize);
 
   // Initialize scratch buffer
   CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params
-    initScratchBufferParams = {
-      CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params_STRUCT_SIZE, nullptr};
+      initScratchBufferParams = {
+          CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params_STRUCT_SIZE,
+          nullptr};
 
   initScratchBufferParams.counterDataImageSize =
-    calculateSizeParams.counterDataImageSize;
+      calculateSizeParams.counterDataImageSize;
 
-  initScratchBufferParams.pCounterDataImage = initializeParams.pCounterDataImage;
+  initScratchBufferParams.pCounterDataImage =
+      initializeParams.pCounterDataImage;
   initScratchBufferParams.counterDataScratchBufferSize =
-    scratchBufferSizeParams.counterDataScratchBufferSize;
+      scratchBufferSizeParams.counterDataScratchBufferSize;
   initScratchBufferParams.pCounterDataScratchBuffer =
-    counterDataScratchBuffer.data();
+      counterDataScratchBuffer.data();
 
   CUPTI_CALL(cuptiProfilerCounterDataImageInitializeScratchBuffer(
       &initScratchBufferParams));
@@ -709,13 +732,15 @@ CuptiRBProfilerSession::CuptiRBProfilerSession(
       deviceId_(opts.deviceId),
       maxRanges_(opts.maxRanges),
       numNestingLevels_(opts.numNestingLevels),
-      cuContext_(opts.cuContext) {};
+      cuContext_(opts.cuContext){};
 CuptiRBProfilerSession::~CuptiRBProfilerSession() {}
 void CuptiRBProfilerSession::stop() {}
 void CuptiRBProfilerSession::enable() {}
 void CuptiRBProfilerSession::disable() {}
 void CuptiRBProfilerSession::beginPass() {}
-bool CuptiRBProfilerSession::endPass() { return true; }
+bool CuptiRBProfilerSession::endPass() {
+  return true;
+}
 void CuptiRBProfilerSession::flushCounterData() {}
 void CuptiRBProfilerSession::pushRange(const std::string& /*rangeName*/) {}
 void CuptiRBProfilerSession::popRange() {}
@@ -732,11 +757,19 @@ CuptiProfilerResult CuptiRBProfilerSession::evaluateMetrics(bool verbose) {
 void CuptiRBProfilerSession::saveCounterData(
     const std::string& /*CounterDataFileName*/,
     const std::string& /*CounterDataSBFileName*/) {}
-bool CuptiRBProfilerSession::initCupti() { return false; }
+bool CuptiRBProfilerSession::initCupti() {
+  return false;
+}
 void CuptiRBProfilerSession::deInitCupti() {}
-bool CuptiRBProfilerSession::staticInit() { return false; }
-std::set<uint32_t> CuptiRBProfilerSession::getActiveDevices() { return {}; }
-bool CuptiRBProfilerSession::createCounterDataImage() { return true; }
+bool CuptiRBProfilerSession::staticInit() {
+  return false;
+}
+std::set<uint32_t> CuptiRBProfilerSession::getActiveDevices() {
+  return {};
+}
+bool CuptiRBProfilerSession::createCounterDataImage() {
+  return true;
+}
 void CuptiRBProfilerSession::startInternal(
     CUpti_ProfilerRange /*profilerRange*/,
     CUpti_ProfilerReplayMode /*profilerReplayMode*/) {}
@@ -746,8 +779,8 @@ std::vector<uint8_t>& CuptiRBProfilerSession::counterAvailabilityImage() {
 }
 #endif // HAS_CUPTI_RANGE_PROFILER
 
-std::unique_ptr<CuptiRBProfilerSession>
-CuptiRBProfilerSessionFactory::make(const CuptiRangeProfilerOptions& opts) {
+std::unique_ptr<CuptiRBProfilerSession> CuptiRBProfilerSessionFactory::make(
+    const CuptiRangeProfilerOptions& opts) {
   return std::make_unique<CuptiRBProfilerSession>(opts);
 }
 

--- a/libkineto/test/CuptiCallbackApiTest.cpp
+++ b/libkineto/test/CuptiCallbackApiTest.cpp
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "src/Logger.h"
 #include "src/CuptiCallbackApi.h"
+#include "src/Logger.h"
 
 #include <gtest/gtest.h>
 #include <atomic>
@@ -21,15 +21,30 @@ const size_t some_data = 42;
 
 std::atomic<int> simple_cb_calls = 0;
 
-void simple_cb(
+void simple_cudaLaunchKernel_cb(
     CUpti_CallbackDomain domain,
     CUpti_CallbackId cbid,
     const CUpti_CallbackData* cbInfo) {
-
   // simple arg check
   EXPECT_EQ(domain, CUPTI_CB_DOMAIN_RUNTIME_API);
   EXPECT_EQ(cbid, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000);
   EXPECT_EQ(*reinterpret_cast<const size_t*>(cbInfo), some_data);
+
+  LOG(INFO) << "CUDA Launch Kernel called";
+
+  simple_cb_calls++;
+}
+
+void simple_cudaLaunchKernelExC_cb(
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData* cbInfo) {
+  // simple arg check
+  EXPECT_EQ(domain, CUPTI_CB_DOMAIN_RUNTIME_API);
+  EXPECT_EQ(cbid, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060);
+  EXPECT_EQ(*reinterpret_cast<const size_t*>(cbInfo), some_data);
+
+  LOG(INFO) << "CUDA Launch Kernel ExC called";
 
   simple_cb_calls++;
 }
@@ -48,24 +63,35 @@ void atomic_cb(
 void empty_cb(
     CUpti_CallbackDomain /*domain*/,
     CUpti_CallbackId /*cbid*/,
-    const CUpti_CallbackData* /*cbInfo*/) {
-}
+    const CUpti_CallbackData* /*cbInfo*/) {}
 
 TEST(CuptiCallbackApiTest, SimpleTest) {
   auto api = CuptiCallbackApi::singleton();
 
-  auto addSimpleCallback = [&]() -> bool {
-    bool ret = api->registerCallback(
-        CUPTI_CB_DOMAIN_RUNTIME_API,
-        CuptiCallbackApi::CUDA_LAUNCH_KERNEL,
-        &simple_cb
-    );
+  auto addSimpleCallback = [&](CuptiCallbackApi::CuptiCallBackID cbApi,
+                               CuptiCallbackFn cb) -> bool {
+    bool ret = api->registerCallback(CUPTI_CB_DOMAIN_RUNTIME_API, cbApi, cb);
     return ret;
   };
-  EXPECT_TRUE(addSimpleCallback()) << "Failed to add callback";
+
+  EXPECT_TRUE(addSimpleCallback(
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL,
+      &simple_cudaLaunchKernel_cb))
+      << "Failed to add callback";
+  EXPECT_TRUE(addSimpleCallback(
+    CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC,
+    &simple_cudaLaunchKernelExC_cb))
+      << "Failed to add callback";
 
   // duplicate add should be okay
-  EXPECT_TRUE(addSimpleCallback()) << "Failed to re-add callback";
+  EXPECT_TRUE(addSimpleCallback(
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL,
+      &simple_cudaLaunchKernel_cb))
+      << "Failed to re-add callback";
+  EXPECT_TRUE(addSimpleCallback(
+    CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC,
+    &simple_cudaLaunchKernelExC_cb))
+      << "Failed to re-add callback";
 
   simple_cb_calls = 0;
 
@@ -77,19 +103,38 @@ TEST(CuptiCallbackApiTest, SimpleTest) {
 
   EXPECT_EQ(simple_cb_calls, 1);
 
+  api->__callback_switchboard(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,
+      reinterpret_cast<const CUpti_CallbackData*>(&some_data));
+
+  EXPECT_EQ(simple_cb_calls, 2);
+
   bool ret = api->deleteCallback(
       CUPTI_CB_DOMAIN_RUNTIME_API,
       CuptiCallbackApi::CUDA_LAUNCH_KERNEL,
-      &simple_cb
-  );
+      &simple_cudaLaunchKernel_cb);
+
+  EXPECT_TRUE(ret) << "Failed to remove callback";
+
+  ret = api->deleteCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CuptiCallbackApi::CUDA_LAUNCH_KERNEL_EXC,
+      &simple_cudaLaunchKernelExC_cb);
 
   EXPECT_TRUE(ret) << "Failed to remove callback";
 
   ret = api->deleteCallback(
       CUPTI_CB_DOMAIN_RUNTIME_API,
       CuptiCallbackApi::CUDA_LAUNCH_KERNEL,
-      &atomic_cb
-  );
+      &atomic_cb);
+
+  EXPECT_FALSE(ret) << "oops! deleted a callback that was never added";
+
+  ret = api->deleteCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CuptiCallbackApi::CUDA_LAUNCH_KERNEL_EXC,
+      &atomic_cb);
 
   EXPECT_FALSE(ret) << "oops! deleted a callback that was never added";
 }
@@ -97,11 +142,10 @@ TEST(CuptiCallbackApiTest, SimpleTest) {
 TEST(CuptiCallbackApiTest, AllCallbacks) {
   auto api = CuptiCallbackApi::singleton();
 
-  auto testCallback = [&](
-      CUpti_CallbackDomain domain,
-      CUpti_CallbackId cbid,
-      CuptiCallbackApi::CuptiCallBackID kineto_cbid) -> bool {
-
+  auto testCallback =
+      [&](CUpti_CallbackDomain domain,
+          CUpti_CallbackId cbid,
+          CuptiCallbackApi::CuptiCallBackID kineto_cbid) -> bool {
     bool ret = api->registerCallback(domain, kineto_cbid, atomic_cb);
     EXPECT_TRUE(ret) << "Failed to add callback";
 
@@ -119,27 +163,29 @@ TEST(CuptiCallbackApiTest, AllCallbacks) {
     return ret;
   };
 
-  EXPECT_TRUE(
-      testCallback(
-        CUPTI_CB_DOMAIN_RESOURCE,
-        CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
-        CuptiCallbackApi::RESOURCE_CONTEXT_CREATED))
-    << "Failed to run callback for RESOURCE_CONTEXT_CREATED";
+  EXPECT_TRUE(testCallback(
+      CUPTI_CB_DOMAIN_RESOURCE,
+      CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
+      CuptiCallbackApi::RESOURCE_CONTEXT_CREATED))
+      << "Failed to run callback for RESOURCE_CONTEXT_CREATED";
 
-  EXPECT_TRUE(
-      testCallback(
-        CUPTI_CB_DOMAIN_RESOURCE,
-        CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
-        CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED))
-    << "Failed to run callback for RESOURCE_CONTEXT_DESTROYED";
+  EXPECT_TRUE(testCallback(
+      CUPTI_CB_DOMAIN_RESOURCE,
+      CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
+      CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED))
+      << "Failed to run callback for RESOURCE_CONTEXT_DESTROYED";
 
-  EXPECT_TRUE(
-      testCallback(
-        CUPTI_CB_DOMAIN_RUNTIME_API,
-        CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
-        CuptiCallbackApi::CUDA_LAUNCH_KERNEL))
-    << "Failed to run callback for CUDA_LAUNCH_KERNEL";
+  EXPECT_TRUE(testCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+      CuptiCallbackApi::CUDA_LAUNCH_KERNEL))
+      << "Failed to run callback for CUDA_LAUNCH_KERNEL";
 
+  EXPECT_TRUE(testCallback(
+      CUPTI_CB_DOMAIN_RUNTIME_API,
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,
+      CuptiCallbackApi::CUDA_LAUNCH_KERNEL_EXC))
+      << "Failed to run callback for CUDA_LAUNCH_KERNEL_EXC";
 }
 
 TEST(CuptiCallbackApiTest, ContentionTest) {
@@ -147,7 +193,7 @@ TEST(CuptiCallbackApiTest, ContentionTest) {
   const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RUNTIME_API;
   const CUpti_CallbackId cbid = CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000;
   const CuptiCallbackApi::CuptiCallBackID kineto_cbid =
-    CuptiCallbackApi::CUDA_LAUNCH_KERNEL;
+      CuptiCallbackApi::CUDA_LAUNCH_KERNEL;
 
   bool ret = api->registerCallback(domain, kineto_cbid, empty_cb);
   EXPECT_TRUE(ret) << "Failed to add callback";
@@ -160,19 +206,18 @@ TEST(CuptiCallbackApiTest, ContentionTest) {
   // simulate callbacks being executed on multiple threads in parallel
   //  during this interval add a new atomic_callback.
   //  this test ensured mutual exclusion is working fine
-  auto read_fn = [&](int tid){
+  auto read_fn = [&](int tid) {
     auto start_ts = high_resolution_clock::now();
     for (int i = 0; i < iters; i++) {
       api->__callback_switchboard(domain, cbid, nullptr);
     }
-    auto runtime_ms = duration_cast<milliseconds>(
-      high_resolution_clock::now() - start_ts);
+    auto runtime_ms =
+        duration_cast<milliseconds>(high_resolution_clock::now() - start_ts);
     LOG(INFO) << "th " << tid << " done in " << runtime_ms.count() << " ms";
   };
 
-
   std::vector<std::thread> read_ths;
-  for (int i = 0; i< num_readers; i++) {
+  for (int i = 0; i < num_readers; i++) {
     read_ths.emplace_back(read_fn, i);
   }
 
@@ -183,7 +228,7 @@ TEST(CuptiCallbackApiTest, ContentionTest) {
     t.join();
   }
 
-  //EXPECT_GT(simple_cb_calls, 0)
+  // EXPECT_GT(simple_cb_calls, 0)
   //  << "Atomic callback should have been called at least once.";
 
   api->deleteCallback(domain, kineto_cbid, empty_cb);
@@ -191,14 +236,13 @@ TEST(CuptiCallbackApiTest, ContentionTest) {
 }
 
 TEST(CuptiCallbackApiTest, Bechmark) {
-
   constexpr int iters = 1000;
   // atomic bench a number of times to get a baseline
 
   const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RUNTIME_API;
   const CUpti_CallbackId cbid = CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000;
   const CuptiCallbackApi::CuptiCallBackID kineto_cbid =
-    CuptiCallbackApi::CUDA_LAUNCH_KERNEL;
+      CuptiCallbackApi::CUDA_LAUNCH_KERNEL;
 
   LOG(INFO) << "Iteration count = " << iters;
 
@@ -214,10 +258,9 @@ TEST(CuptiCallbackApiTest, Bechmark) {
   for (int i = 0; i < iters; i++) {
     (*cbfn)(domain, cbid, nullptr);
   }
-  auto delta_baseline_ns = duration_cast<nanoseconds>(
-      high_resolution_clock::now() - start_ts);
+  auto delta_baseline_ns =
+      duration_cast<nanoseconds>(high_resolution_clock::now() - start_ts);
   LOG(INFO) << "Baseline runtime  = " << delta_baseline_ns.count() << " ns";
-
 
   auto api = CuptiCallbackApi::singleton();
   bool ret = api->registerCallback(domain, kineto_cbid, cbfn);
@@ -233,12 +276,12 @@ TEST(CuptiCallbackApiTest, Bechmark) {
     api->__callback_switchboard(domain, cbid, nullptr);
   }
 
-  auto delta_callback_ns = duration_cast<nanoseconds>(
-      high_resolution_clock::now() - start_ts);
+  auto delta_callback_ns =
+      duration_cast<nanoseconds>(high_resolution_clock::now() - start_ts);
   LOG(INFO) << "Callback runtime  = " << delta_callback_ns.count() << " ns";
 
-  LOG(INFO) << "Callback runtime per iteration = " <<
-    (delta_callback_ns.count() - delta_baseline_ns.count()) / (double) iters
-    << " ns";
-
+  LOG(INFO) << "Callback runtime per iteration = "
+            << (delta_callback_ns.count() - delta_baseline_ns.count()) /
+          (double)iters
+            << " ns";
 }


### PR DESCRIPTION
Summary:
Previous errors when running on H100:

1) //kineto/libkineto:cupti_range_profiler_test_prog failed with CUPTI_ERROR_NOT_INITIALIZED 

2) kineto/libkineto:kineto_playground failed with CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED

Reviewed By: briancoutinho

Differential Revision: D55262038


