### PR TITLE
Fix Windows Build

### DIFF
--- a/libkineto/src/ThreadUtil.cpp
+++ b/libkineto/src/ThreadUtil.cpp
@@ -18,8 +18,10 @@
 #include <locale>
 #define WIN32_LEAN_AND_MEAN
 #define NOGDI
-#include <processthreadsapi.h>
-#include <windows.h>
+#include <windows.h> // @manual
+// windows.h has to come first. Don't alphabetize, clang-format.
+
+#include <processthreadsapi.h> // @manual
 #undef ERROR
 #endif // _WIN32
 


### PR DESCRIPTION
Summary: https://github.com/pytorch/kineto/commit/d260fc03ba474766b950a4c27f4aba2de2b9e145 broke Kineto on Windows because it reordered includes. Reordering them back in this diff.

Differential Revision: D64213969


