### PR TITLE
Revert CuptiRangeProfiler test include path

### DIFF
--- a/libkineto/test/CuptiRangeProfilerApiTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerApiTest.cpp
@@ -10,14 +10,12 @@
 #include <array>
 #include <set>
 
-// TODO(T90238193)
-// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "include/libkineto.h"
 #include "include/Config.h"
 #include "src/CuptiRangeProfilerApi.h"
 
 #include "src/Logger.h"
-#include "CuptiRangeProfilerTestUtil.h"
+#include "test/CuptiRangeProfilerTestUtil.h"
 
 using namespace KINETO_NAMESPACE;
 

--- a/libkineto/test/CuptiRangeProfilerTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerTest.cpp
@@ -16,8 +16,6 @@
 #include <fcntl.h>
 #endif
 
-// TODO(T90238193)
-// @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "include/libkineto.h"
 #include "include/Config.h"
 #include "include/output_base.h"
@@ -28,7 +26,7 @@
 #include "src/output_membuf.h"
 #include "src/Logger.h"
 
-#include "CuptiRangeProfilerTestUtil.h"
+#include "test/CuptiRangeProfilerTestUtil.h"
 
 using namespace KINETO_NAMESPACE;
 


### PR DESCRIPTION
Summary:
We need to change the include path back to
```
#include "test/CuptiRangeProfilerTestUtil.h"
```
Otherwise Github Actions runs into a failure.

Differential Revision: D58528947

Pulled By: aaronenyeshi
