### PR TITLE
Bump Max Events to 5M

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -532,7 +532,7 @@ class Config : public AbstractConfig {
   std::string customConfig_;
 
   // Roctracer settings
-  uint32_t maxEvents_{1000000};
+  uint32_t maxEvents_{5000000};
 };
 
 constexpr char kUseDaemonEnvVar[] = "KINETO_USE_DAEMON";

--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -285,7 +285,7 @@ class RoctracerLogger {
   ApiIdList loggedIds_;
 
   // Api callback data
-  uint32_t maxBufferSize_{1000000}; // 1M GPU runtime/kernel events.
+  uint32_t maxBufferSize_{5000000}; // 5M GPU runtime/kernel events.
   std::vector<roctracerBase*> rows_;
   std::mutex rowsMutex_;
 


### PR DESCRIPTION
Summary: Users are commonly hitting the 1M event limit in roctracer and would rather not set the conf file for many jobs. Lets bump up the limit for now and tweek as necessary

Differential Revision: D78367831


