### PR TITLE
Fix the issue of incorrect External id for non-PyTorch activities

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -351,11 +351,22 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
   int external_id = 0;
   if (op.linkedActivity()) {
     external_id = op.linkedActivity()->correlationId();
-  } else if (op.type() == libkineto::ActivityType::CPU_OP ||
-      op.type() == libkineto::ActivityType::CPU_INSTANT_EVENT ||
-      op.type() == libkineto::ActivityType::USER_ANNOTATION ||
-      op.type() == libkineto::ActivityType::PYTHON_FUNCTION) {
-    external_id = op.correlationId();
+  } else {
+    // Some runtime events and kernels may not have a linked activity,
+    // should not set an "External id" for them. Otherwise, these events
+    // may be incorrectly linked to the other external events.
+    static const std::set<libkineto::ActivityType> excludedTypes = {
+      libkineto::ActivityType::GPU_MEMCPY,
+      libkineto::ActivityType::GPU_MEMSET,
+      libkineto::ActivityType::CONCURRENT_KERNEL,
+      libkineto::ActivityType::CUDA_RUNTIME,
+      libkineto::ActivityType::CUDA_DRIVER,
+      libkineto::ActivityType::PRIVATEUSE1_RUNTIME,
+      libkineto::ActivityType::PRIVATEUSE1_DRIVER
+    };
+    if (excludedTypes.find(op.type()) == excludedTypes.end()) {
+      external_id = op.correlationId();
+    }
   }
   std::string arg_values = "";
   if (external_id != 0) {

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -365,14 +365,13 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
     // should not set an "External id" for them. Otherwise, these events
     // may be incorrectly linked to the other external events.
     static const std::set<libkineto::ActivityType> excludedTypes = {
-      libkineto::ActivityType::GPU_MEMCPY,
-      libkineto::ActivityType::GPU_MEMSET,
-      libkineto::ActivityType::CONCURRENT_KERNEL,
-      libkineto::ActivityType::CUDA_RUNTIME,
-      libkineto::ActivityType::CUDA_DRIVER,
-      libkineto::ActivityType::PRIVATEUSE1_RUNTIME,
-      libkineto::ActivityType::PRIVATEUSE1_DRIVER
-    };
+        libkineto::ActivityType::GPU_MEMCPY,
+        libkineto::ActivityType::GPU_MEMSET,
+        libkineto::ActivityType::CONCURRENT_KERNEL,
+        libkineto::ActivityType::CUDA_RUNTIME,
+        libkineto::ActivityType::CUDA_DRIVER,
+        libkineto::ActivityType::PRIVATEUSE1_RUNTIME,
+        libkineto::ActivityType::PRIVATEUSE1_DRIVER};
     if (excludedTypes.find(op.type()) == excludedTypes.end()) {
       external_id = op.correlationId();
     }

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -348,12 +348,18 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
     duration += 2; // Still need it to end at the original point rounded up.
   }
 
+  int external_id = 0;
+  if (op.linkedActivity()) {
+    external_id = op.linkedActivity()->correlationId();
+  } else if (op.type() == libkineto::ActivityType::CPU_OP ||
+      op.type() == libkineto::ActivityType::CPU_INSTANT_EVENT ||
+      op.type() == libkineto::ActivityType::USER_ANNOTATION ||
+      op.type() == libkineto::ActivityType::PYTHON_FUNCTION) {
+    external_id = op.correlationId();
+  }
   std::string arg_values = "";
-  if (op.linkedActivity() && op.linkedActivity()->correlationId() != 0) {
-    arg_values.append(fmt::format(
-        "\"External id\": {}", op.linkedActivity()->correlationId()));
-  } else if (op.correlationId() != 0) {
-    arg_values.append(fmt::format("\"External id\": {}", op.correlationId()));
+  if (external_id != 0) {
+    arg_values.append(fmt::format("\"External id\": {}", external_id));
   }
   std::string op_metadata = op.metadataJson();
   sanitizeStrForJSON(op_metadata);


### PR DESCRIPTION
Sorry about the incomplete patch addressing the issue of setting the external ID.
I think only the PyTorch activities should set the external id to op.correlationId(), while the external ids for the runtimes and kernels should be set to op.linkedActivity()->correlationId().
However, there may be cases where the linkedActivity() for the runtime or kernel is nullptr (for example, when directly launching a kernel using a pybind mapping interface). In such cases, the external id should be empty, not set to op.correlationId().