### PR TITLE
add new activity type for profiling hccl events in kineto

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -41,6 +41,7 @@ enum class ActivityType {
   XPU_RUNTIME, // host side xpu runtime events
   COLLECTIVE_COMM, // collective communication
   MTIA_WORKLOADD, // MTIA workloadd events
+  MTIA_COLLECTIVE_COMM, // MTIA collective communication events
 
   // PRIVATEUSE1 Activity types are used for custom backends.
   // The corresponding device type is `DeviceType::PrivateUse1` in PyTorch.

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -39,6 +39,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{
      {"xpu_runtime", ActivityType::XPU_RUNTIME},
      {"collective_comm", ActivityType::COLLECTIVE_COMM},
      {"mtia_workloadd", ActivityType::MTIA_WORKLOADD},
+     {"mtia_collective_comm", ActivityType::MTIA_COLLECTIVE_COMM},
      {"privateuse1_runtime", ActivityType::PRIVATEUSE1_RUNTIME},
      {"privateuse1_driver", ActivityType::PRIVATEUSE1_DRIVER},
      {"ENUM_COUNT", ActivityType::ENUM_COUNT}}};


### PR DESCRIPTION
Summary: Add "MTIA_COLLECTIVE_COMM" activity type in kineto for tracing hccl profiler events

Differential Revision: D66713888


