### PR TITLE
Add API for JK Inside Config Validation

### DIFF
--- a/libkineto/include/AbstractConfig.h
+++ b/libkineto/include/AbstractConfig.h
@@ -85,6 +85,7 @@ class AbstractConfig {
 
   // TODO: Separate out each profiler type into features?
   virtual void printActivityProfilerConfig(std::ostream& s) const;
+  virtual void setActivityDependentConfig();
 
   // Helpers for use in handleOption
   // Split a string by delimiter and remove external white space

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -352,7 +352,8 @@ class Config : public AbstractConfig {
   void updateActivityProfilerRequestReceivedTime();
 
   void printActivityProfilerConfig(std::ostream& s) const override;
-
+  void setActivityDependentConfig() override;
+  
   void validate(const std::chrono::time_point<std::chrono::system_clock>&
                     fallbackProfileStartTime) override;
 

--- a/libkineto/src/AbstractConfig.cpp
+++ b/libkineto/src/AbstractConfig.cpp
@@ -191,4 +191,10 @@ void AbstractConfig::printActivityProfilerConfig(std::ostream& s) const {
   }
 }
 
+void AbstractConfig::setActivityDependentConfig() {
+  for (const auto& feature_cfg : featureConfigs_) {
+    feature_cfg.second->setActivityDependentConfig();
+  }
+}
+
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -511,6 +511,7 @@ void Config::validate(
   if (selectedActivityTypes_.size() == 0) {
     selectDefaultActivityTypes();
   }
+  setActivityDependentConfig();
 }
 
 void Config::setReportPeriod(milliseconds msecs) {
@@ -548,6 +549,10 @@ void Config::printActivityProfilerConfig(std::ostream& s) const {
     << fmt::format("{}", fmt::join(activities, ",")) << std::endl;
 
   AbstractConfig::printActivityProfilerConfig(s);
+}
+
+void Config::setActivityDependentConfig(){
+  AbstractConfig::setActivityDependentConfig();
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiRangeProfilerConfig.cpp
+++ b/libkineto/src/CuptiRangeProfilerConfig.cpp
@@ -63,6 +63,8 @@ void CuptiRangeProfilerConfig::printActivityProfilerConfig(std::ostream& s) cons
   }
 }
 
+void CuptiRangeProfilerConfig::setActivityDependentConfig(){}
+
 void CuptiRangeProfilerConfig::registerFactory() {
   Config::addConfigFactory(
       kCuptiProfilerConfigName,

--- a/libkineto/src/CuptiRangeProfilerConfig.h
+++ b/libkineto/src/CuptiRangeProfilerConfig.h
@@ -57,7 +57,7 @@ class CuptiRangeProfilerConfig : public AbstractConfig {
   }
 
   void printActivityProfilerConfig(std::ostream& s) const override;
-
+  void setActivityDependentConfig() override;
   static void registerFactory();
  protected:
   AbstractConfig* cloneDerived(AbstractConfig& parent) const override {


### PR DESCRIPTION
Summary: Right now we initialize all the configuration children when config is initialized. This is fine for the most part except for the fact that we set the selected activities only after the config is initialized. This makes our JustKnobs calls always get ignored. We can fix this by calling an API to check the Knobs after the parent is validated (we set activities before validation)

Differential Revision: D58759304
