### PR TITLE
Align Roctracer to TSC Clock

### DIFF
--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -52,6 +52,7 @@ class RoctracerActivityApi {
     const std::set<ActivityType>& selected_activities);
   void clearActivities();
   void teardownContext() {}
+  void setTimeOffset(timestamp_t toffset);
 
   virtual int processActivities(
     std::function<void(const roctracerBase*)> handler,
@@ -63,6 +64,7 @@ class RoctracerActivityApi {
 
  private:
   bool registered_{false};
+  timestamp_t toffset_{0};
 
   // Enabled Activity Filters
   uint32_t activityMask_{0};


### PR DESCRIPTION
Summary: Right now we align Roctracer events to system clock blindly regardless of what we are using in torch.profiler. We should use a clock based on  what is defined instead. This wont fix overlapping kernel events since we do a static offset when aligning but it will help make sure that kernel events always happen after kernel launches

Reviewed By: aaronenyeshi, briancoutinho

Differential Revision: D62984793
