### PR TITLE
Make ITraceActivity::flowId return int64_t instead of int

### DIFF
--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -75,7 +75,7 @@ class GenericTraceActivity : public ITraceActivity {
     return flow.type;
   }
 
-  int flowId() const override {
+  int64_t flowId() const override {
     return flow.id;
   }
 

--- a/libkineto/include/ITraceActivity.h
+++ b/libkineto/include/ITraceActivity.h
@@ -35,7 +35,7 @@ struct ITraceActivity {
   virtual int64_t correlationId() const = 0;
   // Part of a flow, identified by flow id and type
   virtual int flowType() const = 0;
-  virtual int flowId() const = 0;
+  virtual int64_t flowId() const = 0;
   virtual bool flowStart() const = 0;
   virtual ActivityType type() const = 0;
   virtual const std::string name() const = 0;

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -80,7 +80,7 @@ struct CuptiActivity : public ITraceActivity {
   int flowType() const override {
     return kLinkAsyncCpuGpu;
   }
-  int flowId() const override {
+  int64_t flowId() const override {
     return correlationId();
   }
   const T& raw() const {

--- a/libkineto/src/RoctracerActivity.h
+++ b/libkineto/src/RoctracerActivity.h
@@ -58,7 +58,7 @@ struct RoctracerActivity : public ITraceActivity {
   int flowType() const override {
     return kLinkAsyncCpuGpu;
   }
-  int flowId() const override {
+  int64_t flowId() const override {
     return correlationId();
   }
   const T& raw() const {


### PR DESCRIPTION
Summary: RoctracerActivity::flowId and CuptiActivity::flowId return correlationId(), which is an int64.

Differential Revision: D66827501


