### PR TITLE
Log RocTracer, HIP Driver and HIP Runtime versions to Scuba

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -253,7 +253,12 @@ void CuptiActivityProfiler::logGpuVersions() {
             << "; Runtime: " << hipRuntimeVersion
             << "; Driver: " << hipDriverVersion;
 
-  // TODO: Log AMD versions to Scuba and verify with MAST.
+  LOGGER_OBSERVER_ADD_METADATA(
+      "roctracer_version", roctracerVersion);
+  LOGGER_OBSERVER_ADD_METADATA(
+      "hip_runtime_version", std::to_string(hipRuntimeVersion));
+  LOGGER_OBSERVER_ADD_METADATA(
+      "hip_driver_version", std::to_string(hipDriverVersion));
 #endif
 }
 


### PR DESCRIPTION
Summary: Log the versions for roctracer, hip driver and hip runtime. Using same logger observer api as CUDA / CUPTI.

Reviewed By: houseroad

Differential Revision: D57349962

Pulled By: aaronenyeshi


