### PR TITLE
Move Time Converter to Configure by default

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -42,6 +42,7 @@ def get_libkineto_xpupti_srcs(with_api = True):
 def get_libkineto_cpu_only_srcs(with_api = True):
     return [
         "src/AbstractConfig.cpp",
+        "src/ApproximateClock.cpp",
         "src/CuptiActivityProfiler.cpp",
         "src/ActivityProfilerController.cpp",
         "src/ActivityProfilerProxy.cpp",

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -391,10 +391,6 @@ void CuptiActivityProfiler::processTraceInternal(ActivityLogger& logger) {
 #ifdef HAS_ROCTRACER
   if (!cpuOnly_) {
     VLOG(0) << "Retrieving GPU activity buffers";
-    if (gpuOnly_) {
-      ApproximateClockToUnixTimeConverter clockConverter;
-      get_time_converter() = clockConverter.makeConverter();
-    }
     timestamp_t offset = getTimeOffset();
     cupti_.setTimeOffset(offset);
     const int count = cupti_.processActivities(
@@ -1055,6 +1051,8 @@ void CuptiActivityProfiler::configure(
     LOG(WARNING) << "CuptiActivityProfiler already busy, terminating";
     return;
   }
+  ApproximateClockToUnixTimeConverter clockConverter;
+  get_time_converter() = clockConverter.makeConverter();
 
   config_ = config.clone();
 

--- a/libkineto/stress_test/kineto_stress_test.cpp
+++ b/libkineto/stress_test/kineto_stress_test.cpp
@@ -30,8 +30,6 @@ void trace_collection_thread(
     uint32_t trace_delay_us,
     uint32_t trace_length_us,
     uint32_t cupti_buffer_mb) {
-  c10::ApproximateClockToUnixTimeConverter clockConverter;
-
   if (cupti_buffer_mb > 0) {
     // Configure CUPTI buffer sizes
     size_t attrValue = 0, attrValueSize = sizeof(size_t);
@@ -52,8 +50,6 @@ void trace_collection_thread(
   auto& profiler = libkineto::api().activityProfiler();
   libkineto::api().initProfilerIfRegistered();
   profiler.prepareTrace(types);
-  auto converter = clockConverter.makeConverter();
-  libkineto::get_time_converter() = converter;
 
   // Wait a bit before collecting the trace
   usleep(trace_delay_us);

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -26,6 +26,7 @@
 #include "include/output_base.h"
 #include "include/time_since_epoch.h"
 #include "src/ActivityTrace.h"
+#include "src/ApproximateClock.h"
 #include "src/CuptiActivityApi.h"
 #include "src/CuptiActivityProfiler.h"
 #include "src/output_json.h"
@@ -474,6 +475,7 @@ TEST_F(CuptiActivityProfilerTest, SyncTrace) {
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
   profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
 
   profiler.recordThreadInfo();
 
@@ -611,6 +613,7 @@ TEST_F(CuptiActivityProfilerTest, GpuNCCLCollectiveTest) {
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
   profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
 
   int64_t kernelLaunchTime = start_time_ns + 20;
   profiler.recordThreadInfo();
@@ -783,6 +786,7 @@ TEST_F(CuptiActivityProfilerTest, GpuUserAnnotationTest) {
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
   profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
 
   int64_t kernelLaunchTime = start_time_ns + 20;
   profiler.recordThreadInfo();
@@ -1047,6 +1051,7 @@ TEST_F(CuptiActivityProfilerTest, JsonGPUIDSortTest) {
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
   profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
   profiler.recordThreadInfo();
 
   // Set up CPU events and corresponding GPU events


### PR DESCRIPTION
Summary: Right now we are setting the converter after getting timestamps for the gpuOnly case for only AMD. However, when people want to use NV only this causes an issue. Instead of adding to both codepaths lets just add a default converter. In the case that the profiler gets triggered it will overwrite the converter anyways.  This way we are always in sync and always have a converter.

Differential Revision: D74673487


