### PR TITLE
avoid calling libkineto::api().client()->stop twice

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -430,6 +430,8 @@ class CuptiActivityProfiler {
 
   void checkTimestampOrder(const ITraceActivity* act1);
 
+  bool getCollectTraceState();
+
   // On-demand Request Config (should not be modified)
   // TODO: remove this config_, dependency needs to be removed from
   // finalizeTrace.
@@ -494,6 +496,10 @@ class CuptiActivityProfiler {
   // is blocked when profiling by iterations is enabled. Issue #953 shows
   // details.
   std::unique_ptr<std::thread> collectTraceThread_{nullptr};
+
+  // Add a mutex to protect state for CollectTrace
+  std::recursive_mutex collectTraceStateMutex_;
+  bool isCollectingTrace{false};
 
   // Runloop phase
   std::atomic<RunloopState> currentRunloopState_{RunloopState::WaitForRequest};


### PR DESCRIPTION
In normal case,  torch main thread calls `performRunLoopStep` when `profilerStep` is called to collect traces. If  `maxGpuBufferCount_` is set too small, profiling may be stopped early, `profilerThread_` will also call `performRunLoopStep` to collect trace.  If the cpu trace buffer is too big, `collectTrace` may be called twice, and `libkineto::api().client()->stop` will be called twice, which will throw an uncaught `::c10::Error`. Finally, torch process quits with a core file. 
