### PR TITLE
Fix include in namespace libkineto

### DIFF
--- a/libkineto/src/ApproximateClock.h
+++ b/libkineto/src/ApproximateClock.h
@@ -18,8 +18,6 @@
 #include <functional>
 #include <type_traits>
 
-namespace libkineto {
-
 #if defined(__i386__) || defined(__x86_64__) || defined(__amd64__)
 #define KINETO_RDTSC
 #if defined(_MSC_VER)
@@ -41,6 +39,8 @@ namespace libkineto {
 #else
 #define KINETO_UNUSED __attribute__((__unused__))
 #endif //_MSC_VER
+
+namespace libkineto {
 
 using time_t = int64_t;
 using steady_clock_t = std::conditional_t<


### PR DESCRIPTION
Thank you for maintaining Kineto and for all the work that goes into making these tools available! I’ve been using Kineto APIs and encountered an issue in ApproximateClock.h that could lead to unexpected compile errors. 

https://github.com/pytorch/kineto/blob/08fcb941769f6afb6ad5792c29e1c0db891d07ab/libkineto/src/ApproximateClock.h#L21-L43

Here `#include <x86intrin.h>` is placed inside the namespace, which I think is generally discouraged in C/C++ because it causes the contents of the header—and any headers it indirectly includes—to be placed within that namespace. For example, since `ApproximateClock.h` indirectly includes `cstdlib` in the `libkineto` namespace, standard symbols like abs will be defined in `namespace libkineto` instead of the global namespace, resulting in errors such as:
```
/usr/include/c++/14.2.1/bits/std_abs.h:52:11: error: ‘abs’ has not been declared in ‘::’
   52 |   using ::abs;
```

To adhere to best practices and avoid these issues, I have moved the include directives outside of the namespace.
