### PR TITLE
Extend CPU User Annotations to End of Profile

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -397,6 +397,9 @@ void CuptiActivityProfiler::processCpuTrace(
               const std::unique_ptr<GenericTraceActivity>>::value,
           "handleActivity is unsafe and relies on the caller to maintain not "
           "only lifetime but also address stability.");
+      if (act->type() ==  ActivityType::USER_ANNOTATION && act->duration()<=0){
+        act->endTime = captureWindowEndTime_;
+      }
       logger.handleActivity(*act);
     }
     clientActivityTraceMap_[act->correlationId()] = &span_pair;


### PR DESCRIPTION
Summary: If a CPU User Annotation doesn't end by the time the profile ends, the annotation is marked as a 0-length event. This can be annoying to look at because it seems like profiler just never got the annotation event when it did. Lets set the end time to the end of profiling.

Differential Revision: D62604717
