### PR TITLE
Auto-init when CUDA_INJECTION64_PATH=none is set

### DIFF
--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -225,7 +225,7 @@ void libkineto_init(bool cpuOnly, bool logOnError) {
 }
 
 // The cuda driver calls this function if the CUDA_INJECTION64_PATH environment
-// variable is set
+// variable is set. Should be skipped if unset or CUDA_INJECTION64_PATH=none.
 int InitializeInjection(void) {
   LOG(INFO) << "Injection mode: Initializing libkineto";
   libkineto_init(false /*cpuOnly*/, true /*logOnError*/);


### PR DESCRIPTION
Summary:
CUDA_INJECTION64_PATH being set causes Kineto to skip auto-init. However CUDA_INJECTION64_PATH=none is a commonly used config option, and we should not skip auto-init since the path is set to none.

This diff fixes the scenario where `CUDA_INJECTION64_PATH=none` is set and on-demand trace should be enabled.

Reviewed By: briancoutinho

Differential Revision: D61478101

Pulled By: aaronenyeshi
