### PR TITLE
add a custom configuration option

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -393,6 +393,10 @@ class Config : public AbstractConfig {
     return customConfig_;
   }
 
+  uint32_t maxEvents() const {
+    return maxEvents_;
+  }
+
  private:
   explicit Config(const Config& other) = default;
 
@@ -526,6 +530,8 @@ class Config : public AbstractConfig {
   // Used to flexibly configure some custom options, especially for custom
   // backends. How to parse this string is handled by the custom backend.
   std::string customConfig_;
+  // Roctracer settings
+  uint32_t maxEvents_{1000000};
 };
 
 constexpr char kUseDaemonEnvVar[] = "KINETO_USE_DAEMON";

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -389,6 +389,10 @@ class Config : public AbstractConfig {
     useTSCTimestamp_ = flag;
   }
 
+  const std::string& getCustomConfig() const {
+    return customConfig_;
+  }
+
  private:
   explicit Config(const Config& other) = default;
 
@@ -518,6 +522,10 @@ class Config : public AbstractConfig {
   // Memory Profiler
   bool memoryProfilerEnabled_{false};
   int profileMemoryDuration_{1000};
+
+  // Used to flexibly configure some custom options, especially for custom backends.
+  // How to parse this string is handled by the custom backend.
+  std::string customConfig_;
 };
 
 constexpr char kUseDaemonEnvVar[] = "KINETO_USE_DAEMON";

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -523,8 +523,8 @@ class Config : public AbstractConfig {
   bool memoryProfilerEnabled_{false};
   int profileMemoryDuration_{1000};
 
-  // Used to flexibly configure some custom options, especially for custom backends.
-  // How to parse this string is handled by the custom backend.
+  // Used to flexibly configure some custom options, especially for custom
+  // backends. How to parse this string is handled by the custom backend.
   std::string customConfig_;
 };
 

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -165,6 +165,8 @@ constexpr char kLogVerboseLevelKey[] = "VERBOSE_LOG_LEVEL";
 // Example argument: ActivityProfiler.cpp,output_json.cpp
 constexpr char kLogVerboseModulesKey[] = "VERBOSE_LOG_MODULES";
 
+constexpr char kCustomConfigKey[] = "CUSTOM_CONFIG";
+
 // Max devices supported on any system
 constexpr uint8_t kMaxDevices = 8;
 
@@ -470,6 +472,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     enableIpcFabric_ = toBool(val);
   } else if (!name.compare(kOnDemandConfigUpdateIntervalSecsKey)) {
     onDemandConfigUpdateIntervalSecs_ = seconds(toInt32(val));
+  } else if (!name.compare(kCustomConfigKey)) {
+    customConfig_ = val;
   } else {
     return false;
   }


### PR DESCRIPTION
Introduce a `CUSTOM_CONFIG` to enable passing custom configuration options to the custom backend.