### PR TITLE
Remove global using namespace

### DIFF
--- a/libkineto/include/ThreadUtil.h
+++ b/libkineto/include/ThreadUtil.h
@@ -28,7 +28,3 @@ std::string processName(int32_t pid);
 std::vector<std::pair<int32_t, std::string>> pidCommandPairsOfAncestors();
 
 } // namespace libkineto
-
-#ifdef HAS_ROCTRACER
-using namespace libkineto;
-#endif


### PR DESCRIPTION
Summary:
Fixing this:

```
kineto/libkineto/include/ThreadUtil.h:33:17: error: using namespace directive in global context in header [-Werror,-Wheader-hygiene]
   33 | using namespace libkineto;
      |                 ^
1 error generated.
```

Differential Revision: D58904139
