### PR TITLE
Enable `-Wheader-hygiene` for kineto/PACKAGE +1

### DIFF
--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -18,6 +18,7 @@
 #include "ThreadUtil.h"
 #include "Demangle.h"
 
+using namespace libkineto;
 using namespace std::chrono;
 
 class Flush

--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -63,8 +63,6 @@ static timestamp_t timespec_to_ns(const timespec& time) {
   return ((timestamp_t)time.tv_sec * 1000000000) + time.tv_nsec;
 }
 
-using namespace libkineto;
-
 class ApiIdList {
  public:
   ApiIdList();


### PR DESCRIPTION
Summary:
Per title

#buildmore - Be thorough

#buildsonlynotests - No runtime effects!

 - If you approve of this diff, please use the "Accept & Ship" button

no-ig-test - Doesn't require Instagram testing.

(1 file modified.)

Reviewed By: dmm-fb

Differential Revision: D56539017
