### PR TITLE
Remove Stream from HIP Launches

### DIFF
--- a/libkineto/src/RoctracerActivity_inl.h
+++ b/libkineto/src/RoctracerActivity_inl.h
@@ -170,12 +170,10 @@ inline const std::string RuntimeActivity<roctracerKernelRow>::metadataJson() con
 
   return fmt::format(R"JSON(
       {}"cid": {}, "correlation": {},
-      "stream": "{}",
       "grid": [{}, {}, {}],
       "block": [{}, {}, {}],
       "shared memory": {})JSON",
       kernel, raw().cid, raw().id,
-      reinterpret_cast<void*>(raw().stream),
       raw().gridX, raw().gridY, raw().gridZ,
       raw().workgroupX, raw().workgroupY, raw().workgroupZ,
       raw().groupSegmentSize);
@@ -183,15 +181,9 @@ inline const std::string RuntimeActivity<roctracerKernelRow>::metadataJson() con
 
 template<>
 inline const std::string RuntimeActivity<roctracerCopyRow>::metadataJson() const {
-  std::string stream = "";
-  if ((raw().cid == HIP_API_ID_hipMemcpyAsync) || (raw().cid == HIP_API_ID_hipMemcpyWithStream)) {
-    stream = fmt::format(R"JSON(
-    "stream": "{}", )JSON",
-    reinterpret_cast<void*>(raw().stream));
-  }
   return fmt::format(R"JSON(
-      {}"cid": {}, "correlation": {}, "src": "{}", "dst": "{}", "size": "{}", "kind": "{}")JSON",
-      stream, raw().cid, raw().id, raw().src, raw().dst, raw().size, fmt::underlying(raw().kind));
+      "cid": {}, "correlation": {}, "src": "{}", "dst": "{}", "size": "{}", "kind": "{}")JSON",
+      raw().cid, raw().id, raw().src, raw().dst, raw().size, fmt::underlying(raw().kind));
 }
 
 template<>


### PR DESCRIPTION
Summary: We would like for AMD traces to match CUDA matches as closely as possible. Right now we are adding stream to the CPU launches whereas in CUDA we do not. This will make zoomer try to process these events when they shouldn't. To make matters worse, the stream id that is embedded in the cpu event don't even match the GPU event. For this reason, lets get rid of them all together.

Differential Revision: D63798661


