### PR TITLE
Correct the condition when setting External id

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -335,9 +335,10 @@ void ChromeTraceLogger::handleActivity(
   }
 
   std::string arg_values = "";
-  if (op.correlationId() != 0) {
-    arg_values.append(fmt::format("\"External id\": {}",
-      op.linkedActivity() ? op.linkedActivity()->correlationId() : op.correlationId()));
+  if (op.linkedActivity() && op.linkedActivity()->correlationId() != 0) {
+    arg_values.append(fmt::format("\"External id\": {}", op.linkedActivity()->correlationId()));
+  } else if (op.correlationId() != 0) {
+    arg_values.append(fmt::format("\"External id\": {}", op.correlationId()));
   }
   std::string op_metadata = op.metadataJson();
   sanitizeStrForJSON(op_metadata);


### PR DESCRIPTION
The `External id` will be set to op.linkedActivity()->correlationId() if op.linkedActivity() is not nullptr. So in `if` condition we should check if op.linkedActivity()->correlationId() is 0.