### PR TITLE
Setters and getters for trace IDs

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -40,6 +40,11 @@ void ActivityProfilerController::setLoggerCollectorFactory(
     std::function<std::shared_ptr<LoggerCollector>()> factory) {
   loggerCollectorFactory() = factory();
 }
+
+std::shared_ptr<LoggerCollector>
+ActivityProfilerController::getLoggerCollector() {
+  return loggerCollectorFactory();
+}
 #endif // !USE_GOOGLE_LOG
 
 ActivityProfilerController::ActivityProfilerController(

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -40,6 +40,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   ~ActivityProfilerController();
 
 #if !USE_GOOGLE_LOG
+  static std::shared_ptr<LoggerCollector> getLoggerCollector();
   static void setLoggerCollectorFactory(
       std::function<std::shared_ptr<LoggerCollector>()> factory);
 #endif // !USE_GOOGLE_LOG

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1054,12 +1054,10 @@ void CuptiActivityProfiler::configure(
 
   // Set useful metadata into the logger.
   LOGGER_OBSERVER_SET_TRACE_DURATION_MS(config_->activitiesDuration().count());
+  LOGGER_OBSERVER_SET_TRACE_ID(config_->requestTraceID());
+  LOGGER_OBSERVER_SET_GROUP_TRACE_ID(config_->requestGroupTraceID());
   if (!config_->requestTraceID().empty()) {
-    LOGGER_OBSERVER_SET_TRACE_ID(config_->requestTraceID());
     addMetadata("trace_id", "\"" + config_->requestTraceID() + "\"");
-  }
-  if (!config_->requestGroupTraceID().empty()) {
-    LOGGER_OBSERVER_SET_GROUP_TRACE_ID(config_->requestGroupTraceID());
   }
 
 #if defined(HAS_CUPTI) || defined(HAS_ROCTRACER)


### PR DESCRIPTION
Summary:
This commit moves the trace ID initialization logic to be inline with how ActivityProfilers interact with LoggerObservers by setting a default local trace ID when a profiler config does not contain a trace ID.

The USTLoggerCollector, which is our internal LoggerObserver will record the trace ID for a given environment (which is a PID today) using the `setTraceID` method that all LoggerObservers must staisfy. Additionally any internal calls to read this trace ID, for example from our ManifoldChromeTrace logger, may use a special `getTraceID` method that ships with `USTLoggerCollector`.

Group trace IDs are handled accordingly.

Differential Revision: D60267172
