### PR TITLE
Revert CMakeList files

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -4,17 +4,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
-project(kineto VERSION 0.1 LANGUAGES CXX C)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
 #install libraries into correct locations on all platforms
 include(GNUInstallDirs)
 
 # function to extract filelists from libkineto_defs.bzl file
-find_package(Python3 COMPONENTS Interpreter)
+find_package(PythonInterp)
 function(get_filelist name outputvar)
   execute_process(
-    COMMAND "${Python3_EXECUTABLE}" -c
+    COMMAND "${PYTHON_EXECUTABLE}" -c
             "exec(open('libkineto_defs.bzl').read());print(';'.join(${name}))"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     OUTPUT_VARIABLE _tempvar)
@@ -22,9 +23,11 @@ function(get_filelist name outputvar)
   set(${outputvar} ${_tempvar} PARENT_SCOPE)
 endfunction()
 
+project(kineto VERSION 0.1 LANGUAGES CXX C)
+
 set(KINETO_LIBRARY_TYPE "default" CACHE STRING
   "Type of library (default, static or shared) to build")
-set_property(CACHE KINETO_LIBRARY_TYPE PROPERTY STRINGS default shared static)
+set_property(CACHE KINETO_LIBRARY_TYPE PROPERTY STRINGS default shared)
 option(KINETO_BUILD_TESTS "Build kineto unit tests" ON)
 
 set(LIBKINETO_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -35,92 +38,109 @@ set(LIBKINETO_THIRDPARTY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 #We should default to a Release build
-if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
-  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
 
-if(DEFINED CUDA_SOURCE_DIR AND NOT DEFINED CUDAToolkit_ROOT)
-  set(CUDAToolkit_ROOT "${CUDA_SOURCE_DIR}")
-  message(STATUS " CUDA_SOURCE_DIR = ${CUDA_SOURCE_DIR}")
+if (NOT CUDA_SOURCE_DIR)
+    set(CUDA_SOURCE_DIR "$ENV{CUDA_SOURCE_DIR}")
+    message(STATUS " CUDA_SOURCE_DIR = ${CUDA_SOURCE_DIR}")
 endif()
 
-if(NOT ROCM_SOURCE_DIR)
-  set(ROCM_SOURCE_DIR "$ENV{ROCM_SOURCE_DIR}")
-  message(STATUS " ROCM_SOURCE_DIR = ${ROCM_SOURCE_DIR}")
+if (NOT ROCM_SOURCE_DIR)
+    set(ROCM_SOURCE_DIR "$ENV{ROCM_SOURCE_DIR}")
+    message(STATUS " ROCM_SOURCE_DIR = ${ROCM_SOURCE_DIR}")
+endif()
+
+if (KINETO_BUILD_TESTS)
+  enable_testing()
+  if (NOT CUDA_SOURCE_DIR)
+    set(CUDA_SOURCE_DIR "$ENV{CUDA_HOME}")
+    message(STATUS " CUDA_SOURCE_DIR = ${CUDA_SOURCE_DIR}")
+  endif()
+
+  if (NOT CUPTI_INCLUDE_DIR)
+    find_path(CUPTI_INCLUDE_DIR cupti.h PATHS
+        ${CUDA_SOURCE_DIR}/extras/CUPTI/include
+        ${CUDA_INCLUDE_DIRS}
+        ${CUDA_SOURCE_DIR}
+        ${CUDA_SOURCE_DIR}/include
+        NO_DEFAULT_PATH)
+  endif()
+
+  if (NOT CUDA_cupti_LIBRARY)
+    if(NOT MSVC)
+      set(CUPTI_LIB_NAME "libcupti.so")
+    else()
+      set(CUPTI_LIB_NAME "cupti.lib")
+    endif()
+    find_library(CUPTI_LIBRARY_PATH ${CUPTI_LIB_NAME} PATHS
+        ${CUDA_SOURCE_DIR}
+        ${CUDA_SOURCE_DIR}/extras/CUPTI/lib64
+        ${CUDA_SOURCE_DIR}/lib
+        ${CUDA_SOURCE_DIR}/lib64
+        NO_DEFAULT_PATH)
+  endif()
+
+  if (NOT CUDA_nvperf_host_LIBRARY)
+    set(CUDA_NVPERF_HOST_LIB_NAME "libnvperf_host.so")
+    find_library(CUDA_NVPERF_HOST_LIB_PATH ${CUDA_NVPERF_HOST_LIB_NAME} PATHS
+        ${CUDA_SOURCE_DIR}
+        ${CUDA_SOURCE_DIR}/extras/CUPTI/lib64
+        ${CUDA_SOURCE_DIR}/lib
+        ${CUDA_SOURCE_DIR}/lib64
+        NO_DEFAULT_PATH)
+  endif()
+
+  if (NOT CUDA_cudart_LIBRARY)
+    set(CUDA_CUDART_LIB_NAME "libcudart.so")
+    find_library(CUDA_CUDART_LIB_PATH ${CUDA_CUDART_LIB_NAME} PATHS
+        ${CUDA_SOURCE_DIR}
+        ${CUDA_SOURCE_DIR}/lib
+        ${CUDA_SOURCE_DIR}/lib64
+        NO_DEFAULT_PATH)
+  endif()
+
+  if(CUDA_NVPERF_HOST_LIB_PATH)
+    set(CUDA_nvperf_host_LIBRARY ${CUDA_NVPERF_HOST_LIB_PATH})
+    message(STATUS "  CUDA_nvperf_host_LIBRARY = ${CUDA_nvperf_host_LIBRARY}")
+  endif()
+
+  if(CUDA_CUDART_LIB_PATH)
+    set(CUDA_cudart_LIBRARY ${CUDA_CUDART_LIB_PATH})
+    message(STATUS "  CUDA_cudart_LIBRARY = ${CUDA_cudart_LIBRARY}")
+  endif()
+
+  if(CUPTI_LIBRARY_PATH AND CUPTI_INCLUDE_DIR)
+    message(STATUS "  CUPTI_INCLUDE_DIR = ${CUPTI_INCLUDE_DIR}")
+    set(CUDA_cupti_LIBRARY ${CUPTI_LIBRARY_PATH})
+    message(STATUS "  CUDA_cupti_LIBRARY = ${CUDA_cupti_LIBRARY}")
+    message(STATUS "Found CUPTI")
+    set(LIBKINETO_NOCUPTI OFF CACHE STRING "" FORCE)
+  else()
+    message(STATUS "Could not find CUPTI library")
+    set(LIBKINETO_NOCUPTI ON CACHE STRING "" FORCE)
+  endif()
 endif()
 
 # Set LIBKINETO_NOCUPTI to explicitly disable CUPTI
 # Otherwise, CUPTI is disabled if not found
-option(LIBKINETO_NOCUPTI "Disable CUPTI" OFF)
-
-find_package(CUDAToolkit)
-if(NOT LIBKINETO_NOCUPTI)
-  if(NOT CUPTI_INCLUDE_DIR)
-    find_path(CUPTI_INCLUDE_DIR cupti.h PATHS
-      "${CUDAToolkit_LIBRARY_ROOT}/extras/CUPTI/include"
-      "${CUDAToolkit_LIBRARY_ROOT}"
-      "${CUDAToolkit_LIBRARY_ROOT}/include"
-      NO_DEFAULT_PATH)
-  endif()
-
-  if(NOT CUDA_cupti_LIBRARY)
-    find_library(CUDA_cupti_LIBRARY cupti PATHS
-      "${CUDAToolkit_LIBRARY_ROOT}"
-      "${CUDAToolkit_LIBRARY_ROOT}/extras/CUPTI/lib64"
-      "${CUDAToolkit_LIBRARY_ROOT}/lib"
-      "${CUDAToolkit_LIBRARY_ROOT}/lib64"
-      NO_DEFAULT_PATH)
-  endif()
-
-  if(CUDA_cupti_LIBRARY AND CUPTI_INCLUDE_DIR)
-    message(STATUS "  CUPTI_INCLUDE_DIR = ${CUPTI_INCLUDE_DIR}")
-    message(STATUS "  CUDA_cupti_LIBRARY = ${CUDA_cupti_LIBRARY}")
-    message(STATUS "Found CUPTI")
-    if(NOT TARGET CUDA::cupti)
-      add_library(CUDA::cupti INTERFACE IMPORTED)
-      target_link_libraries(CUDA::cupti INTERFACE "${CUDA_cupti_LIBRARY}")
-    endif()
-    target_include_directories(CUDA::cupti INTERFACE "${CUPTI_INCLUDE_DIR}")
-  else()
+IF (NOT CUDA_SOURCE_DIR OR NOT CUPTI_INCLUDE_DIR OR NOT CUDA_cupti_LIBRARY)
     set(LIBKINETO_NOCUPTI ON CACHE BOOL "" FORCE)
-    message(STATUS "Could not find CUPTI library")
-  endif()
-endif()
-if(NOT TARGET CUDA::nvperf_host)
-  find_library(CUDA_NVPERF_HOST_LIB_PATH nvperf_host PATHS
-        "${CUDAToolkit_LIBRARY_ROOT}/lib/x64"
-        "${CUDAToolkit_LIBRARY_ROOT}/extras/CUPTI/lib64"
-        "${CUDAToolkit_LIBRARY_ROOT}/lib"
-        "${CUDAToolkit_LIBRARY_ROOT}/lib64"
-        NO_DEFAULT_PATH)
-  if(CUDA_NVPERF_HOST_LIB_PATH)
-    message(STATUS "Found NVPERF: ${CUDA_NVPERF_HOST_LIB_PATH}")
-    if(WIN32)
-      add_library(CUDA::nvperf_host SHARED IMPORTED)
-      set_target_properties(CUDA::nvperf_host PROPERTIES
-        IMPORTED_IMPLIB "${CUDA_NVPERF_HOST_LIB_PATH}"
-      )
-    else()
-      add_library(CUDA::nvperf_host INTERFACE IMPORTED)
-      target_link_libraries(CUDA::nvperf_host INTERFACE "${CUDA_NVPERF_HOST_LIB_PATH}")
-    endif()
-  endif()
 endif()
 
-if(NOT ROCM_SOURCE_DIR AND NOT ROCTRACER_INCLUDE_DIR)
-  set(LIBKINETO_NOROCTRACER ON CACHE BOOL "" FORCE)
+IF (NOT ROCM_SOURCE_DIR AND NOT ROCTRACER_INCLUDE_DIR)
+    set(LIBKINETO_NOROCTRACER ON CACHE BOOL "" FORCE)
 endif()
 
-if(DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
-  add_subdirectory(src/plugin/xpupti)
-else()
-  set(LIBKINETO_NOXPUPTI ON)
+IF (DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
+    add_subdirectory(src/plugin/xpupti)
 endif()
 
 # Define file lists
-if(LIBKINETO_NOCUPTI AND LIBKINETO_NOROCTRACER AND LIBKINETO_NOXPUPTI)
-  get_filelist("get_libkineto_cpu_only_srcs(with_api=False)" LIBKINETO_SRCS)
-  message(STATUS " CUPTI unavailable or disabled - not building GPU profilers")
+if (LIBKINETO_NOCUPTI AND LIBKINETO_NOROCTRACER AND LIBKINETO_NOXPUPTI)
+    get_filelist("get_libkineto_cpu_only_srcs(with_api=False)" LIBKINETO_SRCS)
+    message(STATUS " CUPTI unavailable or disabled - not building GPU profilers")
 else()
   if(NOT LIBKINETO_NOROCTRACER)
     get_filelist("get_libkineto_roctracer_srcs(with_api=False)" LIBKINETO_roc_SRCS)
@@ -144,44 +164,41 @@ add_library(kineto_api OBJECT ${LIBKINETO_API_SRCS})
 add_custom_target(libkineto_defs.bzl DEPENDS libkineto_defs.bzl)
 add_dependencies(kineto_base libkineto_defs.bzl)
 
-set(KINETO_DEFINITIONS "KINETO_NAMESPACE=libkineto")
-list(APPEND KINETO_DEFINITIONS "ENABLE_IPC_FABRIC")
-set(KINETO_COMPILE_OPTIONS)
-if(MSVC)
-  list(APPEND KINETO_COMPILE_OPTIONS "/utf-8")
+set_target_properties(kineto_base kineto_api PROPERTIES
+      CXX_STANDARD 17
+      CXX_STANDARD_REQUIRED YES
+      CXX_EXTENSIONS NO)
+
+set(KINETO_COMPILE_OPTIONS "-DKINETO_NAMESPACE=libkineto")
+list(APPEND KINETO_COMPILE_OPTIONS "-DFMT_HEADER_ONLY")
+list(APPEND KINETO_COMPILE_OPTIONS "-DENABLE_IPC_FABRIC")
+list(APPEND KINETO_COMPILE_OPTIONS)
+if(NOT MSVC)
+  list(APPEND KINETO_COMPILE_OPTIONS "-std=c++17")
+else()
+  list(APPEND KINETO_COMPILE_OPTIONS "/std:c++17")
+  list(APPEND KINETO_COMPILE_OPTIONS "-DWIN32_LEAN_AND_MEAN")
+  list(APPEND KINETO_COMPILE_OPTIONS "-DNOGDI")
 endif()
-if(NOT LIBKINETO_NOCUPTI)
-  list(APPEND KINETO_DEFINITIONS "HAS_CUPTI")
+if (NOT LIBKINETO_NOCUPTI)
+  list(APPEND KINETO_COMPILE_OPTIONS "-DHAS_CUPTI")
 endif()
-if(DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
+if (DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
   list(APPEND KINETO_COMPILE_OPTIONS ${XPUPTI_BUILD_FLAG})
 endif()
-if(TARGET CUDA::nvperf_host)
-  list(APPEND KINETO_DEFINITIONS "USE_CUPTI_RANGE_PROFILER")
+if (CUDA_nvperf_host_LIBRARY)
+  list(APPEND KINETO_COMPILE_OPTIONS "-DUSE_CUPTI_RANGE_PROFILER")
 endif()
-if(NOT LIBKINETO_NOROCTRACER)
-  list(APPEND KINETO_DEFINITIONS "HAS_ROCTRACER")
-  target_compile_definitions(kineto_base PRIVATE "__HIP_PLATFORM_HCC__")
-  target_compile_definitions(kineto_base PRIVATE "__HIP_PLATFORM_AMD__")
+if (NOT LIBKINETO_NOROCTRACER)
+    target_compile_options(kineto_base PRIVATE "-DHAS_ROCTRACER")
+    target_compile_options(kineto_base PRIVATE "-D__HIP_PLATFORM_HCC__")
+    target_compile_options(kineto_base PRIVATE "-D__HIP_PLATFORM_AMD__")
 endif()
 
-target_compile_definitions(kineto_base PUBLIC "${KINETO_DEFINITIONS}")
 target_compile_options(kineto_base PRIVATE "${KINETO_COMPILE_OPTIONS}")
-target_compile_definitions(kineto_api PUBLIC "${KINETO_DEFINITIONS}")
 target_compile_options(kineto_api PRIVATE "${KINETO_COMPILE_OPTIONS}")
 
-if(NOT ROCTRACER_INCLUDE_DIR)
-  set(ROCTRACER_INCLUDE_DIR "${ROCM_SOURCE_DIR}/include/roctracer")
-endif()
-if(NOT ROCM_INCLUDE_DIRS)
-  set(ROCM_INCLUDE_DIRS "${ROCM_SOURCE_DIR}/include")
-endif()
-
-set(DYNOLOG_INCLUDE_DIR "${LIBKINETO_THIRDPARTY_DIR}/dynolog/")
-set(IPCFABRIC_INCLUDE_DIR "${DYNOLOG_INCLUDE_DIR}/dynolog/src/ipcfabric/")
-add_subdirectory("${IPCFABRIC_INCLUDE_DIR}")
-
-if(NOT TARGET fmt::fmt-header-only)
+if(NOT TARGET fmt)
   if(NOT FMT_SOURCE_DIR)
     set(FMT_SOURCE_DIR "${LIBKINETO_THIRDPARTY_DIR}/fmt"
       CACHE STRING "fmt source directory from submodules")
@@ -191,59 +208,79 @@ if(NOT TARGET fmt::fmt-header-only)
   # FMT and some other libraries use BUILD_SHARED_LIBS to control
   # the library type.
   # Save and restore the value after configuring FMT
-  set(FMT_INSTALL OFF)
+  set(TEMP_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+  set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libs" FORCE)
+  set(FMT_LIBRARY_TYPE static CACHE STRING "Set lib type to static")
   add_subdirectory("${FMT_SOURCE_DIR}" "${LIBKINETO_BINARY_DIR}/fmt")
-  message(STATUS "Kineto: FMT_SOURCE_DIR = ${FMT_SOURCE_DIR}")
+  set_property(TARGET fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
+  set(BUILD_SHARED_LIBS ${TEMP_BUILD_SHARED_LIBS} CACHE BOOL "Build shared libs" FORCE)
 endif()
 
+set(FMT_INCLUDE_DIR "${FMT_SOURCE_DIR}/include")
+message(STATUS "Kineto: FMT_SOURCE_DIR = ${FMT_SOURCE_DIR}")
+message(STATUS "Kineto: FMT_INCLUDE_DIR = ${FMT_INCLUDE_DIR}")
+if (NOT CUPTI_INCLUDE_DIR)
+    set(CUPTI_INCLUDE_DIR "${CUDA_SOURCE_DIR}/extras/CUPTI/include")
+endif()
+if (NOT CUDA_INCLUDE_DIRS)
+    set(CUDA_INCLUDE_DIRS "${CUDA_SOURCE_DIR}/include")
+endif()
+if (NOT ROCTRACER_INCLUDE_DIR)
+    set(ROCTRACER_INCLUDE_DIR "${ROCM_SOURCE_DIR}/include/roctracer")
+endif()
+if (NOT ROCM_INCLUDE_DIRS)
+    set(ROCM_INCLUDE_DIRS "${ROCM_SOURCE_DIR}/include")
+endif()
+
+set(DYNOLOG_INCLUDE_DIR "${LIBKINETO_THIRDPARTY_DIR}/dynolog/")
+set(IPCFABRIC_INCLUDE_DIR "${DYNOLOG_INCLUDE_DIR}/dynolog/src/ipcfabric/")
+
+message(STATUS " CUPTI_INCLUDE_DIR = ${CUPTI_INCLUDE_DIR}")
 message(STATUS " ROCTRACER_INCLUDE_DIR = ${ROCTRACER_INCLUDE_DIR}")
 message(STATUS " DYNOLOG_INCLUDE_DIR = ${DYNOLOG_INCLUDE_DIR}")
 message(STATUS " IPCFABRIC_INCLUDE_DIR = ${IPCFABRIC_INCLUDE_DIR}")
 
+add_subdirectory("${IPCFABRIC_INCLUDE_DIR}")
 target_link_libraries(kineto_base PRIVATE dynolog_ipcfabric_lib)
 
 target_include_directories(kineto_base PUBLIC
       $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${LIBKINETO_SOURCE_DIR}>
       $<BUILD_INTERFACE:${DYNOLOG_INCLUDE_DIR}>
+      $<BUILD_INTERFACE:${FMT_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${IPCFABRIC_INCLUDE_DIR}>
+      $<BUILD_INTERFACE:${CUPTI_INCLUDE_DIR}>
+      $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
       $<BUILD_INTERFACE:${ROCTRACER_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${ROCM_INCLUDE_DIRS}>)
 
 if(DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
   target_include_directories(kineto_base PUBLIC ${XPUPTI_INCLUDE_DIR})
 endif()
-target_link_libraries(kineto_base PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
 
 target_include_directories(kineto_api PUBLIC
-      $<BUILD_INTERFACE:${LIBKINETO_DIR}>
+      $<BUILD_INTERFACE:${FMT_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>)
-target_link_libraries(kineto_api PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
 
 if(KINETO_LIBRARY_TYPE STREQUAL "static")
-  set(BUILD_SHARED_LIBS OFF)
-elseif(KINETO_LIBRARY_TYPE STREQUAL "shared")
-  set(BUILD_SHARED_LIBS ON)
-  set(WINDOWS_EXPORT_ALL_SYMBOLS ON)
-elseif(NOT KINETO_LIBRARY_TYPE STREQUAL "default")
-  message(FATAL_ERROR "Unsupported library type ${KINETO_LIBRARY_TYPE}")
-endif()
-
-add_library(kineto $<TARGET_OBJECTS:kineto_base> $<TARGET_OBJECTS:kineto_api>)
-if(BUILD_SHARED_LIBS)
+  add_library(kineto STATIC
+    $<TARGET_OBJECTS:kineto_base>
+    $<TARGET_OBJECTS:kineto_api>)
+elseif(KINETO_LIBRARY_TYPE STREQUAL "shared" OR (KINETO_LIBRARY_TYPE STREQUAL "default" AND BUILD_SHARED_LIBS))
+  add_library(kineto SHARED
+    $<TARGET_OBJECTS:kineto_base>
+    $<TARGET_OBJECTS:kineto_api>)
   set_property(TARGET kineto_base PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_property(TARGET kineto_api PROPERTY POSITION_INDEPENDENT_CODE ON)
-  set_target_properties(kineto PROPERTIES CXX_VISIBILITY_PRESET hidden)
+  set_target_properties(kineto PROPERTIES
+    CXX_VISIBILITY_PRESET hidden)
+elseif(KINETO_LIBRARY_TYPE STREQUAL "default")
+  add_library(kineto
+    $<TARGET_OBJECTS:kineto_base>
+    $<TARGET_OBJECTS:kineto_api>)
+else()
+  message(FATAL_ERROR "Unsupported library type ${KINETO_LIBRARY_TYPE}")
 endif()
-
-set_target_properties(kineto kineto_base kineto_api PROPERTIES
-      CXX_STANDARD 17
-      CXX_STANDARD_REQUIRED YES
-      CXX_EXTENSIONS NO)
-
-target_include_directories(kineto PUBLIC
-      $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>
-      $<BUILD_INTERFACE:${LIBKINETO_SOURCE_DIR}>)
 
 if(NOT LIBKINETO_NOROCTRACER)
   find_library(ROCTRACER_LIBRARY NAMES libroctracer64.so HINTS
@@ -255,35 +292,28 @@ if(NOT LIBKINETO_NOROCTRACER)
 endif()
 
 if(NOT LIBKINETO_NOCUPTI)
-  target_link_libraries(kineto PUBLIC CUDA::cupti CUDA::cudart CUDA::cuda_driver)
-  target_link_libraries(kineto_base PUBLIC CUDA::cupti CUDA::cudart CUDA::cuda_driver)
+  target_link_libraries(kineto "${CUDA_cupti_LIBRARY}")
 endif()
-if(TARGET CUDA::nvperf_host)
-  target_link_libraries(kineto_base PUBLIC CUDA::nvperf_host)
+if(CUDA_nvperf_host_LIBRARY)
+  target_link_libraries(kineto "${CUDA_nvperf_host_LIBRARY}")
 endif()
 if(DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
   target_link_libraries(kineto "${XPU_xpupti_LIBRARY}")
 endif()
-target_compile_definitions(kineto PUBLIC "${KINETO_DEFINITIONS}")
+target_link_libraries(kineto $<BUILD_INTERFACE:fmt::fmt-header-only>)
+add_dependencies(kineto fmt::fmt-header-only)
 
-if(KINETO_BUILD_TESTS)
-  if(NOT TARGET gtest)
-    set(INSTALL_GTEST OFF)
-    set(TMP_BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS}")
-    set(BUILD_SHARED_LIBS OFF)
-    add_subdirectory("${LIBKINETO_THIRDPARTY_DIR}/googletest")
-    set(BUILD_SHARED_LIBS "${TMP_BUILD_SHARED_LIBS}")
-  endif()
-  enable_testing()
-  add_subdirectory(test)
-endif()
-
-install(TARGETS kineto
-  EXPORT kinetoLibraryConfig
-  DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS kineto EXPORT kinetoLibraryConfig
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(FILES ${LIBKINETO_PUBLIC_HEADERS}
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/kineto")
 
 install(EXPORT kinetoLibraryConfig DESTINATION share/cmake/kineto
   FILE kinetoLibraryConfig.cmake)
+
+if(KINETO_BUILD_TESTS)
+  add_subdirectory(test)
+  add_subdirectory("${LIBKINETO_THIRDPARTY_DIR}/googletest")
+endif()

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -4,28 +4,31 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 include(GoogleTest)
-set(CMAKE_CXX_STANDARD 17)
 
-include_directories(${LIBKINETO_DIR})
-link_libraries(fmt::fmt-header-only)
 # ConfigTest
 add_executable(ConfigTest ConfigTest.cpp)
+target_compile_options(ConfigTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_link_libraries(ConfigTest PRIVATE
     gtest_main
-    kineto_base kineto_api)
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(ConfigTest PRIVATE "${LIBKINETO_DIR}")
 gtest_discover_tests(ConfigTest)
 
-if(NOT LIBKINETO_NOCUPTI)
 # CuptiActivityProfilerTest
 #[[
 add_executable(CuptiActivityProfilerTest
     CuptiActivityProfilerTest.cpp
     MockActivitySubProfiler.cpp)
+target_compile_options(CuptiActivityProfilerTest PRIVATE
+    "${KINETO_COMPILE_OPTIONS}")
 target_link_libraries(CuptiActivityProfilerTest PRIVATE
     gtest_main
     gmock
-    kineto_base kineto_api)
+    kineto
+    "${CUDA_cudart_LIBRARY}")
 target_include_directories(CuptiActivityProfilerTest PRIVATE
     "${LIBKINETO_DIR}"
     "${LIBKINETO_DIR}/include"
@@ -36,75 +39,129 @@ gtest_discover_tests(CuptiActivityProfilerTest)
 ]]
 # CuptiCallbackApiTest
 add_executable(CuptiCallbackApiTest CuptiCallbackApiTest.cpp)
+target_compile_options(CuptiCallbackApiTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_link_libraries(CuptiCallbackApiTest PRIVATE
     gtest_main
-    kineto_base kineto_api)
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiCallbackApiTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}"
+    "${CUDA_SOURCE_DIR}/include")
 gtest_discover_tests(CuptiCallbackApiTest)
 
 # CuptiRangeProfilerApiTest
-# add_executable(CuptiRangeProfilerApiTest CuptiRangeProfilerApiTest.cpp)
-# target_link_libraries(CuptiRangeProfilerApiTest PRIVATE
-#     gtest_main
-#     kineto
-#     CUDA::cupti
-#     $<BUILD_INTERFACE:fmt::fmt-header-only>)
+add_executable(CuptiRangeProfilerApiTest CuptiRangeProfilerApiTest.cpp)
+target_compile_options(CuptiRangeProfilerApiTest PRIVATE
+    "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(CuptiRangeProfilerApiTest PRIVATE
+    gtest_main
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiRangeProfilerApiTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src"
+    "${CUDA_SOURCE_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
 # Skipping due to SEGFault in 12.4
 # Tracked here: https://github.com/pytorch/kineto/issues/949
 # gtest_discover_tests(CuptiRangeProfilerApiTest)
 
 # CuptiRangeProfilerConfigTest
 add_executable(CuptiRangeProfilerConfigTest CuptiRangeProfilerConfigTest.cpp)
+target_compile_options(CuptiRangeProfilerConfigTest PRIVATE
+    "${KINETO_COMPILE_OPTIONS}")
 target_link_libraries(CuptiRangeProfilerConfigTest PRIVATE
     gtest_main
-    kineto_base kineto_api
-    $<BUILD_INTERFACE:fmt::fmt-header-only>)
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiRangeProfilerConfigTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include")
 gtest_discover_tests(CuptiRangeProfilerConfigTest)
 
 # CuptiRangeProfilerTest
-# add_executable(CuptiRangeProfilerTest CuptiRangeProfilerTest.cpp)
-# target_link_libraries(CuptiRangeProfilerTest PRIVATE
-#     gtest_main
-#     kineto
-#     CUDA::cupti
-#     $<BUILD_INTERFACE:fmt::fmt-header-only>)
+add_executable(CuptiRangeProfilerTest CuptiRangeProfilerTest.cpp)
+target_compile_options(CuptiRangeProfilerTest PRIVATE
+    "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(CuptiRangeProfilerTest PRIVATE
+    gtest_main
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiRangeProfilerTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src"
+    "${CUDA_SOURCE_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
 # Skipping due to SEGFault in 12.4
 # Tracked here: https://github.com/pytorch/kineto/issues/949
 # gtest_discover_tests(CuptiRangeProfilerTest)
 
 # CuptiStringsTest
 add_executable(CuptiStringsTest CuptiStringsTest.cpp)
+target_compile_options(CuptiStringsTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_link_libraries(CuptiStringsTest PRIVATE
     gtest_main
-    kineto_base kineto_api)
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiStringsTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${CUDA_SOURCE_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
 gtest_discover_tests(CuptiStringsTest)
 
 # EventProfilerTest
 add_executable(EventProfilerTest EventProfilerTest.cpp)
+target_compile_options(EventProfilerTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_link_libraries(EventProfilerTest PRIVATE
     gtest_main
     gmock
-    kineto_base kineto_api)
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(EventProfilerTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${CUDA_SOURCE_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
 gtest_discover_tests(EventProfilerTest)
-endif()
 
 # LoggerObserverTest
 add_executable(LoggerObserverTest LoggerObserverTest.cpp)
+target_compile_options(LoggerObserverTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_link_libraries(LoggerObserverTest PRIVATE
     gtest_main
-    kineto_base kineto_api)
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(LoggerObserverTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src")
 gtest_discover_tests(LoggerObserverTest)
 
 # PidInfoTest
 add_executable(PidInfoTest PidInfoTest.cpp)
+target_compile_options(PidInfoTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_link_libraries(PidInfoTest PRIVATE
     gtest_main
-    kineto_base kineto_api)
+    kineto
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(PidInfoTest PRIVATE "${LIBKINETO_DIR}")
 gtest_discover_tests(PidInfoTest)
 
 # CuptiProfilerApiTest
-# enable_language(CUDA)
-# add_executable(CuptiProfilerApiTest CuptiProfilerApiTest.cu)
-# target_link_libraries(CuptiProfilerApiTest PRIVATE
-#     kineto
-#     gtest_main)
+enable_language(CUDA)
+add_executable(CuptiProfilerApiTest CuptiProfilerApiTest.cu)
+target_compile_options(CuptiProfilerApiTest PRIVATE "${KINETO_COMPILE_OPTIONS}")
+target_link_libraries(CuptiProfilerApiTest PRIVATE
+    kineto
+    gtest_main
+    cuda
+    "${CUDA_cudart_LIBRARY}")
+target_include_directories(CuptiProfilerApiTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${CUPTI_INCLUDE_DIR}")
 #add_test(NAME CuptiProfilerApiTest_ COMMAND CuptiProfilerApiTest)


### PR DESCRIPTION
Summary:
Right now we are blocked from updating the Kineto Hash because of build issues on windows. Not only are windows builds broken, but also the CMakeLists were causing spurious errors in MacOS builds: https://github.com/pytorch/pytorch/issues/161510

Lets revert to the old version so there are no changes when updating the hash and then reintroduce the changes one-by one later to better understand what is breaking.

Differential Revision: D81332424


