### PR TITLE
build: only build nvperf if cupti is available

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -86,26 +86,10 @@ if(NOT LIBKINETO_NOCUPTI)
     message(STATUS "Could not find CUPTI library")
   endif()
 endif()
-# Only look for NVPERF if CUPTI is enabled
-if(NOT LIBKINETO_NOCUPTI AND NOT TARGET CUDA::nvperf_host)
-  find_library(CUDA_NVPERF_HOST_LIB_PATH nvperf_host PATHS
-        "${CUDAToolkit_LIBRARY_ROOT}/lib/x64"
-        "${CUDAToolkit_LIBRARY_ROOT}/extras/CUPTI/lib64"
-        "${CUDAToolkit_LIBRARY_ROOT}/lib"
-        "${CUDAToolkit_LIBRARY_ROOT}/lib64"
-        NO_DEFAULT_PATH)
-  if(CUDA_NVPERF_HOST_LIB_PATH)
-    message(STATUS "Found NVPERF: ${CUDA_NVPERF_HOST_LIB_PATH}")
-    if(WIN32)
-      add_library(CUDA::nvperf_host SHARED IMPORTED)
-      set_target_properties(CUDA::nvperf_host PROPERTIES
-        IMPORTED_IMPLIB "${CUDA_NVPERF_HOST_LIB_PATH}"
-      )
-    else()
-      add_library(CUDA::nvperf_host INTERFACE IMPORTED)
-      target_link_libraries(CUDA::nvperf_host INTERFACE "${CUDA_NVPERF_HOST_LIB_PATH}")
-    endif()
-  endif()
+# NVPERF target is automatically available via FindCUDAToolkit starting in CUDA 10.2
+# Only check for NVPERF availability if CUPTI is enabled
+if(NOT LIBKINETO_NOCUPTI AND TARGET CUDA::nvperf_host)
+  message(STATUS "Found NVPERF: Using built-in FindCUDAToolkit target")
 endif()
 
 if(NOT ROCM_SOURCE_DIR AND NOT ROCTRACER_INCLUDE_DIR)
@@ -157,7 +141,7 @@ endif()
 if(DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
   list(APPEND KINETO_COMPILE_OPTIONS ${XPUPTI_BUILD_FLAG})
 endif()
-if(TARGET CUDA::nvperf_host)
+if(NOT LIBKINETO_NOCUPTI AND TARGET CUDA::nvperf_host)
   # Disable CUPTI range profiler on Windows temporarily. Should fix in future
   if(NOT WIN32)
     list(APPEND KINETO_DEFINITIONS "USE_CUPTI_RANGE_PROFILER")
@@ -263,7 +247,7 @@ if(NOT LIBKINETO_NOCUPTI)
   target_link_libraries(kineto PUBLIC CUDA::cupti CUDA::cudart CUDA::cuda_driver)
   target_link_libraries(kineto_base PUBLIC CUDA::cupti CUDA::cudart CUDA::cuda_driver)
 endif()
-if(TARGET CUDA::nvperf_host)
+if(NOT LIBKINETO_NOCUPTI AND TARGET CUDA::nvperf_host)
   target_link_libraries(kineto_base PUBLIC CUDA::nvperf_host)
 endif()
 if(DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)


### PR DESCRIPTION
This was resulting in errors like:

```
2025-09-03T00:00:09.6311541Z FAILED: bin/TCPStoreTest 
2025-09-03T00:00:09.6318245Z : && /opt/cache/bin/c++ -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Werror -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-stringop-overflow -DHAVE_AVX512_CPU_DEFINITION -DHAVE_AVX2_CPU_DEFINITION -O3 -DNDEBUG -DNDEBUG -rdynamic -Wl,--no-as-needed test_cpp_c10d/CMakeFiles/TCPStoreTest.dir/TCPStoreTest.cpp.o -o bin/TCPStoreTest -L/lib/intel64   -L/lib/intel64_win   -L/lib/win-x64 -Wl,-rpath,/lib/intel64:/lib/intel64_win:/lib/win-x64:/var/lib/jenkins/workspace/build/lib:  lib/libtorch_cpu.so  lib/libgtest_main.a  lib/libprotobuf.a  lib/libc10.so  /opt/conda/envs/py_3.12/lib/libmkl_intel_lp64.a  /opt/conda/envs/py_3.12/lib/libmkl_gnu_thread.a  /opt/conda/envs/py_3.12/lib/libmkl_core.a  -fopenmp  /usr/lib/x86_64-linux-gnu/libpthread.a  -lm  /usr/lib/x86_64-linux-gnu/libdl.a  lib/libgtest.a && /opt/conda/envs/py_3.12/lib/python3.12/site-packages/cmake/data/bin/cmake -E __run_co_compile --lwyu="ldd;-u;-r" --source=bin/TCPStoreTest && :
2025-09-03T00:00:09.6325463Z /usr/bin/ld: warning: libcuda.so.1, needed by lib/libtorch_cpu.so, not found (try using -rpath or -rpath-link)
2025-09-03T00:00:09.6326209Z /usr/bin/ld: lib/libtorch_cpu.so: undefined reference to `NVPW_InitializeHost'
```

Root cause of this issue was that some container images (like `ghcr.io/pytorch/ci-image:pytorch-linux-jammy-py3.12-halide-18d8825eadf4ad672ab335766741288aa9aef921`) may contain cudatoolkit locally despite building CPU builds which results in libkineto attempting to pick up nvperf (which it shouldn't for a CPU build).

This just makes it so that we don't build nvperf if CUPTI is not enabled.

The double negatives in the cmake files make it a bit difficult to read but that is basically what is happening.