### PR TITLE
Increase kMaxSymbolSize

### DIFF
--- a/libkineto/src/Demangle.cpp
+++ b/libkineto/src/Demangle.cpp
@@ -25,7 +25,7 @@ _Pragma("GCC diagnostic pop");
 
 namespace KINETO_NAMESPACE {
 
-static constexpr int kMaxSymbolSize = 1024;
+static constexpr int kMaxSymbolSize = 8192;
 
 std::string demangle(const char* name) {
 #ifndef _MSC_VER


### PR DESCRIPTION
Recently, while using torch profile, I found that some GPU kernel names are not being demangled, such as:
```
_ZN7cutlass13device_kernelINS_4gemm6kernel13GemmUniversalINS1_17GroupProblemShapeIN4cute5tupleIJlllEEEEENS1_10collective13CollectiveMmaINS1_39MainloopSm90ArrayTmaGmmaWarpSpecializedILi12ENS6_IJNS5_1CILi2EEENSC_ILi1EEESE_EEENS1_55KernelPtrArrayTmaWarpSpecializedCooperativeFP8FastAccumEEENS6_IJNSC_ILi128EEENSC_ILi16EEESI_EEENS_12float_e4m3_tEPNS6_IJlSE_NSC_ILi0EEEEEESL_SO_NS5_8TiledMMAINS5_8MMA_AtomIJNS5_4SM904GMMA30MMA_64x16x32_F32E4M3E4M3_SS_TNILNSS_7ScaleInE1ELSU_1EEEEEENS5_6LayoutISF_NS6_IJSE_SM_SM_EEEEENS6_IJNS5_10UnderscoreES10_S10_EEEEENS5_13SM90_TMA_LOADENS5_14ComposedLayoutINS5_7SwizzleILi3ELi4ELi3EEENS5_18smem_ptr_flag_bitsILi8EEENSX_INS6_IJNSC_ILi8EEESI_EEENS6_IJSI_SE_EEEEEEEvNS5_8identityENS5_23SM90_TMA_LOAD_MULTICASTES1D_vS1E_EENS_8epilogue10collective18CollectiveEpilogueINS1H_30Sm90PtrArrayTmaWarpSpecializedILi1ELi1ELi8ELb0ELb0ELi2EEEJSK_NS6_IJSI_SJ_EEEvPNS6_IJSE_lSM_EEENS_10bfloat16_tES1O_NS1H_6fusion15FusionCallbacksIS1L_NS1Q_17LinearCombinationIS1P_fvfLNS_15FloatRoundStyleE2EEESK_S1M_JEEES13_NS14_IS16_NS17_ILi16EEENSX_INS6_IJNSC_ILi64EEES19_EEENS6_IJSE_S1X_EEEEEEENS5_17SM75_U16x8_LDSM_TENS5_14SM90_TMA_STOREES21_NS5_17SM90_U16x8_STSM_TENS5_9Copy_AtomIJNS5_17SM90_U32x4_STSM_NENS_6half_tEEEEvEEEvvEEEEvNT_6ParamsE
```
I tried this name on http://demangler.com/ and it was parsed correctly, but kineto failed. The reason is that this kernel name exceeds the current kineto demangle length limit. To improve performance, many kernels extensively use complex C++ templates, making the kernel names extremely long. I hope to increase the kineto length limit so that it can properly demangle and display these names.