### PR TITLE
Get rid of fmt::localtime

### DIFF
--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -296,7 +296,9 @@ const seconds Config::maxRequestAge() const {
 
 static std::string getTimeStr(time_point<system_clock> t) {
   std::time_t t_c = system_clock::to_time_t(t);
-  return fmt::format("{:%H:%M:%S}", fmt::localtime(t_c));
+  std::tm tm{};
+  localtime_r(&t_c, &tm);
+  return fmt::format("{:%H:%M:%S}", tm);
 }
 
 static time_point<system_clock> handleRequestTimestamp(int64_t ms) {
@@ -588,8 +590,9 @@ void Config::printActivityProfilerConfig(std::ostream& s) const {
     }
   } else if (hasProfileStartTime()) {
     std::time_t t_c = system_clock::to_time_t(requestTimestamp());
-    s << "  Trace start time: "
-      << fmt::format("{:%Y-%m-%d %H:%M:%S}", fmt::localtime(t_c));
+    std::tm tm{};
+    localtime_r(&t_c, &tm);
+    s << "  Trace start time: " << fmt::format("{:%Y-%m-%d %H:%M:%S}", tm);
     s << "  Trace duration: " << activitiesDuration().count() << "ms"
       << std::endl;
     s << "  Warmup duration: " << activitiesWarmupDuration().count() << "s"

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -39,8 +39,10 @@ Logger::Logger(int severity, int line, const char* filePath, int errnum)
 
   const auto tt =
       std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  std::tm tm_result;
+  localtime_r(&tt, &tm_result);
   const char* file = strrchr(filePath, '/');
-  buf_ << fmt::format("{:%Y-%m-%d %H:%M:%S}", fmt::localtime(tt)) << " "
+  buf_ << fmt::format("{:%Y-%m-%d %H:%M:%S}", tm_result) << " "
        << processId(false) << ":" << systemThreadId(false) << " "
        << (file ? file + 1 : filePath) << ":" << line << "] ";
 }

--- a/libkineto/src/output_csv.cpp
+++ b/libkineto/src/output_csv.cpp
@@ -50,11 +50,13 @@ void EventCSVLogger::handleSample(
   if (out_) {
     auto now = system_clock::now();
     auto time = system_clock::to_time_t(now);
+    std::tm tm_result;
+    localtime_r(&time, &tm_result);
     for (const Stat& s : sample.stats) {
       if (eventNames_.find(s.name) == eventNames_.end()) {
         continue;
       }
-      *out_ << fmt::format("{:%Y-%m-%d %H:%M:%S}", fmt::localtime(time)) << ",";
+      *out_ << fmt::format("{:%Y-%m-%d %H:%M:%S}", tm_result) << ",";
       *out_ << sample.deltaMsec << ",";
       *out_ << device << ",";
       *out_ << s.name;


### PR DESCRIPTION
Summary: fmt::localtime is deprecated. Use std for better compatability

Differential Revision: D75563129


