### PR TITLE
Disable NvPerfMetric for CUDA 12.6.0

### DIFF
--- a/libkineto/src/CuptiNvPerfMetric.cpp
+++ b/libkineto/src/CuptiNvPerfMetric.cpp
@@ -9,7 +9,7 @@
 #ifdef HAS_CUPTI
 #include <cuda_runtime_api.h>
 #if defined(USE_CUPTI_RANGE_PROFILER) && defined(CUDART_VERSION) && \
-    CUDART_VERSION > 10000
+    CUDART_VERSION > 10000 && CUDART_VERSION < 12060
 #include <nvperf_cuda_host.h>
 #include <nvperf_host.h>
 #include <nvperf_target.h>
@@ -46,7 +46,7 @@ namespace nvperf {
 // After CUDA RT 11.04, the structure has changed.
 // TODO update the structure NVPA_RawMetricsConfig to support 11.04
 #if defined(USE_CUPTI_RANGE_PROFILER) && defined(CUDART_VERSION) && \
-    CUDART_VERSION > 10000
+    CUDART_VERSION > 10000 && CUDART_VERSION < 12060
 
 bool getRawMetricRequests(
     NVPA_MetricsContext* metricsContext,


### PR DESCRIPTION
Summary: 12.6.0 changes all the headers and APIs used in this file so we need to disable it for now

Differential Revision: D66265298


