### PR TITLE
Fix CPU Trace Message

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1368,10 +1368,10 @@ const time_point<system_clock> CuptiActivityProfiler::performRunLoopStep(
 void CuptiActivityProfiler::finalizeTrace(
     const Config& config,
     ActivityLogger& logger) {
-  LOG(INFO) << "Traces Recorded:";
+  LOG(INFO) << "CPU Traces Recorded:";
   {
     for (const auto& it : iterationCountMap_) {
-      LOG(INFO) << it.first << ": " << it.second << " iterations";
+      LOG(INFO) << it.first << ": " << it.second << " span(s) recorded";
     }
     iterationCountMap_.clear();
   }


### PR DESCRIPTION
Summary: Several users have complained about how the current CPU trace iteration message is confusing. They tend to think that this means there is only one step iteration recorded. Lets change the wording to make it clear it is an entire span that is being recorded. Lets also make it clear this is for specifically CPU

Reviewed By: aaronenyeshi

Differential Revision: D66683879


