### PR TITLE
Fix division by zero

### DIFF
--- a/tb_plugin/torch_tb_profiler/profiler/run_generator.py
+++ b/tb_plugin/torch_tb_profiler/profiler/run_generator.py
@@ -84,8 +84,12 @@ class RunGenerator:
                           '<b>{}: {}us</b><br>'
                           'Percentage: {}%'
                           '</div>')
-            percentage = round(100 * part_cost / costs.costs[ProfileRole.Total], 2)
-            return format_str.format(step_name, costs.costs[ProfileRole.Total], part_name, part_cost, percentage)
+
+            if (total_cost := costs.costs[ProfileRole.Total]) == 0:
+                percentage = 0.0
+            else:
+                percentage = round(part_cost / total_cost, 2)
+            return format_str.format(step_name, total_cost, part_name, part_cost, percentage)
 
         def build_avg_cost_dict(part_name: str, part_cost: float):
             cost_dict = {'name': part_name,


### PR DESCRIPTION
Summary:
```
W0530 09:23:50.932043 139856935265408 loader.py:102] Failed to parse profile data for Run train on 1716249387. Exception=float division by zero
Traceback (most recent call last):
  File "/mnt/xarfuse/uid-218352/391895d9-seed-nspid4026531836_cgpid68799117-ns-4026531841/torch_tb_profiler/profiler/loader.py", line 93, in _process_data
    profile = generator.generate_run_profile()
  File "/mnt/xarfuse/uid-218352/391895d9-seed-nspid4026531836_cgpid68799117-ns-4026531841/torch_tb_profiler/profiler/run_generator.py", line 32, in generate_run_profile
    profile_run.overview = self._generate_overview()
  File "/mnt/xarfuse/uid-218352/391895d9-seed-nspid4026531836_cgpid68799117-ns-4026531841/torch_tb_profiler/profiler/run_generator.py", line 131, in _generate_overview
    build_part_time_str(costs.costs[ProfileRole.Kernel], 'Kernel'),
  File "/mnt/xarfuse/uid-218352/391895d9-seed-nspid4026531836_cgpid68799117-ns-4026531841/torch_tb_profiler/profiler/run_generator.py", line 87, in build_part_time_str
    percentage = round(100 * part_cost / costs.costs[ProfileRole.Total], 2)
```

Differential Revision: D57975306


