### PR TITLE
Fix CUPTI Range Profiler test

### DIFF
--- a/libkineto/src/CuptiRangeProfilerApi.cpp
+++ b/libkineto/src/CuptiRangeProfilerApi.cpp
@@ -336,6 +336,7 @@ CuptiRBProfilerSession::CuptiRBProfilerSession(
   // used in unittests only
   if (opts.unitTest) {
     initSuccess_ = true;
+    unitTest_ = true;
     profiler_map[deviceId_] = this;
     return;
   }
@@ -714,7 +715,7 @@ bool CuptiRBProfilerSession::createCounterDataImage() {
 }
 
 CuptiRBProfilerSession::~CuptiRBProfilerSession() {
-  if (initSuccess_) {
+  if (initSuccess_ && !unitTest_) {
     CuptiRBProfilerSession::deInitCupti();
   }
 }

--- a/libkineto/src/CuptiRangeProfilerApi.h
+++ b/libkineto/src/CuptiRangeProfilerApi.h
@@ -209,6 +209,7 @@ class CuptiRBProfilerSession {
 
   bool initSuccess_ = false;
   bool profilingActive_ = false;
+  bool unitTest_ = false;
 
   friend void __trackCudaKernelLaunch(CUcontext ctx, const char* kernelName);
 };


### PR DESCRIPTION
Summary:
Fixes #949 
Simple fix that was causing a test failure earlier. The test mocks the object but the destructor calls CUDA deinit() API. This should have been fused out basically. 

https://github.com/pytorch/kineto/blob/main/libkineto/src/CuptiRangeProfilerApi.cpp#L716-L719

Differential Revision: D75494874


