### PR TITLE
Fix Clear On Fork

### DIFF
--- a/libkineto/include/ThreadUtil.h
+++ b/libkineto/include/ThreadUtil.h
@@ -27,4 +27,8 @@ std::string processName(int32_t pid);
 // and its parents.
 std::vector<std::pair<int32_t, std::string>> pidCommandPairsOfAncestors();
 
+// Resets all cached Thread local state, this must be done on
+// forks to prevent stale values from being retained.
+void resetTLS();
+
 } // namespace libkineto

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -171,7 +171,9 @@ void ConfigLoader::stopThread() {
       std::lock_guard<std::mutex> lock(updateThreadMutex_);
       updateThreadCondVar_.notify_one();
     }
-    updateThread_->join();
+    if (updateThread_->joinable()) {
+      updateThread_->join();
+    }
     updateThread_ = nullptr;
   }
 }

--- a/libkineto/src/ThreadUtil.cpp
+++ b/libkineto/src/ThreadUtil.cpp
@@ -39,6 +39,14 @@ thread_local int32_t _tid = 0;
 thread_local int32_t _sysTid = 0;
 }
 
+// Resets all cached Thread local state, this must be done on
+// forks to prevent stale values from being retained.
+void resetTLS() {
+  _pid = 0;
+  _tid = 0;
+  _sysTid = 0;
+}
+
 int32_t processId(bool cache) {
   int32_t pid = 0;
   if (!_pid) {

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -121,6 +121,9 @@ extern "C" {
 
 // Return true if no CUPTI errors occurred during init
 void libkineto_init(bool cpuOnly, bool logOnError) {
+  // register fork handler
+  pthread_atfork(nullptr, nullptr, &resetTLS);
+
   // Start with initializing the log level
   const char* logLevelEnv = getenv("KINETO_LOG_LEVEL");
   if (logLevelEnv) {


### PR DESCRIPTION
Summary: Threads can have the same PID and TID if forked after they have been cached. This can be dangerous especially if you have already ran a profiler workload and then decide to fork after and run another workload. To get around this, we add a routine to always clear the PID/TID when forking. Also, we make sure that the ConfigLoader will not wait on a thread when destructing since the forked thread will have no spawned child if the configuration has been already enabled.

Differential Revision: D63924780


