### PR TITLE
Add UST Logging for Empty Trace

### DIFF
--- a/libkineto/include/ILoggerObserver.h
+++ b/libkineto/include/ILoggerObserver.h
@@ -15,6 +15,10 @@ constexpr char kWarmUpStage[] = "Warm Up";
 constexpr char kCollectionStage[] = "Collection";
 constexpr char kPostProcessingStage[] = "Post Processing";
 
+// Special string in UST for determining if traces are empty
+constexpr char kEmptyTrace[] =
+    "No Valid Trace Events (CPU/GPU) found. Outputting empty trace.";
+
 #if !USE_GOOGLE_LOG
 
 #include <map>

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -375,8 +375,7 @@ void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
   }
 #endif // HAS_ROCTRACER
   if (!traceNonEmpty()) {
-    LOG(WARNING)
-        << "No Valid Trace Events (CPU/GPU) found. Outputting empty trace.";
+    LOG(WARNING) << kEmptyTrace;
   }
 
   for (const auto& session : sessions_) {


### PR DESCRIPTION
Summary: There was a request to have UST log when traces are empty. We make a special case in the logger to log when the desired string is encountered

Differential Revision: D64559516


