### PR TITLE
[CUPTI] Do not clear out per-thread buffer flag

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -202,6 +202,15 @@ std::unique_ptr<CuptiActivityBufferMap> CuptiActivityApi::activityBuffers() {
     flushOverhead =
         duration_cast<microseconds>(system_clock::now() - t1).count();
   }
+
+#if (CUDART_VERSION >= 12030)
+  // Clear out per-thread buffer flag in case it was set
+  uint8_t value = 0;
+  size_t sizeof_value = sizeof(value);
+
+  CUPTI_CALL(cuptiActivitySetAttribute(
+      CUPTI_ACTIVITY_ATTR_PER_THREAD_ACTIVITY_BUFFER, &sizeof_value, &value));
+#endif // (CUDART_VERSION >= 12030)
 #endif
   std::lock_guard<std::mutex> guard(mutex_);
   // Transfer ownership of buffers to caller. A new map is created on-demand.

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -419,14 +419,6 @@ void CuptiActivityApi::disableCuptiActivities(
     }
   }
   externalCorrelationEnabled_ = false;
-  // Clear out per-thread buffer flag in case it was set
-#if (CUDART_VERSION >= 12030)
-  uint8_t value = 0;
-  size_t sizeof_value = sizeof(value);
-
-  CUPTI_CALL(cuptiActivitySetAttribute(
-      CUPTI_ACTIVITY_ATTR_PER_THREAD_ACTIVITY_BUFFER, &sizeof_value, &value));
-#endif // (CUDART_VERSION >= 12030)
 #endif // HAS_CUPTI
 }
 


### PR DESCRIPTION
According to the [documentation](https://docs.nvidia.com/cupti/api/group__CUPTI__ACTIVITY__API.html#_CPPv4N23CUpti_ActivityAttribute46CUPTI_ACTIVITY_ATTR_PER_THREAD_ACTIVITY_BUFFERE) it is not safe to modify `CUPTI_ACTIVITY_ATTR_PER_THREAD_ACTIVITY_BUFFER` attribute: "Changing this attribute in the middle of the profiling session will result in undefined behavior."