### PR TITLE
Omit default if device info is provided by a profiler plugin session

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1422,7 +1422,7 @@ void CuptiActivityProfiler::finalizeTrace(
   }
 
   // Thread & stream info
-  for (auto pair : resourceInfo_) {
+  for (const auto& pair : resourceInfo_) {
     const auto& resource = pair.second;
     logger.handleResourceInfo(resource, captureWindowStartTime_);
   }
@@ -1436,7 +1436,7 @@ void CuptiActivityProfiler::finalizeTrace(
     }
 
     auto resource_infos = session->getResourceInfos();
-    for (auto resource_info : resource_infos) {
+    for (const auto& resource_info : resource_infos) {
       logger.handleResourceInfo(resource_info, captureWindowStartTime_);
     }
   }
@@ -1457,9 +1457,9 @@ void CuptiActivityProfiler::finalizeTrace(
       for (int gpu = 0; gpu <= kMaxGpuID; gpu++) {
         logger.handleDeviceInfo(
             {gpu,
-            gpu + kExceedMaxPid,
-            process_name,
-            fmt::format("GPU {}", gpu)},
+             gpu + kExceedMaxPid,
+             process_name,
+             fmt::format("GPU {}", gpu)},
             captureWindowStartTime_);
       }
     }


### PR DESCRIPTION
We are working to support our own custom backend and have noticed the following issue...

Currently, default GPU device info is written to the output JSON even if a profiler plugin provides its own device info. The rationale of comment https://github.com/pytorch/kineto/pull/909#issuecomment-2062905554 regarding this design decision does not hold if the plugin device uses process IDs in the range 0-15. In these cases, you have overlapping `process_labels` entries in the JSON and you end up with a concatenation of device names when viewing the trace.

<img width="271" alt="image" src="https://github.com/user-attachments/assets/87dc4363-08dd-4cfb-8b53-950daae69544" />
