### PR TITLE
Enable all activities in range profiler mode and other fixes

### DIFF
--- a/libkineto/sample_programs/kineto_cupti_profiler.cpp
+++ b/libkineto/sample_programs/kineto_cupti_profiler.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <thread>
 
+#include <folly/init/Init.h>
 #include <libkineto.h>
 
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
@@ -20,11 +21,15 @@ using namespace kineto;
 
 static const std::string kFileName = "/tmp/kineto_playground_trace.json";
 
-int main() {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
   warmup();
 
   // Kineto config
   std::set<libkineto::ActivityType> types_cupti_prof = {
+      libkineto::ActivityType::CUDA_DRIVER,
+      libkineto::ActivityType::CUDA_RUNTIME,
+      libkineto::ActivityType::CONCURRENT_KERNEL,
       libkineto::ActivityType::CUDA_PROFILER_RANGE,
   };
 
@@ -39,7 +44,7 @@ int main() {
 
   std::string profiler_config =
       "ACTIVITIES_WARMUP_PERIOD_SECS=0\n "
-      "CUPTI_PROFILER_METRICS=kineto__cuda_core_flops\n "
+      "CUPTI_PROFILER_METRICS=kineto__cuda_core_flops,sm__inst_executed.sum\n "
       "CUPTI_PROFILER_ENABLE_PER_KERNEL=true";
 
   auto& profiler = libkineto::api().activityProfiler();

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -497,6 +497,7 @@ class CuptiActivityProfiler {
   bool gpuOnly_{false};
   bool cpuActivityPresent_{false};
   bool gpuActivityPresent_{false};
+  bool rangeProfilingActive_{false};
 
   // ***************************************************************************
   // Below state is shared with external threads.

--- a/libkineto/test/CuptiRangeProfilerTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerTest.cpp
@@ -181,7 +181,7 @@ void saveTrace(ActivityTrace& /*trace*/) {
 #endif
 }
 
-TEST_F(CuptiRangeProfilerTest, BasicTest) {
+TEST_F(CuptiRangeProfilerTest, BasicSetupTest) {
   EXPECT_NE(profiler_->name().size(), 0);
   EXPECT_EQ(profiler_->availableActivities(), getActivityTypes());
 
@@ -193,16 +193,6 @@ TEST_F(CuptiRangeProfilerTest, BasicTest) {
   cfg_->setSelectedActivityTypes({});
   EXPECT_EQ(profiler_->configure(incorrect_act_types, *cfg_).get(), nullptr)
       << "Profiler config should fail for wrong activity type";
-
-  incorrect_act_types.insert(ActivityType::CUDA_PROFILER_RANGE);
-
-  cfg_ = std::make_unique<Config>();
-  cfg_->setClientDefaults();
-  cfg_->setSelectedActivityTypes(incorrect_act_types);
-
-  EXPECT_EQ(profiler_->configure(incorrect_act_types, *cfg_).get(), nullptr)
-      << "Profiler config should fail if the activity types is not exclusively"
-      << " CUDA_PROFILER_RANGE";
 }
 
 TEST_F(CuptiRangeProfilerTest, UserRangeTest) {


### PR DESCRIPTION
Summary:
# Summary

Makes several updates to Kineto range profiler to enable co-running activity profiler (regular tracing mode). This will help setup a fix that handles dynamic kernels better.

## Changes
* Explicitly disable Range profiler for CUDA >= 12.6, where the API has now been replaced.
* Enabling GPU Activities in Range Profiler Mode, save a bool that can used to determine whether to enable or disable kernel callbacks. Add log message warnings if other GPU activities are not enabled.
* Sample Program Update

Reviewed By: nadavrot

Differential Revision: D75544122


