### PR TITLE
[Kineto] Add Config-specified "trace_id" to JSON metadata in ChromeTraceLogger

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1044,6 +1044,7 @@ void CuptiActivityProfiler::configure(
   LOGGER_OBSERVER_SET_TRACE_DURATION_MS(config_->activitiesDuration().count());
   if (!config_->requestTraceID().empty()) {
     LOGGER_OBSERVER_SET_TRACE_ID(config_->requestTraceID());
+    addMetadata("trace_id", "\"" + config_->requestTraceID() + "\"");
   }
   if (!config_->requestGroupTraceID().empty()) {
     LOGGER_OBSERVER_SET_GROUP_TRACE_ID(config_->requestGroupTraceID());


### PR DESCRIPTION
Summary: Add "trace_id" to JSON output for ChromeTraceLogger

Differential Revision: D65634044


