### PR TITLE
use `make_shared` to create singleton

### DIFF
--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -159,8 +159,7 @@ void CuptiCallbackApi::__callback_switchboard(
 
 std::shared_ptr<CuptiCallbackApi> CuptiCallbackApi::singleton() {
   static const std::shared_ptr<CuptiCallbackApi> instance = [] {
-    std::shared_ptr<CuptiCallbackApi> inst =
-        std::shared_ptr<CuptiCallbackApi>(new CuptiCallbackApi());
+    std::shared_ptr<CuptiCallbackApi> inst = std::make_shared<CuptiCallbackApi>();
     return inst;
   }();
   return instance;

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -159,7 +159,7 @@ void CuptiCallbackApi::__callback_switchboard(
 
 std::shared_ptr<CuptiCallbackApi> CuptiCallbackApi::singleton() {
   static const std::shared_ptr<CuptiCallbackApi> instance = [] {
-    std::shared_ptr<CuptiCallbackApi> inst = 
+    std::shared_ptr<CuptiCallbackApi> inst =
         std::make_shared<CuptiCallbackApi>();
     return inst;
   }();

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -159,7 +159,8 @@ void CuptiCallbackApi::__callback_switchboard(
 
 std::shared_ptr<CuptiCallbackApi> CuptiCallbackApi::singleton() {
   static const std::shared_ptr<CuptiCallbackApi> instance = [] {
-    std::shared_ptr<CuptiCallbackApi> inst = std::make_shared<CuptiCallbackApi>();
+    std::shared_ptr<CuptiCallbackApi> inst = 
+        std::make_shared<CuptiCallbackApi>();
     return inst;
   }();
   return instance;


### PR DESCRIPTION
Hi, this change fixes a compiler-related issue in our internal environment.

`make_shared` is recommended over `std::shared_ptr(new)`. Although it's not broken in the open-source version, I still believe it is valuable to merge this change.