### PR TITLE
Dynolog fix on MacOS

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -220,7 +220,6 @@ target_compile_options(kineto_api PRIVATE "${KINETO_COMPILE_OPTIONS}")
 
 set(DYNOLOG_INCLUDE_DIR "${LIBKINETO_THIRDPARTY_DIR}/dynolog/")
 set(IPCFABRIC_INCLUDE_DIR "${DYNOLOG_INCLUDE_DIR}/dynolog/src/ipcfabric/")
-add_subdirectory("${IPCFABRIC_INCLUDE_DIR}")
 
 if(NOT TARGET fmt::fmt-header-only)
   if(NOT FMT_SOURCE_DIR)
@@ -239,8 +238,6 @@ endif()
 
 message(STATUS " DYNOLOG_INCLUDE_DIR = ${DYNOLOG_INCLUDE_DIR}")
 message(STATUS " IPCFABRIC_INCLUDE_DIR = ${IPCFABRIC_INCLUDE_DIR}")
-
-target_link_libraries(kineto_base PRIVATE dynolog_ipcfabric_lib)
 
 target_include_directories(kineto_base PUBLIC
       $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>


### PR DESCRIPTION
Don't link to dynolog_ipcfabric_lib.