### PR TITLE
Support QNX SDP 8.0 and 7.1 in basic CPU build

### DIFF
--- a/libkineto/src/ThreadUtil.cpp
+++ b/libkineto/src/ThreadUtil.cpp
@@ -10,7 +10,11 @@
 
 #ifndef _WIN32
 #include <pthread.h>
+#ifdef __QNX__
+#include <process.h>
+#else
 #include <sys/syscall.h>
+#endif
 #include <sys/types.h>
 #include <unistd.h>
 #else // _WIN32
@@ -66,6 +70,8 @@ int32_t systemThreadId(bool cache) {
     sysTid = (int32_t)GetCurrentThreadId();
 #elif defined __FreeBSD__
     syscall(SYS_thr_self, &sysTid);
+#elif defined __QNX__
+    _sysTid = (int32_t)gettid();
 #else
     sysTid = (int32_t)syscall(SYS_gettid);
 #endif


### PR DESCRIPTION
Added QNX support in cpu build (i.e. libkineto without XPU, ROCM, or CUDA) to support pytorch mobile, see build instructions at https://github.com/qnx-ports/build-files/tree/pytorch_qnx_main .

libkineto/test/CMakeLists.txt seems to assume you have a CUDA compiler, so I could not run the tests with these changes.