### PR TITLE
Add 1ns buffer to Roctracer Events

### DIFF
--- a/libkineto/src/RoctracerActivity.h
+++ b/libkineto/src/RoctracerActivity.h
@@ -101,6 +101,15 @@ struct GpuActivity : public RoctracerActivity<roctracerAsyncRow> {
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
 
+  // Add small buffer to fix visual error created by https://github.com/ROCm/roctracer/issues/105
+  // Once this is resolved we can use ifdef to handle having this buffer or not based on version
+  int64_t timestamp() const override {
+    return activity_.begin + 1;
+  }
+  int64_t duration() const override {
+    return activity_.end - (activity_.begin + 1);
+  }
+
  private:
    ActivityType type_;
 };


### PR DESCRIPTION
Summary: As reported in https://github.com/ROCm/roctracer/issues/105, there is an issue where event starts and ends can "tie". This can cause a visual issue in the traces. Lets add a tiny buffer so the events are separate. At the single nanosecond level, the timings are inaccurate anyways so it doesn't really hurt to add this buffer in the meanwhile. Remove/wrap in ifdef once it is issue is resolved

Differential Revision: D63296093
