### PR TITLE
Allow multiple profiling threads per on-demand session

### DIFF
--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -27,6 +27,11 @@
 #include "LoggerCollector.h"
 
 namespace KINETO_NAMESPACE {
+enum ThreadType {
+  KINETO = 0,
+  MEMORY_SNAPSHOT,
+  THREAD_MAX_COUNT // Number of enum entries (used for array sizing)
+};
 
 class Config;
 
@@ -117,7 +122,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   std::unique_ptr<CuptiActivityProfiler> profiler_;
   std::unique_ptr<ActivityLogger> logger_;
   std::shared_ptr<LoggerCollector> loggerCollectorFactory_;
-  std::thread* profilerThread_{nullptr};
+  std::thread* profilerThreads_[ThreadType::THREAD_MAX_COUNT] = {nullptr};
   std::atomic_bool stopRunloop_{false};
   std::atomic<std::int64_t> iterationCount_{-1};
   ConfigLoader& configLoader_;

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1283,6 +1283,10 @@ const time_point<system_clock> CuptiActivityProfiler::performRunLoopStep(
       << "Run loop on application step(), iteration = " << currentIter;
 
   switch (currentRunloopState_) {
+    case RunloopState::CollectMemorySnapshot:
+      LOG(WARNING)
+          << "Entered CollectMemorySnapshot in Kineto Loop Step, skipping loop";
+      break;
     case RunloopState::WaitForRequest:
       VLOG(1) << "State: WaitForRequest";
       // Nothing to do
@@ -1424,7 +1428,7 @@ const void CuptiActivityProfiler::performMemoryLoop(
     uint32_t profile_time,
     ActivityLogger* logger,
     Config& config) {
-  currentRunloopState_ = RunloopState::CollectTrace;
+  currentRunloopState_ = RunloopState::CollectMemorySnapshot;
   if (libkineto::api().client()) {
     libkineto::api().client()->start_memory_profile();
     LOG(INFO) << "Running memory profiling for " << profile_time << " ms";

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -129,6 +129,9 @@ class CuptiActivityProfiler {
   bool isActive() const {
     return currentRunloopState_ != RunloopState::WaitForRequest;
   }
+  bool isCollectingMemorySnapshot() const {
+    return currentRunloopState_ == RunloopState::CollectMemorySnapshot;
+  }
 
   // Invoke at a regular interval to perform profiling activities.
   // When not active, an interval of 1-5 seconds is probably fine,
@@ -464,7 +467,8 @@ class CuptiActivityProfiler {
     WaitForRequest,
     Warmup,
     CollectTrace,
-    ProcessTrace
+    ProcessTrace,
+    CollectMemorySnapshot,
   };
 
   // All recorded trace spans, both CPU and GPU


### PR DESCRIPTION
Summary: Add multiple threads to activity profiler to allow for memory profiling as well as regular kineto profiling.

Differential Revision: D73403474


