### PR TITLE
Fix GPU Only Timestamps

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -101,20 +101,30 @@ std::function<time_t(approx_time_t)>& get_time_converter() {
   return _time_converter;
 }
 #ifdef HAS_ROCTRACER
-timestamp_t getTimeOffset() {
-  int64_t t0, t00;
+timestamp_t getTimeOffset(bool gpuOnly) {
   timespec t1;
-  t0 = libkineto::getApproximateTime();
-  clock_gettime(CLOCK_MONOTONIC, &t1);
-  t00 = libkineto::getApproximateTime();
+  if (gpuOnly) {
+    timespec t0, t00;
+    clock_gettime(CLOCK_REALTIME, &t0);
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    clock_gettime(CLOCK_REALTIME, &t00);
 
-  // Confvert to ns (if necessary)
-  t0 = libkineto::get_time_converter()(t0);
-  t00 = libkineto::get_time_converter()(t00);
+    return (timespec_to_ns(t0) >> 1) + (timespec_to_ns(t00) >> 1) -
+        timespec_to_ns(t1);
+  } else {
+    int64_t t0, t00;
+    t0 = libkineto::getApproximateTime();
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    t00 = libkineto::getApproximateTime();
 
-  // Our stored timestamps (from roctracer and generated) are in CLOCK_MONOTONIC
-  // domain (in ns).
-  return (t0 >> 1) + (t00 >> 1) - timespec_to_ns(t1);
+    // Confvert to ns (if necessary)
+    t0 = libkineto::get_time_converter()(t0);
+    t00 = libkineto::get_time_converter()(t00);
+
+    // Our stored timestamps (from roctracer and generated) are in
+    // CLOCK_MONOTONIC domain (in ns).
+    return (t0 >> 1) + (t00 >> 1) - timespec_to_ns(t1);
+  }
 }
 #endif
 
@@ -391,7 +401,7 @@ void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
 #ifdef HAS_ROCTRACER
   if (!cpuOnly_) {
     VLOG(0) << "Retrieving GPU activity buffers";
-    timestamp_t offset = getTimeOffset();
+    timestamp_t offset = getTimeOffset(gpuOnly_);
     cupti_.setTimeOffset(offset);
     const int count = cupti_.processActivities(
         std::bind(
@@ -1075,6 +1085,7 @@ void CuptiActivityProfiler::configure(
     config_->printActivityProfilerConfig(LIBKINETO_DBG_STREAM);
   }
   if (!cpuOnly_ && !libkineto::api().client()) {
+    gpuOnly_ = true;
     if (derivedConfig_->isProfilingByIteration()) {
       LOG(INFO) << "GPU-only tracing for " << config_->activitiesRunIterations()
                 << " iterations";

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -494,6 +494,7 @@ class CuptiActivityProfiler {
   profilerOverhead setupOverhead_;
 
   bool cpuOnly_{false};
+  bool gpuOnly_{false};
   bool cpuActivityPresent_{false};
   bool gpuActivityPresent_{false};
 


### PR DESCRIPTION
Summary: We are assuming that the CPU traces will come in and set the time converter in Kineto when we shouldn't as GPU only tests/jobs can run. If that is the case, use the system clock instead.

Differential Revision: D73881831


