### PR TITLE
Add Logging for Empty Traces

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -136,6 +136,22 @@ class CuptiActivityProfiler {
     logger_ = logger;
   }
 
+ inline void setCpuActivityPresent(bool val){
+    cpuActivityPresent_ = val;
+  }
+
+  inline void setGpuActivityPresent(bool val){
+    gpuActivityPresent_ = val;
+  } 
+
+  inline bool gpuActivityPresent(){
+    return gpuActivityPresent_;
+  }
+
+  inline bool traceNonEmpty(){
+    return cpuActivityPresent_ || gpuActivityPresent_;
+  }
+
   // Synchronous control API
   void startTrace(
       const std::chrono::time_point<std::chrono::system_clock>& now) {
@@ -443,6 +459,8 @@ class CuptiActivityProfiler {
   profilerOverhead setupOverhead_;
 
   bool cpuOnly_{false};
+  bool cpuActivityPresent_{false};
+  bool gpuActivityPresent_{false};
 
   // ***************************************************************************
   // Below state is shared with external threads.


### PR DESCRIPTION
Summary: Recently, we have had users seen empty traces when the system is idle leading to confusion as to whether it was caused by a bug in kineto formatting or not. This diff adds further logging to ensure that the user is aware that kineto finds no valid trace events and is expecting an empty trace.

Differential Revision: D60311331
