### PR TITLE
Move "baseTimeNanoseconds" and "displayTimeUnit" before "traceEvents"

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -131,6 +131,13 @@ void ChromeTraceLogger::handleTraceStart(
       device_properties);
 
   metadataToJSON(metadata);
+
+  traceOf_ << fmt::format(
+      R"JSON(
+  "displayTimeUnit": "ms",
+  "baseTimeNanoseconds": {},)JSON",
+      ChromeTraceBaseTime::singleton().get());
+
   traceOf_ << R"JSON(
   "traceEvents": [)JSON";
 }
@@ -681,13 +688,9 @@ void ChromeTraceLogger::finalizeTrace(
 #endif // !USE_GOOGLE_LOG
 
   // Putting this here because the last entry MUST not end with a comma.
-
-  traceOf_ << fmt::format(R"JSON(
-  "traceName": "{}",
-  "displayTimeUnit": "ms",
-  "baseTimeNanoseconds": {}
-}})JSON", fileName_, ChromeTraceBaseTime::singleton().get());
-  // clang-format on
+    traceOf_ << fmt::format(R"JSON(
+  "traceName": "{}"
+}})JSON", fileName_);
 
   traceOf_.close();
   // On some systems, rename() fails if the destination file exists.


### PR DESCRIPTION
Summary: `baseTimeNanoseconds` is currently put at the end of the trace after `traceEvents` which makes efficiently parsing this trace metadata with `ijson` difficult. This diff moves "baseTimeNanoseconds" and "displayTimeUnit" before "traceEvents" - we intentionally leave `traceName` at the end of the trace for the time being to avoid having to make a more sprawling change to correctly handle trailing commas.

Differential Revision: D70404528


