### PR TITLE
Add Max Event Option to Roctracer

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -389,6 +389,10 @@ class Config : public AbstractConfig {
     useTSCTimestamp_ = flag;
   }
 
+  uint32_t maxEvents() const {
+    return maxEvents_;
+  }
+
  private:
   explicit Config(const Config& other) = default;
 
@@ -518,6 +522,9 @@ class Config : public AbstractConfig {
   // Memory Profiler
   bool memoryProfilerEnabled_{false};
   int profileMemoryDuration_{1000};
+
+  // Roctracer settings
+  uint32_t maxEvents_{1000000};
 };
 
 constexpr char kUseDaemonEnvVar[] = "KINETO_USE_DAEMON";

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -99,6 +99,9 @@ constexpr char kActivitiesIterationsKey[] = "ACTIVITIES_ITERATIONS";
 constexpr char kProfileMemory[] = "PROFILE_MEMORY";
 constexpr char kProfileMemoryDuration[] = "PROFILE_MEMORY_DURATION_MSECS";
 
+// Roctracer
+constexpr char kRoctracerSetMaxEvents[] = "ROCTRACER_MAX_EVENTS";
+
 // Common
 
 // Client-side timestamp used for synchronized start across hosts for
@@ -431,6 +434,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     requestTraceID_ = val;
   } else if (!name.compare(kRequestGroupTraceID)) {
     requestGroupTraceID_ = val;
+  } else if (!name.compare(kRoctracerSetMaxEvents)) {
+    maxEvents_ = toInt32(val);
   }
 
   // TODO: Deprecate Client Interface

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -101,20 +101,30 @@ std::function<time_t(approx_time_t)>& get_time_converter() {
   return _time_converter;
 }
 #ifdef HAS_ROCTRACER
-timestamp_t getTimeOffset() {
-  int64_t t0, t00;
+timestamp_t getTimeOffset(bool gpuOnly) {
   timespec t1;
-  t0 = libkineto::getApproximateTime();
-  clock_gettime(CLOCK_MONOTONIC, &t1);
-  t00 = libkineto::getApproximateTime();
+  if (gpuOnly) {
+    timespec t0, t00;
+    clock_gettime(CLOCK_REALTIME, &t0);
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    clock_gettime(CLOCK_REALTIME, &t00);
 
-  // Confvert to ns (if necessary)
-  t0 = libkineto::get_time_converter()(t0);
-  t00 = libkineto::get_time_converter()(t00);
+    return (timespec_to_ns(t0) >> 1) + (timespec_to_ns(t00) >> 1) -
+        timespec_to_ns(t1);
+  } else {
+    int64_t t0, t00;
+    t0 = libkineto::getApproximateTime();
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    t00 = libkineto::getApproximateTime();
 
-  // Our stored timestamps (from roctracer and generated) are in CLOCK_MONOTONIC
-  // domain (in ns).
-  return (t0 >> 1) + (t00 >> 1) - timespec_to_ns(t1);
+    // Confvert to ns (if necessary)
+    t0 = libkineto::get_time_converter()(t0);
+    t00 = libkineto::get_time_converter()(t00);
+
+    // Our stored timestamps (from roctracer and generated) are in
+    // CLOCK_MONOTONIC domain (in ns).
+    return (t0 >> 1) + (t00 >> 1) - timespec_to_ns(t1);
+  }
 }
 #endif
 
@@ -391,7 +401,7 @@ void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
 #ifdef HAS_ROCTRACER
   if (!cpuOnly_) {
     VLOG(0) << "Retrieving GPU activity buffers";
-    timestamp_t offset = getTimeOffset();
+    timestamp_t offset = getTimeOffset(gpuOnly_);
     cupti_.setTimeOffset(offset);
     const int count = cupti_.processActivities(
         std::bind(
@@ -1075,6 +1085,7 @@ void CuptiActivityProfiler::configure(
     config_->printActivityProfilerConfig(LIBKINETO_DBG_STREAM);
   }
   if (!cpuOnly_ && !libkineto::api().client()) {
+    gpuOnly_ = true;
     if (derivedConfig_->isProfilingByIteration()) {
       LOG(INFO) << "GPU-only tracing for " << config_->activitiesRunIterations()
                 << " iterations";

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1134,7 +1134,8 @@ void CuptiActivityProfiler::configure(
 #endif // _WIN32
     cupti_.enableCuptiActivities(
         config_->selectedActivityTypes(), config_->perThreadBufferEnabled());
-#else
+#else // HAS_ROCTRACER
+    cupti_.setMaxEvents(config_->maxEvents());
     cupti_.enableActivities(config_->selectedActivityTypes());
 #endif
     if (VLOG_IS_ON(1)) {

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -494,6 +494,7 @@ class CuptiActivityProfiler {
   profilerOverhead setupOverhead_;
 
   bool cpuOnly_{false};
+  bool gpuOnly_{false};
   bool cpuActivityPresent_{false};
   bool gpuActivityPresent_{false};
 

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -145,6 +145,12 @@ void RoctracerActivityApi::clearActivities() {
   d->clearLogs();
 }
 
+void RoctracerActivityApi::setMaxEvents(uint32_t maxEvents) {
+#ifdef HAS_ROCTRACER
+  d->setMaxEvents(maxEvents);
+#endif
+}
+
 void RoctracerActivityApi::enableActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_ROCTRACER

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -45,6 +45,7 @@ class RoctracerActivityApi {
   void clearActivities();
   void teardownContext() {}
   void setTimeOffset(timestamp_t toffset);
+  void setMaxEvents(uint32_t maxEvents);
 
   virtual int processActivities(
       std::function<void(const roctracerBase*)> handler,

--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -314,6 +314,14 @@ void RoctracerLogger::activity_callback(
   }
 }
 
+void RoctracerLogger::setMaxEvents(uint32_t maxBufferSize) {
+#ifdef HAS_ROCTRACER
+  RoctracerLogger* dis = &singleton();
+  std::lock_guard<std::mutex> lock(dis->rowsMutex_);
+  maxBufferSize_ = maxBufferSize;
+#endif
+}
+
 void RoctracerLogger::startLogging() {
   if (!registered_) {
     roctracer_set_properties(

--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -267,6 +267,7 @@ class RoctracerLogger {
   void startLogging();
   void stopLogging();
   void clearLogs();
+  void setMaxEvents(uint32_t maxBufferSize);
 
  private:
   bool registered_{false};


### PR DESCRIPTION
Summary: Sometimes the event buffer in roctracer gets full before tracing. We should make this configurable for users.

Differential Revision: D73881832


