### PR TITLE
Back out "Revert D74278271: [AMD] Use TSC by default for GPU Only"

### DIFF
--- a/libkineto/src/ApproximateClock.cpp
+++ b/libkineto/src/ApproximateClock.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ApproximateClock.h"
+#include <fmt/format.h>
+
+namespace libkineto {
+
+ApproximateClockToUnixTimeConverter::ApproximateClockToUnixTimeConverter()
+    : start_times_(measurePairs()) {}
+
+ApproximateClockToUnixTimeConverter::UnixAndApproximateTimePair
+ApproximateClockToUnixTimeConverter::measurePair() {
+  // Take a measurement on either side to avoid an ordering bias.
+  auto fast_0 = getApproximateTime();
+  auto wall = std::chrono::system_clock::now();
+  auto fast_1 = getApproximateTime();
+
+  auto t = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      wall.time_since_epoch());
+
+  // `x + (y - x) / 2` is a more numerically stable average than `(x + y) / 2`.
+  return {t.count(), fast_0 + (fast_1 - fast_0) / 2};
+}
+
+ApproximateClockToUnixTimeConverter::time_pairs
+ApproximateClockToUnixTimeConverter::measurePairs() {
+  static constexpr auto n_warmup = 5;
+  for (int i = 0; i < n_warmup; i++) {
+    getApproximateTime();
+    static_cast<void>(steady_clock_t::now());
+  }
+
+  time_pairs out;
+  for (int i = 0; i < out.size(); i++) {
+    out[i] = measurePair();
+  }
+  return out;
+}
+
+std::function<time_t(approx_time_t)>
+ApproximateClockToUnixTimeConverter::makeConverter() {
+  auto end_times = measurePairs();
+
+  // Compute the real time that passes for each tick of the approximate clock.
+  std::array<long double, replicates> scale_factors{};
+  for (int i = 0; i < replicates; i++) {
+    auto delta_ns = end_times[i].t_ - start_times_[i].t_;
+    auto delta_approx = end_times[i].approx_t_ - start_times_[i].approx_t_;
+    scale_factors[i] = (double)delta_ns / (double)delta_approx;
+  }
+  std::sort(scale_factors.begin(), scale_factors.end());
+  long double scale_factor = scale_factors[replicates / 2 + 1];
+
+  // We shift all times by `t0` for better numerics. Double precision only has
+  // 16 decimal digits of accuracy, so if we blindly multiply times by
+  // `scale_factor` we may suffer from precision loss. The choice of `t0` is
+  // mostly arbitrary; we just need a factor that is the correct order of
+  // magnitude to bring the intermediate values closer to zero. We are not,
+  // however, guaranteed that `t0_approx` is *exactly* the getApproximateTime
+  // equivalent of `t0`; it is only an estimate that we have to fine tune.
+  auto t0 = start_times_[0].t_;
+  auto t0_approx = start_times_[0].approx_t_;
+  std::array<double, replicates> t0_correction{};
+  for (int i = 0; i < replicates; i++) {
+    auto dt = start_times_[i].t_ - t0;
+    auto dt_approx =
+        (double)(start_times_[i].approx_t_ - t0_approx) * scale_factor;
+    t0_correction[i] = dt - (time_t)dt_approx; // NOLINT
+  }
+  t0 += t0_correction[t0_correction.size() / 2 + 1]; // NOLINT
+
+  return [=](approx_time_t t_approx) {
+    // See above for why this is more stable than `A * t_approx + B`.
+    return t_approx > t0_approx
+        ? (time_t)((double)(t_approx - t0_approx) * scale_factor) + t0
+        : 0;
+  };
+}
+
+} // namespace libkineto

--- a/libkineto/src/ApproximateClock.h
+++ b/libkineto/src/ApproximateClock.h
@@ -89,4 +89,24 @@ static_assert(
     "Expected either int64_t (`getTime`) or uint64_t (some TSC reads).");
 
 std::function<time_t(approx_time_t)>& get_time_converter();
+
+// Convert `getCount` results to Nanoseconds since unix epoch.
+class ApproximateClockToUnixTimeConverter final {
+ public:
+  ApproximateClockToUnixTimeConverter();
+  std::function<time_t(approx_time_t)> makeConverter();
+
+  struct UnixAndApproximateTimePair {
+    time_t t_;
+    approx_time_t approx_t_;
+  };
+  static UnixAndApproximateTimePair measurePair();
+
+ private:
+  static constexpr size_t replicates = 1001;
+  using time_pairs = std::array<UnixAndApproximateTimePair, replicates>;
+  time_pairs measurePairs();
+
+  time_pairs start_times_;
+};
 } // namespace libkineto

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -101,30 +101,20 @@ std::function<time_t(approx_time_t)>& get_time_converter() {
   return _time_converter;
 }
 #ifdef HAS_ROCTRACER
-timestamp_t getTimeOffset(bool gpuOnly) {
+timestamp_t getTimeOffset() {
   timespec t1;
-  if (gpuOnly) {
-    timespec t0, t00;
-    clock_gettime(CLOCK_REALTIME, &t0);
-    clock_gettime(CLOCK_MONOTONIC, &t1);
-    clock_gettime(CLOCK_REALTIME, &t00);
+  int64_t t0, t00;
+  t0 = libkineto::getApproximateTime();
+  clock_gettime(CLOCK_MONOTONIC, &t1);
+  t00 = libkineto::getApproximateTime();
 
-    return (timespec_to_ns(t0) >> 1) + (timespec_to_ns(t00) >> 1) -
-        timespec_to_ns(t1);
-  } else {
-    int64_t t0, t00;
-    t0 = libkineto::getApproximateTime();
-    clock_gettime(CLOCK_MONOTONIC, &t1);
-    t00 = libkineto::getApproximateTime();
+  // Confvert to ns (if necessary)
+  t0 = libkineto::get_time_converter()(t0);
+  t00 = libkineto::get_time_converter()(t00);
 
-    // Confvert to ns (if necessary)
-    t0 = libkineto::get_time_converter()(t0);
-    t00 = libkineto::get_time_converter()(t00);
-
-    // Our stored timestamps (from roctracer and generated) are in
-    // CLOCK_MONOTONIC domain (in ns).
-    return (t0 >> 1) + (t00 >> 1) - timespec_to_ns(t1);
-  }
+  // Our stored timestamps (from roctracer and generated) are in
+  // CLOCK_MONOTONIC domain (in ns).
+  return (t0 >> 1) + (t00 >> 1) - timespec_to_ns(t1);
 }
 #endif
 
@@ -401,7 +391,11 @@ void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
 #ifdef HAS_ROCTRACER
   if (!cpuOnly_) {
     VLOG(0) << "Retrieving GPU activity buffers";
-    timestamp_t offset = getTimeOffset(gpuOnly_);
+    if (gpuOnly_) {
+      ApproximateClockToUnixTimeConverter clockConverter;
+      get_time_converter() = clockConverter.makeConverter();
+    }
+    timestamp_t offset = getTimeOffset();
     cupti_.setTimeOffset(offset);
     const int count = cupti_.processActivities(
         std::bind(


### PR DESCRIPTION
Summary: Original diff failed because of adfinder couldn't build libactivity_profiler.so. There was a duplicate source file which has been removed in this diff.

Differential Revision: D74435241


