### PR TITLE
Fix open source CI failure on GCC 11.4.0

### DIFF
--- a/libkineto/test/CuptiRangeProfilerApiTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerApiTest.cpp
@@ -112,9 +112,9 @@ TEST(CuptiRangeProfilerApiTest, asyncLaunchAutoRange) {
       .metricNames = {"metricNames"},
       .deviceId = 0,
       .maxRanges = 1,
-      .has_gpu_activities_enabled_ = true,
       .numNestingLevels = 1,
-      .cuContext = ctx0};
+      .cuContext = ctx0,
+      .has_gpu_activities_enabled_ = true};
 
   std::unique_ptr<CuptiRBProfilerSession> session_ = mfactory.make(opts);
   auto session = mfactory.asDerived(session_.get());


### PR DESCRIPTION
Summary:
GCC gives an error about the order of initialization of fields in CuptiRangeProfilerOptions in a unit test:


  /kineto/libkineto/test/CuptiRangeProfilerApiTest.cpp: In member function ‘virtual void
  CuptiRangeProfilerApiTest_asyncLaunchAutoRange_Test::TestBody()’:
  /kineto/libkineto/test/CuptiRangeProfilerApiTest.cpp:117:24: error: designator order for field
  ‘libkineto::CuptiRangeProfilerOptions::numNestingLevels’ does not match declaration order in
  ‘libkineto::CuptiRangeProfilerOptions’
    117 |       .cuContext = ctx0};

This is a fix for T226111187.

Differential Revision: D75750612


