### PR TITLE
Fix bugs in kineto sample programs.

### DIFF
--- a/libkineto/sample_programs/build.sh
+++ b/libkineto/sample_programs/build.sh
@@ -18,5 +18,7 @@ g++ \
   -lpthread \
   -lcuda \
   -lcudart \
+  -lcupti \
+  -lnvperf_host \
   /usr/local/lib/libkineto.a \
   kplay_cu.o

--- a/libkineto/sample_programs/kineto_playground.cpp
+++ b/libkineto/sample_programs/kineto_playground.cpp
@@ -15,14 +15,18 @@
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "kineto_playground.cuh"
 
-#define CHECK_CUDA(call)                                                      \
-  do {                                                                        \
-    cudaError_t status = call;                                                \
-    if (status != cudaSuccess) {                                              \
-      fprintf(stderr, "CUDA Error at %s:%d: %s\n", __FILE__, __LINE__,         \
-              cudaGetErrorString(status));                                     \
-      exit(1);                                                                \
-    }                                                                         \
+#define CHECK_CUDA(call)               \
+  do {                                 \
+    cudaError_t status = call;         \
+    if (status != cudaSuccess) {       \
+      fprintf(                         \
+          stderr,                      \
+          "CUDA Error at %s:%d: %s\n", \
+          __FILE__,                    \
+          __LINE__,                    \
+          cudaGetErrorString(status)); \
+      exit(1);                         \
+    }                                  \
   } while (0)
 
 using namespace kineto;

--- a/libkineto/sample_programs/kineto_playground.cpp
+++ b/libkineto/sample_programs/kineto_playground.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cuda_runtime.h>
 #include <iostream>
 #include <string>
 
@@ -13,6 +14,16 @@
 
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "kineto_playground.cuh"
+
+#define CHECK_CUDA(call)                                                      \
+  do {                                                                        \
+    cudaError_t status = call;                                                \
+    if (status != cudaSuccess) {                                              \
+      fprintf(stderr, "CUDA Error at %s:%d: %s\n", __FILE__, __LINE__,         \
+              cudaGetErrorString(status));                                     \
+      exit(1);                                                                \
+    }                                                                         \
+  } while (0)
 
 using namespace kineto;
 
@@ -23,6 +34,7 @@ int main() {
   warmup();
 
   // Kineto config
+  libkineto_init(false, true);
 
   // Empty types set defaults to all types
   std::set<libkineto::ActivityType> types;
@@ -38,6 +50,7 @@ int main() {
   profiler.startTrace();
   std::cout << "Start playground" << std::endl;
   playground();
+  CHECK_CUDA(cudaDeviceSynchronize());
 
   std::cout << "Stop Trace" << std::endl;
   auto trace = profiler.stopTrace();

--- a/libkineto/sample_programs/kineto_playground.cu
+++ b/libkineto/sample_programs/kineto_playground.cu
@@ -76,7 +76,7 @@ __global__ void square(float* A, int N) {
 
 void playground(void) {
   // Add your experimental CUDA implementation here.
-  basicMemcpyFromDevice();
+  basicMemcpyToDevice();
   compute();
   basicMemcpyFromDevice();
 }


### PR DESCRIPTION
Thank you for maintaining Kineto and for all the work that goes into making these tools available! I’ve been using it recently and find some bugs in the sample programs. This PR aims to fix them. Specifically, 
- Fix incorrect function call: In libkineto/sample_programs/kineto_playground.cu (line 79), the example incorrectly calls `basicMemcpyFromDevice` instead of `basicMemcpyToDevice`, which may be a typo.
https://github.com/pytorch/kineto/blob/26661c0c7620267f09ac54a2900e55f08cb0799e/libkineto/sample_programs/kineto_playground.cu#L77-L82
- Add `CHECK_CUDA(cudaDeviceSynchronize())` to the main function to make similar potential runtime errors more clearly, preventing silent failures.
- Add a call to `libkineto_init` in the main function and include the necessary libraries in the build script, to ensure the example runs out of the box.
