### PR TITLE
Add new ActivityType for Insight event

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -32,6 +32,7 @@ enum class ActivityType {
   OVERHEAD, // CUPTI induced overhead events sampled from its overhead API.
   MTIA_RUNTIME, // host side MTIA runtime events
   MTIA_CCP_EVENTS, // MTIA ondevice CCP events
+  MTIA_INSIGHT, // MTIA Insight Events
   CUDA_SYNC, // synchronization events between runtime and kernels
 
   // Optional Activity types

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -32,6 +32,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{
      {"overhead", ActivityType::OVERHEAD},
      {"mtia_runtime", ActivityType::MTIA_RUNTIME},
      {"mtia_ccp_events", ActivityType::MTIA_CCP_EVENTS},
+     {"mtia_insight", ActivityType::MTIA_INSIGHT},
      {"cuda_sync", ActivityType::CUDA_SYNC},
      {"glow_runtime", ActivityType::GLOW_RUNTIME},
      {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -103,6 +103,7 @@ TEST(ParseTest, ActivityTypes) {
            ActivityType::CUDA_DRIVER,
            ActivityType::CUDA_SYNC,
            ActivityType::MTIA_RUNTIME,
+           ActivityType::MTIA_INSIGHT,
            ActivityType::MTIA_CCP_EVENTS}));
 
   Config cfg2;


### PR DESCRIPTION
Summary: Create Activity Type for insight. User need to specify the activity type in the config to enable it

Differential Revision: D75237589


