### PR TITLE
build: Simplify CUPTI lookup, use built-in target

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -55,37 +55,14 @@ option(LIBKINETO_NOCUPTI "Disable CUPTI" OFF)
 
 find_package(CUDAToolkit)
 if(NOT LIBKINETO_NOCUPTI)
-  if(NOT CUPTI_INCLUDE_DIR)
-    find_path(CUPTI_INCLUDE_DIR cupti.h PATHS
-      "${CUDAToolkit_LIBRARY_ROOT}/extras/CUPTI/include"
-      "${CUDAToolkit_LIBRARY_ROOT}"
-      "${CUDAToolkit_LIBRARY_ROOT}/include"
-      NO_DEFAULT_PATH)
-  endif()
-
-  if(NOT CUDA_cupti_LIBRARY)
-    find_library(CUDA_cupti_LIBRARY cupti PATHS
-      "${CUDAToolkit_LIBRARY_ROOT}"
-      "${CUDAToolkit_LIBRARY_ROOT}/extras/CUPTI/lib64"
-      "${CUDAToolkit_LIBRARY_ROOT}/lib"
-      "${CUDAToolkit_LIBRARY_ROOT}/lib64"
-      NO_DEFAULT_PATH)
-  endif()
-
-  if(CUDA_cupti_LIBRARY AND CUPTI_INCLUDE_DIR)
-    message(STATUS "  CUPTI_INCLUDE_DIR = ${CUPTI_INCLUDE_DIR}")
-    message(STATUS "  CUDA_cupti_LIBRARY = ${CUDA_cupti_LIBRARY}")
+  if(TARGET CUDA::cupti)
     message(STATUS "Found CUPTI")
-    if(NOT TARGET CUDA::cupti)
-      add_library(CUDA::cupti INTERFACE IMPORTED)
-      target_link_libraries(CUDA::cupti INTERFACE "${CUDA_cupti_LIBRARY}")
-    endif()
-    target_include_directories(CUDA::cupti INTERFACE "${CUPTI_INCLUDE_DIR}")
   else()
     set(LIBKINETO_NOCUPTI ON CACHE BOOL "" FORCE)
     message(STATUS "Could not find CUPTI library")
   endif()
 endif()
+
 # NVPERF target is automatically available via FindCUDAToolkit starting in CUDA 10.2
 # Only check for NVPERF availability if CUPTI is enabled
 if(NOT LIBKINETO_NOCUPTI AND TARGET CUDA::nvperf_host)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1141
* #1140
* __->__ #1139

CMAKE has support for these now so we should use it.

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>

Differential Revision: [D81643912](https://our.internmc.facebook.com/intern/diff/D81643912)