### PR TITLE
Skip CUPTIRangeProfilerApiTest and CuptiRangeProfilerTest due to SEGFAULT in CUDA 12.4

### DIFF
--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -65,7 +65,9 @@ target_include_directories(CuptiRangeProfilerApiTest PRIVATE
     "${LIBKINETO_DIR}/src"
     "${CUDA_SOURCE_DIR}/include"
     "${CUPTI_INCLUDE_DIR}")
-gtest_discover_tests(CuptiRangeProfilerApiTest)
+# Skipping due to SEGFault in 12.4
+# Tracked here: https://github.com/pytorch/kineto/issues/949
+# gtest_discover_tests(CuptiRangeProfilerApiTest)
 
 # CuptiRangeProfilerConfigTest
 add_executable(CuptiRangeProfilerConfigTest CuptiRangeProfilerConfigTest.cpp)
@@ -94,7 +96,9 @@ target_include_directories(CuptiRangeProfilerTest PRIVATE
     "${LIBKINETO_DIR}/src"
     "${CUDA_SOURCE_DIR}/include"
     "${CUPTI_INCLUDE_DIR}")
-gtest_discover_tests(CuptiRangeProfilerTest)
+# Skipping due to SEGFault in 12.4
+# Tracked here: https://github.com/pytorch/kineto/issues/949
+# gtest_discover_tests(CuptiRangeProfilerTest)
 
 # CuptiStringsTest
 add_executable(CuptiStringsTest CuptiStringsTest.cpp)


### PR DESCRIPTION
Summary:
Github Actions CI on NVIDIA A10G instances are failing for these tests since the upgrade to 12.4:

19 - CuptiRangeProfilerApiTest.asyncLaunchUserRange (SEGFAULT)
20 - CuptiRangeProfilerApiTest.asyncLaunchAutoRange (SEGFAULT)
24 - CuptiRangeProfilerTest.UserRangeTest (SEGFAULT)
25 - CuptiRangeProfilerTest.AutoRangeTest (SEGFAULT)

We are tracking the issue here: https://github.com/pytorch/kineto/issues/949

Differential Revision: D58588836

Pulled By: aaronenyeshi
