### PR TITLE
Pass additional metadata to logger observer

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -300,10 +300,27 @@ void CuptiActivityProfiler::logGpuVersions() {
 #endif
 }
 
+namespace {
+
+const std::unordered_set<std::string>& getLoggerMedataAllowList() {
+  static const std::unordered_set<std::string> kLoggerMedataAllowList{
+      "with_stack", "with_modules", "record_shapes", "profile_memory"};
+  return kLoggerMedataAllowList;
+}
+
+} // namespace
+
 void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
   LOG(INFO) << "Processing " << traceBuffers_->cpu.size() << " CPU buffers";
   VLOG(0) << "Profile time range: " << captureWindowStartTime_ << " - "
           << captureWindowEndTime_;
+
+  // Pass metadata within the trace to the logger observer.
+  for (const auto& pair : metadata_) {
+    if (getLoggerMedataAllowList().count(pair.first) > 0) {
+      LOGGER_OBSERVER_ADD_METADATA(pair.first, pair.second);
+    }
+  }
   for (auto& pair : versionMetadata_) {
     addMetadata(pair.first, pair.second);
   }


### PR DESCRIPTION
Summary:
Enables logger observer to see additional metadata passed down to kineto 
The main goal is to add metadata like "with_stack" to logger observers that could use third party logging 
https://github.com/pytorch/pytorch/blob/main/torch/profiler/profiler.py#L203-L213

Reviewed By: sraikund16

Differential Revision: D69835610


