### PR TITLE
Add Metadata for Annotation

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -442,6 +442,9 @@ void CuptiActivityProfiler::processCpuTrace(
       if (act->type() == ActivityType::USER_ANNOTATION &&
           act->duration() <= 0) {
         act->endTime = captureWindowEndTime_;
+        act->addMetadata("finished", "false");
+      } else {
+        act->addMetadata("finished", "true");
       }
       logger.handleActivity(*act);
     }


### PR DESCRIPTION
Summary: We recently extended annotations for on-demand to the end of a profile if the annotation does not finish by then. This is useful to know where the tracing ended. However, it is hard to tell when looking to see if the annotation ended as the trace ended or if the annotation ended because of the tracing ended. We add this extra metadata to deliniate this

Differential Revision: D68864115


