### PR TITLE
Optimize string2hex method in output.json

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -10,6 +10,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <iterator>
 #include <time.h>
 #include <fstream>
 #include "Config.h"

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -12,7 +12,6 @@
 #include <fmt/ostream.h>
 #include <time.h>
 #include <fstream>
-#include <iomanip>
 #include "Config.h"
 #include "TraceSpan.h"
 

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -10,9 +10,9 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
-#include <iterator>
 #include <time.h>
 #include <fstream>
+#include <iterator>
 #include "Config.h"
 #include "TraceSpan.h"
 

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -82,7 +82,7 @@ static std::string string2hex(const std::string& str) {
   std::string out;
   out.reserve(str.size() * 2);
   for (uint8_t c : str) {
-    // “:02x” → two‐digit, zero‐padded, lowercase hex
+    // “:02x” -> two‐digit, zero‐padded, lowercase hex
     fmt::format_to(std::back_inserter(out), "{:02x}", c);
   }
   return out;

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -80,12 +80,13 @@ void ChromeTraceLogger::sanitizeStrForJSON(std::string& value) {
 }
 
 static std::string string2hex(const std::string& str) {
-  std::stringstream ofs;
+  std::string out;
+  out.reserve(str.size() * 2);
   for (uint8_t c : str) {
-    ofs << std::nouppercase << std::setw(2) << std::setfill('0') << std::hex
-        << static_cast<int>(c);
+    // “:02x” → two‐digit, zero‐padded, lowercase hex
+    fmt::format_to(std::back_inserter(out), "{:02x}", c);
   }
-  return ofs.str();
+  return out;
 }
 
 static void sanitizeForNonReadableChars(std::string& value) {


### PR DESCRIPTION
Use libfmt APIs directly to convert value to hexstring.