### PR TITLE
Fix fmtlib bug in CuptiRangeProfilerConfig.cpp

### DIFF
--- a/libkineto/src/CuptiRangeProfilerConfig.cpp
+++ b/libkineto/src/CuptiRangeProfilerConfig.cpp
@@ -62,8 +62,8 @@ void CuptiRangeProfilerConfig::printActivityProfilerConfig(
   if (activitiesCuptiMetrics_.size() > 0) {
     fmt::print(
         s,
-        "Cupti Profiler metrics : {}\n",
-        "Cupti Profiler measure per kernel : {}\n",
+        "Cupti Profiler metrics : {}\n"
+        "Cupti Profiler measure per kernel : {}\n"
         "Cupti Profiler max ranges : {}\n",
         fmt::join(activitiesCuptiMetrics_, ", "),
         cuptiProfilerPerKernel_,


### PR DESCRIPTION
I'm surprised this compiled, it definitely will not on C++20 which has static compile time checks for this.