### PR TITLE
Fixed uncalled lambda function in CUPTI

### DIFF
--- a/libkineto/src/ScopeExit.h
+++ b/libkineto/src/ScopeExit.h
@@ -31,4 +31,4 @@ ScopeExit<T> makeScopeExit(T t) {
 #define ANON_VAR(name, line) __kINETO_CONCAT(name, line)
 
 #define SCOPE_EXIT(func) \
-  const auto ANON_VAR(SCOPE_BLOCK, __LINE__) = makeScopeExit([=]() { func; })
+  const auto ANON_VAR(SCOPE_BLOCK, __LINE__) = makeScopeExit([=]() { func(); })


### PR DESCRIPTION
Summary:
https://www.internalfb.com/T215416375, Run the following cmd

buck2 build --config cxx.extra_cxxflags=-Wunused-value  kineto/libkineto:cupti_api

It will show

734 kineto/libkineto/src/CuptiNvPerfMetric.cpp:339:14: error: expression result unused [-Werror,-Wunused-value]
  733 kineto/libkineto/src/CuptiNvPerfMetric.cpp:303:14: error: expression result unused [-Werror,-Wunused-value]
  722 kineto/libkineto/src/CuptiNvPerfMetric.cpp:211:14: error: expression result unused [-Werror,-Wunused-value]
  721 kineto/libkineto/src/CuptiNvPerfMetric.cpp:142:14: error: expression result unused [-Werror,-Wunused-value]
  720 kineto/libkineto/src/CuptiNvPerfMetric.cpp:451:14: error: expression result unused [-Werror,-Wunused-value]

The fix is to add () after func in SCOPE_EXIT

Reviewed By: briancoutinho

Differential Revision: D69949682


