### PR TITLE
Add Manifold Support to Memory on-demand

### DIFF
--- a/libkineto/include/output_base.h
+++ b/libkineto/include/output_base.h
@@ -63,6 +63,8 @@ class ActivityLogger {
     handleTraceStart(std::unordered_map<std::string, std::string>(), "");
   }
 
+  virtual void finalizeMemoryTrace(const std::string&, const Config&) = 0;
+
   virtual void finalizeTrace(
       const Config& config,
       std::unique_ptr<ActivityBuffers> buffers,

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -400,7 +400,6 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   } else if (!name.compare(kProfileMemory)) {
     memoryProfilerEnabled_ = toBool(val);
     activitiesLogFile_ = defaultMemoryTraceFileName();
-    activitiesLogUrl_ = fmt::format("file://{}", activitiesLogFile_);
   } else if (!name.compare(kProfileMemoryDuration)) {
     profileMemoryDuration_ = toInt32(val);
   } else if (!name.compare(kActivitiesLogFileKey)) {

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -140,7 +140,11 @@ class CuptiActivityProfiler {
       const std::chrono::time_point<std::chrono::system_clock>& nextWakeupTime,
       int64_t currentIter = -1);
 
-  const void performMemoryLoop(const std::string& path, uint32_t profile_time);
+  const void performMemoryLoop(
+      const std::string& path,
+      uint32_t profile_time,
+      ActivityLogger* logger,
+      Config& config);
 
   // Used for async requests
   void setLogger(ActivityLogger* logger) {

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -160,6 +160,10 @@ void ChromeTraceLogger::openTraceFile() {
   }
 }
 
+void ChromeTraceLogger::finalizeMemoryTrace(const std::string&, const Config&) {
+  LOG(INFO) << "finalizeMemoryTrace not implemented for ChromeTraceLogger";
+}
+
 ChromeTraceLogger::ChromeTraceLogger(const std::string& traceFileName) {
   fileName_ = traceFileName.empty() ? defaultFileName() : traceFileName;
   traceOf_.clear(std::ios_base::badbit);

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -81,6 +81,8 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
       std::unordered_map<std::string, std::vector<std::string>>& metadata)
       override;
 
+  void finalizeMemoryTrace(const std::string&, const Config&) override;
+
   std::string traceFileName() const {
     return fileName_;
   }

--- a/libkineto/src/output_membuf.h
+++ b/libkineto/src/output_membuf.h
@@ -18,6 +18,7 @@
 #include "ActivityBuffers.h"
 #include "Config.h"
 #include "GenericTraceActivity.h"
+#include "Logger.h"
 #include "output_base.h"
 
 namespace KINETO_NAMESPACE {
@@ -76,6 +77,10 @@ class MemoryTraceLogger : public ActivityLogger {
       override {
     buffers_ = std::move(buffers);
     endTime_ = endTime;
+  }
+
+  void finalizeMemoryTrace(const std::string&, const Config&) override {
+    LOG(INFO) << "finalizeMemoryTrace not implemented for MemLogger";
   }
 
   const std::vector<const ITraceActivity*>* traceActivities() {


### PR DESCRIPTION
Summary: Currently, we can only use memory on-demand to save files locally under tmp. This diff adds support for manifold upload. It abstracts much of the logic for internal files to maintain OSS compliance

Differential Revision: D72650433


