### PR TITLE
sync + flush when toggle profiler state

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -240,6 +240,12 @@ const std::pair<int, size_t> CuptiActivityApi::processActivities(
   return res;
 }
 
+void CuptiActivityApi::flushActivities() {
+#ifdef HAS_CUPTI
+  CUPTI_CALL(cuptiActivityFlushAll(0));
+#endif
+}
+
 void CuptiActivityApi::clearActivities() {
   {
     std::lock_guard<std::mutex> guard(mutex_);

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -60,6 +60,7 @@ class CuptiActivityApi {
   void disableCuptiActivities(
       const std::set<ActivityType>& selected_activities);
   void clearActivities();
+  void flushActivities();
   void teardownContext();
 
   virtual std::unique_ptr<CuptiActivityBufferMap> activityBuffers();

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1197,18 +1197,24 @@ void CuptiActivityProfiler::ensureCollectTraceDone() {
 }
 void CuptiActivityProfiler::toggleCollectionDynamic(const bool enable) {
 #ifdef HAS_CUPTI
+  CUDA_CALL(cudaDeviceSynchronize());
   if (enable) {
+    cupti_.flushActivities();
     cupti_.enableCuptiActivities(
         derivedConfig_->profileActivityTypes(),
         derivedConfig_->isPerThreadBufferEnabled());
   } else {
+    cupti_.flushActivities();
     cupti_.disableCuptiActivities(derivedConfig_->profileActivityTypes());
   }
 #endif
 #ifdef HAS_ROCTRACER
+  CUDA_CALL(cudaDeviceSynchronize());
   if (enable) {
+    cupti_.flushActivities();
     cupti_.enableActivities(derivedConfig_->profileActivityTypes());
   } else {
+    cupti_.flushActivities();
     cupti_.disableActivities(derivedConfig_->profileActivityTypes());
   }
 #endif

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -168,6 +168,9 @@ int RoctracerActivityApi::processActivities(
   return count;
 }
 
+// TODO: implement the actual flush with roctracer_flush_activity
+void RoctracerActivityApi::flushActivities() {}
+
 void RoctracerActivityApi::clearActivities() {
   d->clearLogs();
 }

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -43,6 +43,7 @@ class RoctracerActivityApi {
   void enableActivities(const std::set<ActivityType>& selected_activities);
   void disableActivities(const std::set<ActivityType>& selected_activities);
   void clearActivities();
+  void flushActivities();
   void teardownContext() {}
   void setMaxEvents(uint32_t maxEvents);
 

--- a/libkineto/src/plugin/xpupti/XpuptiActivityApi.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityApi.cpp
@@ -140,6 +140,12 @@ const std::pair<int, int> XpuptiActivityApi::processActivities(
   return res;
 }
 
+void XpuptiActivityApi::flushActivities() {
+#ifdef HAS_XPUPTI
+  XPUPTI_CALL(ptiFlushAllViews());
+#endif
+}
+
 void XpuptiActivityApi::clearActivities() {
   {
     std::lock_guard<std::mutex> guard(mutex_);

--- a/libkineto/src/plugin/xpupti/XpuptiActivityApi.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityApi.h
@@ -31,6 +31,7 @@ class XpuptiActivityApi {
       const std::set<ActivityType>& selected_activities);
   void disablePtiActivities(const std::set<ActivityType>& selected_activities);
   void clearActivities();
+  void flushActivities();
 
   virtual std::unique_ptr<XpuptiActivityBufferMap> activityBuffers();
 


### PR DESCRIPTION
Summary: When we try to toggle the profiler state, we need to synchronize and also flush the cupti buffer. Otherwise, the activities will be held within cupti, and the end time will be the next time we re-enable the activities.

Differential Revision: D76797072
