### PR TITLE
fix static variable client access vialotion in DamonConfigLoader 

### DIFF
--- a/libkineto/src/DaemonConfigLoader.cpp
+++ b/libkineto/src/DaemonConfigLoader.cpp
@@ -13,14 +13,15 @@
 #include "Logger.h"
 #include "ConfigLoader.h"
 #include "DaemonConfigLoader.h"
-#include "IpcFabricConfigClient.h"
 
 namespace KINETO_NAMESPACE {
 
 // TODO : implications of this singleton being thread safe on forks?
-IpcFabricConfigClient* getConfigClient() {
-  static auto client = std::make_unique<IpcFabricConfigClient>();
-  return client.get();
+IpcFabricConfigClient* DaemonConfigLoader::getConfigClient() {
+  if (!configClient){
+    configClient = std::make_unique<IpcFabricConfigClient>();
+  }
+  return configClient.get();
 }
 
 std::string DaemonConfigLoader::readBaseConfig() {

--- a/libkineto/src/DaemonConfigLoader.h
+++ b/libkineto/src/DaemonConfigLoader.h
@@ -14,6 +14,7 @@
 #if !USE_GOOGLE_LOG
 #include <memory>
 #endif // !USE_GOOGLE_LOG
+#include "IpcFabricConfigClient.h"
 
 namespace KINETO_NAMESPACE {
 
@@ -53,7 +54,11 @@ class DaemonConfigLoader : public IDaemonConfigLoader {
 
   void setCommunicationFabric(bool enabled) override;
 
+  IpcFabricConfigClient* getConfigClient();
+
   static void registerFactory();
+private:
+  std::unique_ptr<IpcFabricConfigClient> configClient;
 };
 #endif // __linux__
 


### PR DESCRIPTION
As discussed in pytorch issue [#129626](https://github.com/pytorch/pytorch/issues/129626) , `updateThread` of `Config` will keep on accessing `client` after main thread quits.  But when main thread quits,  `client` will be destructed.  Functions in `updateThread` may use a dangling pointer of `client`, which will cause invalid memory access, and finally, `Segment fault` occurs, a core file will be generated, which  doesn't behave as expected. 