### PR TITLE
Add JustKnobs to TSC CUPTI Callback

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -368,6 +368,14 @@ class Config : public AbstractConfig {
   // correct destruction order can be ensured.
   static std::shared_ptr<void> getStaticObjectsLifetimeHandle();
 
+  bool getTSCTimestampFlag() const{
+    return useTSCTimestamp_;
+  }
+
+  void setTSCTimestampFlag(bool flag) {
+    useTSCTimestamp_ = flag;
+  }
+
  private:
   explicit Config(const Config& other) = default;
 
@@ -486,6 +494,9 @@ class Config : public AbstractConfig {
   // CUPTI Device Buffer
   size_t cuptiDeviceBufferSize_;
   size_t cuptiDeviceBufferPoolLimit_;
+
+  // CUPTI Timestamp Format
+  bool useTSCTimestamp_{true};
 };
 
 constexpr char kUseDaemonEnvVar[] = "KINETO_USE_DAEMON";

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -27,6 +27,10 @@ namespace KINETO_NAMESPACE {
 using namespace libkineto;
 struct TraceSpan;
 
+// This function allows us to activate/deactivate TSC CUPTI callbacks 
+// via a killswitch
+bool& use_cupti_tsc();
+
 // These classes wrap the various CUPTI activity types
 // into subclasses of ITraceActivity so that they can all be accessed
 // using the ITraceActivity interface and logged via ActivityLogger.
@@ -43,7 +47,11 @@ struct CuptiActivity : public ITraceActivity {
   #if defined(_WIN32) || CUDA_VERSION < 11060
     return activity_.start;
   #else
-    return get_time_converter()(activity_.start);
+    if (use_cupti_tsc()){
+      return get_time_converter()(activity_.start);
+    } else {
+      return activity_.start;
+    }
   #endif
   }
 
@@ -51,7 +59,11 @@ struct CuptiActivity : public ITraceActivity {
   #if defined(_WIN32) || CUDA_VERSION < 11060
     return activity_.end - activity_.start;
   #else
-    return get_time_converter()(activity_.end) - get_time_converter()(activity_.start);
+    if (use_cupti_tsc()){
+      return get_time_converter()(activity_.end) - get_time_converter()(activity_.start);
+    } else {
+      return activity_.end - activity_.start;
+    }
   #endif
   }
   // TODO(T107507796): Deprecate ITraceActivity
@@ -121,7 +133,11 @@ struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
   #if defined(_WIN32) || CUDA_VERSION < 11060
     return activity_.start;
   #else
-    return get_time_converter()(activity_.start);
+    if (use_cupti_tsc()){
+      return get_time_converter()(activity_.start);
+    } else {
+      return activity_.start;
+    }
   #endif
   }
 
@@ -129,7 +145,11 @@ struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
   #if defined(_WIN32) || CUDA_VERSION < 11060
     return activity_.end - activity_.start;
   #else
-    return get_time_converter()(activity_.end) - get_time_converter()(activity_.start);
+    if (use_cupti_tsc()){
+      return get_time_converter()(activity_.end) - get_time_converter()(activity_.start);
+    } else {
+      return activity_.end - activity_.start;
+    }
   #endif
   }
 


### PR DESCRIPTION
Summary:
Add JustKnobs so that we can turn TSC CUPTI Callback on and off. Since we need to meet open source compliance, we need to first add a default value of true in the Config class. In the FBConfig class we then add a method that checks the JK and overrides the default value of true. We also add a static variable to the CuptiActivityProfiler which will be overriden by the Config value upon initialization. Once this is set, the profiler as well as all headers will use the flag that was set by the JK. Using this flag we can essentially use the TSC timestamp or system clock via killswitch. Since the JK can run asynchronously across many initializations, wrap it in a try/catch.

On top of this change, ApproximateClock is moved from src/ to include/. This is because it is a forward facing header so it makes sense to expose it as a public header. Added also to the bazel file as a public header.

Differential Revision: D58485370
