### PR TITLE
Add Join to ManifoldTraceLogger

### DIFF
--- a/libkineto/src/ActivityTrace.h
+++ b/libkineto/src/ActivityTrace.h
@@ -37,7 +37,8 @@ class ActivityTrace : public ActivityTraceInterface {
     if (url.find("://") == url.npos) {
       prefix = "file://";
     }
-    memLogger_->log(*loggerFactory_.makeLogger(prefix + url));
+    memLogger_->setChromeLogger(loggerFactory_.makeLogger(prefix + url));
+    memLogger_->log(*memLogger_->getChromeLogger());
   }
 
  private:

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -104,6 +104,13 @@ class MemoryTraceLogger : public ActivityLogger {
     loggerMetadata_ = std::move(lmd);
   }
 
+  void setChromeLogger(std::shared_ptr<ActivityLogger> logger) {
+    chrome_logger_ = logger;
+  }
+
+  std::shared_ptr<ActivityLogger> getChromeLogger() {
+    return chrome_logger_;
+  }
  private:
 
   std::unique_ptr<Config> config_;
@@ -116,6 +123,7 @@ class MemoryTraceLogger : public ActivityLogger {
   std::unordered_map<std::string, std::string> metadata_;
   std::unordered_map<std::string, std::vector<std::string>> loggerMetadata_;
   int64_t endTime_{0};
+  std::shared_ptr<ActivityLogger> chrome_logger_;
 };
 
 } // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Summary:
Requested in this post:
https://fb.workplace.com/groups/ai.efficiency.tools.users/permalink/1777663889385748/

Manifold upload fail because resources get cleaned by parent thread while manifold is still being uploaded to. In order to fix this, we save any uploading thread as an instance variable. Then, during the destructor, join on this thread if possible. 

Currently, the ChromeLogger is declared locally so it will deconstruct once the save() function is exited. This will result in a join() happening right after the thread launch, which negates the use of multithreading. For this reason, we save the ChomeLogger  as an instance variable of the MemLogger. That way, when the CuptiTraceActivity class exits, the MemLogger will exit and then the ChromeLogger will exit thereby calling its destructor (which is much after the save() gets called).

Differential Revision: D57741999


