### PR TITLE
Support child profilers add their metadata

### DIFF
--- a/libkineto/include/IActivityProfiler.h
+++ b/libkineto/include/IActivityProfiler.h
@@ -130,6 +130,10 @@ class IActivityProfilerSession {
     return "";
   }
 
+  virtual std::unordered_map<std::string, std::string> getMetadata() {
+    return {};
+  }
+
  protected:
   TraceStatus status_ = TraceStatus::READY;
 };

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -336,6 +336,9 @@ void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
         device_properties.push_back(props);
       }
     }
+    for (const auto& [key, value] : session->getMetadata()) {
+      addMetadata(key, value);
+    }
   }
   logger.handleTraceStart(
       metadata_, fmt::format("{}", fmt::join(device_properties, ",")));


### PR DESCRIPTION
Add a virtual function because our out-of-tree backend wants to add some metadata.