### PR TITLE
Add Dist Info for On-Demand NCCL Traces

### DIFF
--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <ostream>
 #include <ratio>
+#include <string>
 #include <thread>
 #include <unordered_map>
 
@@ -31,6 +32,28 @@ namespace KINETO_NAMESPACE {
 namespace KINETO_NAMESPACE {
 
 class Config;
+
+
+struct pgConfig {
+  pgConfig() = default;
+  std::string pg_name{""};
+  std::string pg_desc{""};
+  std::string backend_config{""};
+  std::string pg_size{""};
+  std::string ranks{""};
+
+};
+
+struct DistributedInfo {
+  DistributedInfo() = default;
+
+  std::string backend{""};
+  std::string rank{""};
+  std::string world_size{""};
+  std::string pg_count{""};
+  std::string nccl_version{""};
+  bool distInfo_present_{false};
+};
 
 class ChromeTraceLogger : public libkineto::ActivityLogger {
  public:
@@ -91,9 +114,16 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
 
   void sanitizeStrForJSON(std::string& value);
 
+  void addOnDemandDistMetadata();
+
   std::string fileName_;
   std::string tempFileName_;
   std::ofstream traceOf_;
+  DistributedInfo distInfo_ = DistributedInfo();
+  // Map of all observed process groups to their configs in trace. Key is pg_name, 
+  // value is pgConfig that will be used to populate pg_config in 
+  // distributedInfo of trace
+  std::unordered_map<std::string, pgConfig> pgMap = {};
 };
 
 //std::chrono header start


### PR DESCRIPTION
Summary:
Currently, auto-trace uses pytorches c10d.distributed library to set up the "distributedInfo" field in the chrome tracing. This makes sense as all the process groups are initialized and maintained in python. Because of this, however, on-demand is unable to retrieve this information directly as it has no access to the python side of a graph. However, we can glean the process group information based on the information that is added in to the dispatcher.

In this diff, we keep a global to enumerate all the nccl information via the args in the collectives as we print them out to the trace. At the end of the trace we output the distributed information. In order to prevent double counting for auto-trace, we skip if there was previously distributedInfo outputted to the trace.

Fixes https://github.com/pytorch/kineto/issues/885

Differential Revision: D58736045
