### PR TITLE
Clear Buffer When Toggling

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1198,18 +1198,22 @@ void CuptiActivityProfiler::ensureCollectTraceDone() {
 void CuptiActivityProfiler::toggleCollectionDynamic(const bool enable) {
 #ifdef HAS_CUPTI
   if (enable) {
+    cupti_.clearActivities();
     cupti_.enableCuptiActivities(
         derivedConfig_->profileActivityTypes(),
         derivedConfig_->isPerThreadBufferEnabled());
   } else {
     cupti_.disableCuptiActivities(derivedConfig_->profileActivityTypes());
+    cupti_.clearActivities();
   }
 #endif
 #ifdef HAS_ROCTRACER
   if (enable) {
+    cupti_.clearActivities();
     cupti_.enableActivities(derivedConfig_->profileActivityTypes());
   } else {
     cupti_.disableActivities(derivedConfig_->profileActivityTypes());
+    cupti_.clearActivities();
   }
 #endif
 #ifdef HAS_XPUPTI


### PR DESCRIPTION
Summary: Get rid of extraneous events when toggling. We have seen that in D76431700 there can sometimes be a build up of "junk" events in CUPTI sent over because we are turning off activities without flushing. We should flush whenever we toggle to make sure these events get dropped

Differential Revision: D76453586
