### PR TITLE
Move root level TARGETS into subdirectories

### DIFF
--- a/libkineto/test/CuptiRangeProfilerApiTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerApiTest.cpp
@@ -10,12 +10,14 @@
 #include <array>
 #include <set>
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "include/libkineto.h"
 #include "include/Config.h"
 #include "src/CuptiRangeProfilerApi.h"
 
 #include "src/Logger.h"
-#include "test/CuptiRangeProfilerTestUtil.h"
+#include "CuptiRangeProfilerTestUtil.h"
 
 using namespace KINETO_NAMESPACE;
 

--- a/libkineto/test/CuptiRangeProfilerTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerTest.cpp
@@ -16,6 +16,8 @@
 #include <fcntl.h>
 #endif
 
+// TODO(T90238193)
+// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "include/libkineto.h"
 #include "include/Config.h"
 #include "include/output_base.h"
@@ -26,7 +28,7 @@
 #include "src/output_membuf.h"
 #include "src/Logger.h"
 
-#include "test/CuptiRangeProfilerTestUtil.h"
+#include "CuptiRangeProfilerTestUtil.h"
 
 using namespace KINETO_NAMESPACE;
 


### PR DESCRIPTION
Summary: Moving unit tests, samples, and stress test binaries into their respective subdirectories to make libkineto/TARGETS cleaner.

Reviewed By: davidberard98

Differential Revision: D58441051

Pulled By: aaronenyeshi
