### PR TITLE
Fix DeviceProperties compile on AMD

### DIFF
--- a/libkineto/src/DeviceProperties.cpp
+++ b/libkineto/src/DeviceProperties.cpp
@@ -15,7 +15,7 @@
 #include <cuda_runtime.h>
 #include <cuda_occupancy.h>
 #elif defined(HAS_ROCTRACER)
-#include <hip_runtime.h>
+#include <hip/hip_runtime.h>
 #endif
 
 #include "Logger.h"


### PR DESCRIPTION
Summary: One of the headers is incorrect. Need to change to <hip/hip_runtime.h>

Differential Revision: D57788137


