### PR TITLE
Fix fmt::format() in logging

### DIFF
--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -121,6 +121,7 @@ class GenericTraceActivity : public ITraceActivity {
       if (!first) {
         json << ", ";
       }
+      // Ok to use fmt::format here as we are not logging
       val.second ? json << fmt::format("\"{}\": \"{}\"", key, val.first)
                  : json << fmt::format("\"{}\": {}", key, val.first);
       first = false;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -12,6 +12,7 @@
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <fmt/ranges.h>
 #include <time.h>
 #include <chrono>
@@ -577,37 +578,46 @@ void Config::setReportPeriod(milliseconds msecs) {
 }
 
 void Config::printActivityProfilerConfig(std::ostream& s) const {
-  s << "  Log file: " << activitiesLogFile() << std::endl;
+  fmt::print(s, "  Log file: {}\n", activitiesLogFile());
   if (hasProfileStartIteration()) {
-    s << "  Trace start Iteration: " << profileStartIteration() << std::endl;
-    s << "  Trace warmup Iterations: " << activitiesWarmupIterations()
-      << std::endl;
-    s << "  Trace profile Iterations: " << activitiesRunIterations()
-      << std::endl;
+    fmt::print(
+        s,
+        "  Trace start Iteration: {}\n"
+        "  Trace warmup Iterations: {}\n"
+        "  Trace profile Iterations: {}\n",
+        profileStartIteration(),
+        activitiesWarmupIterations(),
+        activitiesRunIterations());
     if (profileStartIterationRoundUp() > 0) {
-      s << "  Trace start iteration roundup : "
-        << profileStartIterationRoundUp() << std::endl;
+      fmt::print(
+          "  Trace start iteration roundup : {}\n",
+          profileStartIterationRoundUp());
     }
   } else if (hasProfileStartTime()) {
     std::time_t t_c = system_clock::to_time_t(requestTimestamp());
     std::tm tm{};
     localtime_r(&t_c, &tm);
-    s << "  Trace start time: " << fmt::format("{:%Y-%m-%d %H:%M:%S}", tm);
-    s << "  Trace duration: " << activitiesDuration().count() << "ms"
-      << std::endl;
-    s << "  Warmup duration: " << activitiesWarmupDuration().count() << "s"
-      << std::endl;
+    fmt::print(
+        s,
+        "  Trace start time: {:%Y-%m-%d %H:%M:%S}\n"
+        "  Trace duration: {}ms\n"
+        "  Warmup duration: {}s\n",
+        tm,
+        activitiesDuration().count(),
+        activitiesWarmupDuration().count());
   }
 
-  s << "  Max GPU buffer size: " << activitiesMaxGpuBufferSize() / 1024 / 1024
-    << "MB" << std::endl;
+  fmt::print(
+      s,
+      "  Max GPU buffer size: {:.0f}MB\n",
+      activitiesMaxGpuBufferSize() / 1024.0 / 1024.0);
 
-  std::vector<const char*> activities;
+  std::vector<std::string> activities;
+  activities.reserve(selectedActivityTypes_.size());
   for (const auto& activity : selectedActivityTypes_) {
     activities.push_back(toString(activity));
   }
-  s << "  Enabled activities: " << fmt::format("{}", fmt::join(activities, ","))
-    << std::endl;
+  fmt::print(s, "  Enabled activities: {}\n", fmt::join(activities, ","));
 
   AbstractConfig::printActivityProfilerConfig(s);
 }

--- a/libkineto/src/CuptiNvPerfMetric.h
+++ b/libkineto/src/CuptiNvPerfMetric.h
@@ -32,6 +32,8 @@ struct CuptiProfilerResult {
 /* Utilities for CUPTI and NVIDIA PerfWorks Metric API
  */
 
+// ok to use fmt::format as error will not occur often. Can't use fmt::print
+// easily since LOG(...) can return void, causes compiler error
 #define NVPW_CALL(call)                                                \
   [&]() -> bool {                                                      \
     NVPA_Status _status_ = call;                                       \

--- a/libkineto/src/CuptiRangeProfilerConfig.cpp
+++ b/libkineto/src/CuptiRangeProfilerConfig.cpp
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <fmt/ranges.h>
 #include <ostream>
 
@@ -59,12 +60,14 @@ void CuptiRangeProfilerConfig::setDefaults() {
 void CuptiRangeProfilerConfig::printActivityProfilerConfig(
     std::ostream& s) const {
   if (activitiesCuptiMetrics_.size() > 0) {
-    s << "Cupti Profiler metrics : "
-      << fmt::format("{}", fmt::join(activitiesCuptiMetrics_, ", "))
-      << std::endl;
-    s << "Cupti Profiler measure per kernel : " << cuptiProfilerPerKernel_
-      << std::endl;
-    s << "Cupti Profiler max ranges : " << cuptiProfilerMaxRanges_ << std::endl;
+    fmt::print(
+        s,
+        "Cupti Profiler metrics : {}\n",
+        "Cupti Profiler measure per kernel : {}\n",
+        "Cupti Profiler max ranges : {}\n",
+        fmt::join(activitiesCuptiMetrics_, ", "),
+        cuptiProfilerPerKernel_,
+        cuptiProfilerMaxRanges_);
   }
 }
 

--- a/libkineto/src/DeviceUtil.h
+++ b/libkineto/src/DeviceUtil.h
@@ -15,6 +15,8 @@
 #include <cuda_runtime.h>
 #include <cupti.h>
 
+// ok to use fmt::format as error will not occur often. Can't use fmt::print
+// easily since LOG(...) can return void, causes compiler error
 #define CUDA_CALL(call)                                    \
   [&]() -> cudaError_t {                                   \
     cudaError_t _status_ = call;                           \

--- a/libkineto/src/EventProfiler.cpp
+++ b/libkineto/src/EventProfiler.cpp
@@ -9,6 +9,7 @@
 #include "EventProfiler.h"
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <fmt/ranges.h>
 #include <time.h>
 #include <algorithm>
@@ -144,7 +145,7 @@ struct Metric::CalculatedValues Metric::calculate(
 }
 
 void Metric::printDescription(ostream& s) const {
-  s << fmt::format("{} ({})", name, fmt::join(events_, ",")) << endl;
+  fmt::print(s, "{} ({})\n", name, fmt::join(events_, ","));
 }
 
 // ---------------------------------------------------------------------

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -21,6 +21,7 @@
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "ThreadUtil.h"
 
@@ -41,10 +42,15 @@ Logger::Logger(int severity, int line, const char* filePath, int errnum)
       std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
   std::tm tm_result;
   localtime_r(&tt, &tm_result);
-  const char* file = strrchr(filePath, '/');
-  buf_ << fmt::format("{:%Y-%m-%d %H:%M:%S}", tm_result) << " "
-       << processId(false) << ":" << systemThreadId(false) << " "
-       << (file ? file + 1 : filePath) << ":" << line << "] ";
+  const char* file = std::strrchr(filePath, '/');
+  fmt::print(
+      buf_,
+      "{:%Y-%m-%d %H:%M:%S} {}:{} {}:{}] ",
+      tm_result,
+      processId(false),
+      systemThreadId(false),
+      (file ? file + 1 : filePath),
+      line);
 }
 
 Logger::~Logger() {


### PR DESCRIPTION
Summary: Change << fmt::format() to fmt::print for *most* logging cases. We can't do it for the LOG(...) cases because it can return (void) 0 if the severity is not high enough. Luckly for us, these cases are rare as they only occur on unexpected errors. The big instances of this speedup occur in Logger.cpp and output_json.cpp and we are able to fix all instances of it.

Differential Revision: D75828524


