### PR TITLE
Fix libfmt linking

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -196,22 +196,6 @@ endif()
 target_compile_options(kineto_base PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_compile_options(kineto_api PRIVATE "${KINETO_COMPILE_OPTIONS}")
 
-if(NOT TARGET fmt::fmt-header-only)
-  if(NOT FMT_SOURCE_DIR)
-    set(FMT_SOURCE_DIR "${LIBKINETO_THIRDPARTY_DIR}/fmt"
-      CACHE STRING "fmt source directory from submodules")
-  endif()
-
-  # Build FMT.
-  # FMT and some other libraries use BUILD_SHARED_LIBS to control
-  # the library type.
-  # Save and restore the value after configuring FMT
-  add_subdirectory("${FMT_SOURCE_DIR}" "${LIBKINETO_BINARY_DIR}/fmt")
-endif()
-
-set(FMT_INCLUDE_DIR "${FMT_SOURCE_DIR}/include")
-message(STATUS "Kineto: FMT_SOURCE_DIR = ${FMT_SOURCE_DIR}")
-message(STATUS "Kineto: FMT_INCLUDE_DIR = ${FMT_INCLUDE_DIR}")
 if (NOT CUPTI_INCLUDE_DIR)
     set(CUPTI_INCLUDE_DIR "${CUDA_SOURCE_DIR}/extras/CUPTI/include")
 endif()
@@ -227,14 +211,28 @@ endif()
 
 set(DYNOLOG_INCLUDE_DIR "${LIBKINETO_THIRDPARTY_DIR}/dynolog/")
 set(IPCFABRIC_INCLUDE_DIR "${DYNOLOG_INCLUDE_DIR}/dynolog/src/ipcfabric/")
+add_subdirectory("${IPCFABRIC_INCLUDE_DIR}")
+
+if(NOT TARGET fmt::fmt-header-only)
+  if(NOT FMT_SOURCE_DIR)
+    set(FMT_SOURCE_DIR "${LIBKINETO_THIRDPARTY_DIR}/fmt"
+      CACHE STRING "fmt source directory from submodules")
+  endif()
+
+  # Build FMT.
+  # FMT and some other libraries use BUILD_SHARED_LIBS to control
+  # the library type.
+  # Save and restore the value after configuring FMT
+  add_subdirectory("${FMT_SOURCE_DIR}" "${LIBKINETO_BINARY_DIR}/fmt")
+  message(STATUS "Kineto: FMT_SOURCE_DIR = ${FMT_SOURCE_DIR}")
+endif()
 
 message(STATUS " CUPTI_INCLUDE_DIR = ${CUPTI_INCLUDE_DIR}")
 message(STATUS " ROCTRACER_INCLUDE_DIR = ${ROCTRACER_INCLUDE_DIR}")
 message(STATUS " DYNOLOG_INCLUDE_DIR = ${DYNOLOG_INCLUDE_DIR}")
 message(STATUS " IPCFABRIC_INCLUDE_DIR = ${IPCFABRIC_INCLUDE_DIR}")
 
-add_subdirectory("${IPCFABRIC_INCLUDE_DIR}")
-target_link_libraries(kineto_base PRIVATE dynolog_ipcfabric_lib dynolog_lib)
+target_link_libraries(kineto_base PRIVATE dynolog_ipcfabric_lib)
 
 target_include_directories(kineto_base PUBLIC
       $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>
@@ -308,5 +306,7 @@ install(EXPORT kinetoLibraryConfig DESTINATION share/cmake/kineto
 
 if(KINETO_BUILD_TESTS)
   add_subdirectory(test)
-  add_subdirectory("${LIBKINETO_THIRDPARTY_DIR}/googletest")
+  if(NOT TARGET gtest)
+    add_subdirectory("${LIBKINETO_THIRDPARTY_DIR}/googletest")
+  endif()
 endif()

--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -196,7 +196,7 @@ endif()
 target_compile_options(kineto_base PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_compile_options(kineto_api PRIVATE "${KINETO_COMPILE_OPTIONS}")
 
-if(NOT TARGET fmt)
+if(NOT TARGET fmt::fmt-header-only)
   if(NOT FMT_SOURCE_DIR)
     set(FMT_SOURCE_DIR "${LIBKINETO_THIRDPARTY_DIR}/fmt"
       CACHE STRING "fmt source directory from submodules")
@@ -206,12 +206,7 @@ if(NOT TARGET fmt)
   # FMT and some other libraries use BUILD_SHARED_LIBS to control
   # the library type.
   # Save and restore the value after configuring FMT
-  set(TEMP_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
-  set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libs" FORCE)
-  set(FMT_LIBRARY_TYPE static CACHE STRING "Set lib type to static")
   add_subdirectory("${FMT_SOURCE_DIR}" "${LIBKINETO_BINARY_DIR}/fmt")
-  set_property(TARGET fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
-  set(BUILD_SHARED_LIBS ${TEMP_BUILD_SHARED_LIBS} CACHE BOOL "Build shared libs" FORCE)
 endif()
 
 set(FMT_INCLUDE_DIR "${FMT_SOURCE_DIR}/include")
@@ -245,7 +240,6 @@ target_include_directories(kineto_base PUBLIC
       $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${LIBKINETO_SOURCE_DIR}>
       $<BUILD_INTERFACE:${DYNOLOG_INCLUDE_DIR}>
-      $<BUILD_INTERFACE:${FMT_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${IPCFABRIC_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${CUPTI_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
@@ -255,10 +249,11 @@ target_include_directories(kineto_base PUBLIC
 if(DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
   target_include_directories(kineto_base PUBLIC ${XPUPTI_INCLUDE_DIR})
 endif()
+target_link_libraries(kineto_base PRIVATE fmt::fmt-header-only)
 
 target_include_directories(kineto_api PUBLIC
-      $<BUILD_INTERFACE:${FMT_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>)
+target_link_libraries(kineto_api PRIVATE fmt::fmt-header-only)
 
 if(KINETO_LIBRARY_TYPE STREQUAL "static")
   add_library(kineto STATIC


### PR DESCRIPTION
Link `fmt::fmt-header-only` privately and remove unused code.