### PR TITLE
[XPU PTI] Add following eligible unified runtime ops for drawing flow in traced JSON file

### DIFF
--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.cpp
@@ -10,14 +10,21 @@ std::vector<std::array<unsigned char, 16>>
     XpuptiActivityProfilerSession::deviceUUIDs_ = {};
 std::vector<std::string> XpuptiActivityProfilerSession::correlateRuntimeOps_ = {
     "piextUSMEnqueueFill",
+    "urEnqueueUSMFill",
     "piextUSMEnqueueFill2D",
+    "urEnqueueUSMFill2D",
     "piextUSMEnqueueMemcpy",
+    "urEnqueueUSMMemcpy",
     "piextUSMEnqueueMemset",
     "piextUSMEnqueueMemcpy2D",
+    "urEnqueueUSMMemcpy2D",
     "piextUSMEnqueueMemset2D",
     "piEnqueueKernelLaunch",
+    "urEnqueueKernelLaunch",
     "piextEnqueueKernelLaunchCustom",
-    "piextEnqueueCooperativeKernelLaunch"};
+    "urEnqueueKernelLaunchCustomExp",
+    "piextEnqueueCooperativeKernelLaunch",
+    "urEnqueueCooperativeKernelLaunchExp"};
 
 // =========== Session Constructor ============= //
 XpuptiActivityProfilerSession::XpuptiActivityProfilerSession(


### PR DESCRIPTION
Intel GPU toolchain is using the unified runtime for now. As the profiling tools XPTI, it should be compatible with the unified runtime and previous SYCL runtime, so this PR adds the following eligible unified runtime ops for drawing flow in traced JSON file when using unified runtime.
```
urEnqueueUSMFill
urEnqueueUSMFill2D
urEnqueueUSMMemcpy
urEnqueueUSMMemcpy2D
urEnqueueKernelLaunch
urEnqueueKernelLaunchCustomExp
urEnqueueCooperativeKernelLaunchExp
```