### PR TITLE
CUPTI Segfault Reproducer for Denying Buffer Request

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -164,11 +164,12 @@ void CuptiActivityApi::bufferRequested(
     size_t* maxNumRecords) {
   std::lock_guard<std::mutex> guard(mutex_);
   LOG(VERBOSE) << "CUPTI buffer requested";
-  if (allocatedGpuTraceBuffers_.size() >= maxGpuBufferCount_) {
-    stopCollection = true;
+  if (allocatedGpuTraceBuffers_.size() >= 1) {
     LOG(WARNING) << "Exceeded max GPU buffer count ("
-                 << allocatedGpuTraceBuffers_.size()
-                 << " >= " << maxGpuBufferCount_ << ") - terminating tracing";
+                 << allocatedGpuTraceBuffers_.size() << " >= " << 1
+                 << ") - denying request ";
+    *buffer = NULL;
+    return;
   }
 
   auto buf = std::make_unique<CuptiActivityBuffer>(kBufSize);


### PR DESCRIPTION
Summary: We induce a buffer request denial and by running a  basic resnet50 training script on this branch. It induces a segfault in libcutpi.so

Differential Revision: D69558264


