### PR TITLE
Add dynamic plugin along with counter events, cupti disable support

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -42,6 +42,7 @@ enum class ActivityType {
   HPU_OP, // HPU host side runtime event
   XPU_RUNTIME, // host side xpu runtime events
   COLLECTIVE_COMM, // collective communication
+  GPU_PM_COUNTER, // GPU performance monitoring counter
 
   // PRIVATEUSE1 Activity types are used for custom backends.
   // The corresponding device type is `DeviceType::PrivateUse1` in PyTorch.

--- a/libkineto/include/KinetoDynamicPluginInterface.h
+++ b/libkineto/include/KinetoDynamicPluginInterface.h
@@ -1,0 +1,448 @@
+#ifndef KINETO_DYNAMIC_PLUGIN_FORMAT_H
+#define KINETO_DYNAMIC_PLUGIN_FORMAT_H
+
+#include <stdint.h>
+
+#define KINETO_PLUGIN_LIB_DIR_PATH_ENV_VARIABLE "KINETO_PLUGIN_LIB_DIR_PATH"
+
+// NOTE: This file uses unpadded struct size for version control
+// To support backward compatibility, do NOT remove, reorder, or resize the
+// existing fields For details, visit
+// https://github.com/annarev/community/commit/09e231324c3b2b1f653c3f385fd2120edd460815
+#define KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(struct_type, last_field_name) \
+  (size_t)(offsetof(struct_type, last_field_name) +                      \
+           sizeof(((struct_type*)1000)->last_field_name))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Event types that can be supported via plugin. Please sync
+// with ActivityType.h if you add new event types.
+enum KinetoPlugin_ProfileEventType {
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_INVALID = 0,
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_CPU_OP, // cpu side ops
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_USER_ANNOTATION,
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_USER_ANNOTATION,
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_MEMCPY,
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_MEMSET,
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_CONCURRENT_KERNEL, // on-device kernels
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_EXTERNAL_CORRELATION,
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_RUNTIME, // host side cuda runtime
+                                                 // events
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_DRIVER, // host side cuda driver events
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_CPU_INSTANT_EVENT, // host side point-like
+                                                      // events
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_PYTHON_FUNCTION,
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_OVERHEAD, // CUPTI induced overhead events
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_MTIA_RUNTIME, // host side MTIA runtime
+                                                 // events
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_MTIA_CCP_EVENTS, // MTIA ondevice CCP events
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_MTIA_INSIGHT, // MTIA Insight Events
+                                                 // sampled from its overhead
+                                                 // API.
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_SYNC, // synchronization events between
+                                              // runtime and kernels
+  // Optional Activity types
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_GLOW_RUNTIME, // host side glow runtime
+                                                 // events
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_PROFILER_RANGE, // CUPTI Profiler range
+                                                        // for performance
+                                                        // metrics
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_HPU_OP, // HPU host side runtime event
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_XPU_RUNTIME, // host side xpu runtime events
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_COLLECTIVE_COMM, // collective communication
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_PM_COUNTER, // GPU performance monitoring
+                                                   // counter
+
+  // PRIVATEUSE1 Activity types are used for custom backends.
+  // The corresponding device type is `DeviceType::PrivateUse1` in PyTorch.
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_PRIVATEUSE1_RUNTIME, // host side privateUse1
+                                                        // runtime events
+  KINETO_PLUGIN_PROFILE_EVENT_TYPE_PRIVATEUSE1_DRIVER, // host side privateUse1
+                                                       // driver events
+
+  KINETO_PLUGIN_PROFILE_EVENT_NUM_TYPES
+};
+
+struct KinetoPlugin_ProfileEvent {
+  // Always set to KINETO_PLUGIN_PROFILE_EVENT_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+  // Event type
+  KinetoPlugin_ProfileEventType eventType;
+  // Start timestamp in UTC nanoseconds
+  int64_t startTimeUtcNs;
+  // End timestamp in UTC nanoseconds
+  int64_t endTimeUtcNs;
+  // Event ID
+  int64_t eventId;
+  // If CPU, equivalent to process ID
+  union {
+    int32_t deviceId;
+    int32_t processId;
+  };
+  // If CPU, equivalent to thread ID
+  union {
+    int32_t resourceId;
+    int32_t threadId;
+  };
+};
+#define KINETO_PLUGIN_PROFILE_EVENT_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(struct KinetoPlugin_ProfileEvent, threadId)
+
+enum KinetoPlugin_ProfileEventFlowType {
+  KINETO_PLUGIN_PROFILE_EVENT_FLOW_TYPE_INVALID = 0,
+  KINETO_PLUGIN_PROFILE_EVENT_FLOW_TYPE_FWD_BWD,
+  KINETO_PLUGIN_PROFILE_EVENT_FLOW_TYPE_ASYNC_CPU_GPU,
+  KINETO_PLUGIN_PROFILE_EVENT_NUM_FLOW_TYPES
+};
+
+struct KinetoPlugin_ProfileEventFlow {
+  // Always set to KINETO_PLUGIN_PROFILE_EVENT_FLOW_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+  // Flow type
+  KinetoPlugin_ProfileEventFlowType flowType;
+  // Use the same non-zero ID to connect two events
+  uint32_t flowId;
+  // Set to true if flow is a starting point
+  bool isStartPoint;
+};
+#define KINETO_PLUGIN_PROFILE_EVENT_FLOW_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                         \
+      struct KinetoPlugin_ProfileEventFlow, isStartPoint)
+
+struct KinetoPlugin_ProfileDeviceInfo {
+  // Always set to KINETO_PLUGIN_PROFILE_DEVICE_INFO_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+  // Device ID
+  int64_t deviceId;
+  // Device sort index
+  int64_t sortIndex;
+  // Device name
+  const char* pName;
+  // Device label
+  const char* pLabel;
+};
+#define KINETO_PLUGIN_PROFILE_DEVICE_INFO_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                          \
+      struct KinetoPlugin_ProfileDeviceInfo, pLabel)
+struct KinetoPlugin_ProfileResourceInfo {
+  // Always set to KINETO_PLUGIN_PROFILE_RESOURCE_INFO_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+  // If CPU, equivalent to process ID
+  union {
+    int32_t deviceId;
+    int32_t processId;
+  };
+  // If CPU, equivalent to thread ID
+  union {
+    int32_t resourceId;
+    int32_t threadId;
+  };
+  // Lower value is displayed more towards top
+  int32_t displayOrder;
+  // Textual display in the viewer (ephemeral pointer)
+  const char* pName;
+};
+#define KINETO_PLUGIN_PROFILE_RESOURCE_INFO_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                            \
+      struct KinetoPlugin_ProfileResourceInfo, pName)
+
+typedef struct KinetoPlugin_TraceBuilderHandle KinetoPlugin_TraceBuilderHandle;
+
+// Trace Builder is an opaque object provided by Kineto that helps the plugin
+// log event data without having to serialize down the wire over a C interface
+// Trace Builder also takes care of memory management / ownership
+struct KinetoPlugin_TraceBuilder {
+  // Always set to KINETO_PLUGIN_TRACE_BUILDER_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle;
+
+
+  // Usage: For each event, call addEvent(), then setLastEventName().
+  // Optionally call addLastEventMetadata() and setLastEventFlow().
+  // Use addDeviceInfo() and addResourceInfo() for device/resource metadata.
+  //
+  // Example:
+  //   KinetoPlugin_ProfileEvent event = {
+  //     .unpaddedStructSize = KINETO_PLUGIN_PROFILE_EVENT_UNPADDED_STRUCT_SIZE,
+  //     .eventType = KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_RUNTIME,
+  //     .startTimeUtcNs = 1000000000, .endTimeUtcNs = 1000005000,
+  //     .eventId = 1, .deviceId = 0, .resourceId = 123
+  //   };
+  //   traceBuilder->addEvent(traceBuilder->pTraceBuilderHandle, &event);
+  //   traceBuilder->setLastEventName(traceBuilder->pTraceBuilderHandle,
+  //   "cudaLaunchKernel");
+
+  // Several of these APIs do not have failure cases, but we still return an
+  // integer for future extensibility.
+
+  // returns 0 on success, -1 on failure, generally this is not expected to fail.
+  int (*addEvent)(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const struct KinetoPlugin_ProfileEvent* pProfileEvent);
+
+  // returns 0 on success, -1 on failure, this can happen if the last event is not set.
+  int (*setLastEventName)(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const char* pName);
+
+  // returns 0 on success, -1 on failure, this can happen if the last event is not set.
+  int (*setLastEventFlow)(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const struct KinetoPlugin_ProfileEventFlow* pProfileEventFlow);
+  // If metadata value is a string itself (e.g., "metadata value"), MUST add
+  // additional quote around it (e.g., "\"metadata value\"") If metadata value
+  // is a list (e.g., 1, 2, 3), MUST add square bracket around it (e.g., "[1, 2,
+  // 3]")
+  // returns 0 on success, -1 on failure, this can happen if the last event is not set.
+  int (*addLastEventMetadata)(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const char* pKey,
+      const char* pValue);
+
+  // returns 0 on success, -1 on failure, generally this is not expected to fail.
+  int (*addDeviceInfo)(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const struct KinetoPlugin_ProfileDeviceInfo* pProfileDeviceInfo);
+
+  // returns 0 on success, -1 on failure, generally this is not expected to fail.
+  int (*addResourceInfo)(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const struct KinetoPlugin_ProfileResourceInfo* pProfileResourceInfo);
+};
+#define KINETO_PLUGIN_TRACE_BUILDER_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                    \
+      struct KinetoPlugin_TraceBuilder, addResourceInfo)
+
+typedef struct KinetoPlugin_ProfilerHandle KinetoPlugin_ProfilerHandle;
+
+struct KinetoPlugin_ProfilerCreate_Params {
+  // Always set to KINETO_PLUGIN_PROFILER_CREATE_PARAMS_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // [out] An instance created by plugin
+  KinetoPlugin_ProfilerHandle* pProfilerHandle;
+
+  // [in] Enabled activity types.
+  KinetoPlugin_ProfileEventType* pEnabledActivityTypes;
+
+  // [in] Max length of pEnabledActivityTypes
+  size_t enabledActivityTypesMaxLen;
+};
+#define KINETO_PLUGIN_PROFILER_CREATE_PARAMS_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                             \
+      struct KinetoPlugin_ProfilerCreate_Params, enabledActivityTypesMaxLen)
+
+struct KinetoPlugin_ProfilerDestroy_Params {
+  // Always set to KINETO_PLUGIN_PROFILER_DESTROY_PARAMS_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // [in] An instance created via profilerCreate()
+  KinetoPlugin_ProfilerHandle* pProfilerHandle;
+};
+#define KINETO_PLUGIN_PROFILER_DESTROY_PARAMS_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                              \
+      struct KinetoPlugin_ProfilerDestroy_Params, pProfilerHandle)
+
+struct KinetoPlugin_ProfilerQuery_Params {
+  // Always set to KINETO_PLUGIN_PROFILER_QUERY_PARAMS_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // [in] An instance created via profilerCreate()
+  KinetoPlugin_ProfilerHandle* pProfilerHandle;
+
+  // [in/out] Memory space to receive profiler name
+  char* pProfilerName;
+
+  // [in] Max length of pProfilerName excluding null terminator
+  size_t profilerNameMaxLen;
+
+  // [in/out] Supported activity types.
+  KinetoPlugin_ProfileEventType* pSupportedActivityTypes;
+
+  // [in] Max length of pSupportedActivityTypes
+  size_t supportedActivityTypesMaxLen;
+};
+#define KINETO_PLUGIN_PROFILER_QUERY_PARAMS_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                            \
+      struct KinetoPlugin_ProfilerQuery_Params, supportedActivityTypesMaxLen)
+
+struct KinetoPlugin_ProfilerStart_Params {
+  // Always set to KINETO_PLUGIN_PROFILER_START_PARAMS_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // [in] An instance created via profilerCreate()
+  KinetoPlugin_ProfilerHandle* pProfilerHandle;
+};
+#define KINETO_PLUGIN_PROFILER_START_PARAMS_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                            \
+      struct KinetoPlugin_ProfilerStart_Params, pProfilerHandle)
+
+struct KinetoPlugin_ProfilerStop_Params {
+  // Always set to KINETO_PLUGIN_PROFILER_STOP_PARAMS_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // [in] An instance created via profilerCreate()
+  KinetoPlugin_ProfilerHandle* pProfilerHandle;
+};
+#define KINETO_PLUGIN_PROFILER_STOP_PARAMS_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                           \
+      struct KinetoPlugin_ProfilerStop_Params, pProfilerHandle)
+
+struct KinetoPlugin_ProfilerProcessEvents_Params {
+  // Always set to
+  // KINETO_PLUGIN_PROFILER_PROCESS_EVENTS_PARAMS_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // [in] An instance created via profilerCreate()
+  KinetoPlugin_ProfilerHandle* pProfilerHandle;
+
+  // [in] APIs to build a trace
+  const struct KinetoPlugin_TraceBuilder* pTraceBuilder;
+};
+#define KINETO_PLUGIN_PROFILER_PROCESS_EVENTS_PARAMS_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                                     \
+      struct KinetoPlugin_ProfilerProcessEvents_Params, pTraceBuilder)
+
+struct KinetoPlugin_ProfilerPushCorrelationId_Params {
+  // Always set to
+  // KINETO_PLUGIN_PROFILER_PUSH_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // [in] Correlation ID
+  uint64_t correlationId;
+
+  // [in] An instance created via profilerCreate()
+  KinetoPlugin_ProfilerHandle* pProfilerHandle;
+};
+#define KINETO_PLUGIN_PROFILER_PUSH_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                                          \
+      struct KinetoPlugin_ProfilerPushCorrelationId_Params, pProfilerHandle)
+
+struct KinetoPlugin_ProfilerPopCorrelationId_Params {
+  // Always set to
+  // KINETO_PLUGIN_PROFILER_POP_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // [in] An instance created via profilerCreate()
+  KinetoPlugin_ProfilerHandle* pProfilerHandle;
+};
+#define KINETO_PLUGIN_PROFILER_POP_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                                         \
+      struct KinetoPlugin_ProfilerPopCorrelationId_Params, pProfilerHandle)
+
+struct KinetoPlugin_ProfilerPushUserCorrelationId_Params {
+  // Always set to
+  // KINETO_PLUGIN_PROFILER_PUSH_USER_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // [in] User correlation ID
+  uint64_t userCorrelationId;
+
+  // [in] An instance created via profilerCreate()
+  KinetoPlugin_ProfilerHandle* pProfilerHandle;
+};
+#define KINETO_PLUGIN_PROFILER_PUSH_USER_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                                               \
+      struct KinetoPlugin_ProfilerPushUserCorrelationId_Params,                     \
+      pProfilerHandle)
+
+struct KinetoPlugin_ProfilerPopUserCorrelationId_Params {
+  // Always set to
+  // KINETO_PLUGIN_PROFILER_POP_USER_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // [in] An instance created via profilerCreate()
+  KinetoPlugin_ProfilerHandle* pProfilerHandle;
+};
+#define KINETO_PLUGIN_PROFILER_POP_USER_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                                              \
+      struct KinetoPlugin_ProfilerPopUserCorrelationId_Params,                     \
+      pProfilerHandle)
+
+struct KinetoPlugin_ProfilerInterface {
+  // Always set to KINETO_PLUGIN_PROFILER_INTERFACE_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  // Create an instance of the profiler session
+  int (*profilerCreate)(
+      struct KinetoPlugin_ProfilerCreate_Params* pProfilerCreateParams);
+
+  // Destroy an instance of the profiler session
+  int (*profilerDestroy)(
+      struct KinetoPlugin_ProfilerDestroy_Params* pProfilerDestroyParams);
+
+  // Query additional information about the profile such as its name, supported
+  // activity types, etc.
+  int (*profilerQuery)(
+      struct KinetoPlugin_ProfilerQuery_Params* pProfilerQueryParams);
+
+  // Start the trace collection
+  int (*profilerStart)(
+      struct KinetoPlugin_ProfilerStart_Params* pProfilerStartParams);
+
+  // Stop the trace collection
+  int (*profilerStop)(
+      struct KinetoPlugin_ProfilerStop_Params* pProfilerStopParams);
+
+  // The following interfaces are optional and can be used to track correlation
+  // IDs If not implemented, the correlation IDs will not be tracked through the
+  // profiler session.
+
+  // Push a correlation ID to the profiler session
+  int (*profilerPushCorrelationId)(
+      struct KinetoPlugin_ProfilerPushCorrelationId_Params*
+          pProfilerPushCorrelationIdParams);
+
+  // Pop a correlation ID from the profiler session
+  int (*profilerPopCorrelationId)(
+      struct KinetoPlugin_ProfilerPopCorrelationId_Params*
+          pProfilerPopCorrelationIdParams);
+
+  // Push a user correlation ID to the profiler session
+  int (*profilerPushUserCorrelationId)(
+      struct KinetoPlugin_ProfilerPushUserCorrelationId_Params*
+          pProfilerPushUserCorrelationIdParams);
+
+  // Pop a user correlation ID from the profiler session
+  int (*profilerPopUserCorrelationId)(
+      struct KinetoPlugin_ProfilerPopUserCorrelationId_Params*
+          pProfilerPopUserCorrelationIdParams);
+
+  // Process the events collected by the profiler session to the central
+  // profiler. This leverages the trace builder to enqueue events.
+  int (*profilerProcessEvents)(struct KinetoPlugin_ProfilerProcessEvents_Params*
+                                   pProfilerProcessEventsParams);
+};
+#define KINETO_PLUGIN_PROFILER_INTERFACE_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(                         \
+      struct KinetoPlugin_ProfilerInterface, profilerProcessEvents)
+
+typedef struct KinetoPlugin_RegistryHandle KinetoPlugin_RegistryHandle;
+
+struct KinetoPlugin_Registry {
+  // Always set to KINETO_PLUGIN_REGISTRY_UNPADDED_STRUCT_SIZE
+  size_t unpaddedStructSize;
+
+  KinetoPlugin_RegistryHandle* pRegistryHandle;
+
+  int (*registerProfiler)(
+      KinetoPlugin_RegistryHandle* pRegistryHandle,
+      const struct KinetoPlugin_ProfilerInterface* pProfiler);
+};
+#define KINETO_PLUGIN_REGISTRY_UNPADDED_STRUCT_SIZE \
+  KINETO_PLUGIN_UNPADDED_STRUCT_SIZE(               \
+      struct KinetoPlugin_Registry, registerProfiler)
+
+// .so function signature
+// To be implemented by plugin
+// To be called by Kineto
+int KinetoPlugin_register(const struct KinetoPlugin_Registry* pRegistry);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // KINETO_DYNAMIC_PLUGIN_FORMAT_H

--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -71,6 +71,10 @@ def get_libkineto_cpu_only_srcs(with_api = True):
         "src/init.cpp",
         "src/output_csv.cpp",
         "src/output_json.cpp",
+        "src/dynamic_plugin/PluginLoader.h",
+        "src/dynamic_plugin/PluginProfiler.h",
+        "src/dynamic_plugin/PluginTraceBuilder.h",
+        "src/dynamic_plugin/PluginUtils.h",
     ] + (get_libkineto_api_srcs() if with_api else [])
 
 def get_libkineto_public_headers():
@@ -81,6 +85,7 @@ def get_libkineto_public_headers():
         "include/ActivityType.h",
         "include/Config.h",
         "include/ClientInterface.h",
+        "include/KinetoDynamicPluginInterface.h",
         "include/GenericTraceActivity.h",
         "include/IActivityProfiler.h",
         "include/ILoggerObserver.h",

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -40,6 +40,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{
      {"hpu_op", ActivityType::HPU_OP},
      {"xpu_runtime", ActivityType::XPU_RUNTIME},
      {"collective_comm", ActivityType::COLLECTIVE_COMM},
+     {"gpu_pm_counter", ActivityType::GPU_PM_COUNTER},
      {"privateuse1_runtime", ActivityType::PRIVATEUSE1_RUNTIME},
      {"privateuse1_driver", ActivityType::PRIVATEUSE1_DRIVER},
      {"ENUM_COUNT", ActivityType::ENUM_COUNT}}};

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1520,7 +1520,7 @@ void CuptiActivityProfiler::finalizeTrace(
   if (!process_name.empty()) {
     logger.handleDeviceInfo(
         {pid, pid, process_name, "CPU"}, captureWindowStartTime_);
-    if (!cpuOnly_ && use_default_device_info) {
+    if (use_default_device_info) {
       // Usually, GPU events use device id as pid (0-7).
       // In some cases, CPU sockets are numbered starting from 0.
       // In the worst case, 8 CPU sockets + 8 GPUs, so the max GPU ID is 15.

--- a/libkineto/src/dynamic_plugin/PluginLoader.h
+++ b/libkineto/src/dynamic_plugin/PluginLoader.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <filesystem>
+
+#include "KinetoDynamicPluginInterface.h"
+#include "Logger.h"
+#include "PluginProfiler.h"
+
+namespace libkineto {
+
+#ifdef _WIN32
+constexpr const char* kPluginExtension = "dll";
+#elif defined(__linux__) || defined(__APPLE__)
+constexpr const char* kPluginExtension = "so";
+#else
+constexpr const char* kPluginExtension = "DONOTMATCHANYTHING";
+#endif
+
+class PluginRegistry {
+ public:
+  static PluginRegistry& instance() {
+    static PluginRegistry instance;
+    return instance;
+  }
+
+  int registerPluginProfiler(const KinetoPlugin_ProfilerInterface* pProfiler) {
+    if (pProfiler == nullptr) {
+      LOG(ERROR) << "Failed to register plugin profiler of nullptr";
+
+      return -1;
+    }
+
+    // Store in raw registry
+    rawPluginProfilers_.push_back(*pProfiler);
+
+    // Pass to internal registry
+    const auto& profiler = rawPluginProfilers_.back();
+    libkineto::api().registerProfilerFactory(
+        [profiler]() -> std::unique_ptr<IActivityProfiler> {
+          return std::make_unique<PluginProfiler>(profiler);
+        });
+
+    return 0;
+  }
+
+  const KinetoPlugin_Registry toCRegistry() {
+    return KinetoPlugin_Registry{
+        .unpaddedStructSize = KINETO_PLUGIN_REGISTRY_UNPADDED_STRUCT_SIZE,
+        .pRegistryHandle = reinterpret_cast<KinetoPlugin_RegistryHandle*>(this),
+        .registerProfiler = cRegisterProfiler};
+  }
+
+ private:
+  PluginRegistry() = default;
+  ~PluginRegistry() = default;
+  PluginRegistry(const PluginRegistry&) = delete;
+  PluginRegistry& operator=(const PluginRegistry&) = delete;
+
+  static int cRegisterProfiler(
+      KinetoPlugin_RegistryHandle* pRegistryHandle,
+      const KinetoPlugin_ProfilerInterface* pProfiler) {
+    auto pPluginRegistry = reinterpret_cast<PluginRegistry*>(pRegistryHandle);
+    return pPluginRegistry->registerPluginProfiler(pProfiler);
+  }
+
+  std::vector<KinetoPlugin_ProfilerInterface> rawPluginProfilers_;
+};
+
+inline void loadPlugins() {
+  const char* pPluginLibDirPathEnvVar = KINETO_PLUGIN_LIB_DIR_PATH_ENV_VARIABLE;
+
+  const char* pPluginLibDirPath = getenv(pPluginLibDirPathEnvVar);
+
+  if (pPluginLibDirPath == nullptr) {
+    LOG(VERBOSE) << "Environment variable " << pPluginLibDirPathEnvVar
+                 << " not set";
+
+    return;
+  }
+
+  std::vector<std::string> libFilePaths;
+  try {
+    for (const auto& entry :
+         std::filesystem::directory_iterator(pPluginLibDirPath)) {
+      if (entry.is_regular_file() && entry.path().extension() == kPluginExtension) {
+        libFilePaths.push_back(entry.path().string());
+      }
+    }
+  } catch (const std::filesystem::filesystem_error& e) {
+    LOG(ERROR) << "Error: " << e.what();
+
+    return;
+  }
+
+  PluginRegistry& pluginRegistry = PluginRegistry::instance();
+  KinetoPlugin_Registry cPluginRegistry = pluginRegistry.toCRegistry();
+
+  for (const auto& libFilePath : libFilePaths) {
+    // Clear error state
+    dlerror();
+
+    void* pHandle = dlopen(libFilePath.c_str(), RTLD_LAZY);
+    if (pHandle == nullptr) {
+      char* pError = dlerror();
+      LOG(WARNING) << "Failed to open " << libFilePath
+                   << " at dlopen() with error " << pError;
+      continue;
+    }
+
+    int (*pfxRegister)(const KinetoPlugin_Registry* pRegistry) =
+        reinterpret_cast<int (*)(const KinetoPlugin_Registry* pRegistry)>(
+            dlsym(pHandle, "KinetoPlugin_register"));
+
+    if (pfxRegister == nullptr) {
+      char* pError = dlerror();
+      LOG(VERBOSE) << "Failed to find symbol KinetoPlugin_register() from "
+                   << libFilePath << " at dlsym() with error " << pError;
+      dlclose(pHandle);
+      continue;
+    }
+
+    LOG(INFO) << "Found symbol KinetoPlugin_register() from " << libFilePath;
+
+    int errorCode = pfxRegister(&cPluginRegistry);
+    if (errorCode != 0) {
+      LOG(ERROR) << "Failed to register plugin profiler from " << libFilePath
+                 << " at pfxRegister() with error " << errorCode;
+      dlclose(pHandle);
+      continue;
+    }
+  }
+
+  return;
+}
+
+} // namespace libkineto

--- a/libkineto/src/dynamic_plugin/PluginProfiler.h
+++ b/libkineto/src/dynamic_plugin/PluginProfiler.h
@@ -1,0 +1,494 @@
+#pragma once
+
+#include <libkineto.h>
+#include <chrono>
+
+#include "IActivityProfiler.h"
+#include "Logger.h"
+#include "output_base.h"
+
+#include "KinetoDynamicPluginInterface.h"
+#include "PluginTraceBuilder.h"
+#include "PluginUtils.h"
+
+namespace libkineto {
+
+// This file handles pure C plugin profiler interface and converts to internal
+// profiler interface
+
+class PluginProfilerSession : public IActivityProfilerSession {
+ public:
+  PluginProfilerSession(
+      const KinetoPlugin_ProfilerInterface& profiler,
+      const std::string& name,
+      const std::set<ActivityType>& enabled_activity_types)
+      : name_(name),
+        profiler_(profiler),
+        enabled_activity_types_(enabled_activity_types) {
+    KinetoPlugin_ProfilerCreate_Params createParams{
+        KINETO_PLUGIN_PROFILER_CREATE_PARAMS_UNPADDED_STRUCT_SIZE};
+
+    std::vector<KinetoPlugin_ProfileEventType> enabledActivityTypes =
+        convertActivityTypeSet(enabled_activity_types_);
+    createParams.pEnabledActivityTypes = enabledActivityTypes.data();
+    createParams.enabledActivityTypesMaxLen = enabledActivityTypes.size();
+
+    int errorCode = profiler_.profilerCreate(&createParams);
+    if (errorCode != 0) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " failed at profilerCreate() with error " << errorCode;
+      pProfilerHandle_ = nullptr;
+    } else {
+      pProfilerHandle_ = createParams.pProfilerHandle;
+    }
+  }
+
+  ~PluginProfilerSession() {
+    if (pProfilerHandle_ == nullptr) {
+      return;
+    }
+
+    KinetoPlugin_ProfilerDestroy_Params destroyParams{
+        KINETO_PLUGIN_PROFILER_DESTROY_PARAMS_UNPADDED_STRUCT_SIZE};
+    destroyParams.pProfilerHandle = pProfilerHandle_;
+
+    int errorCode = profiler_.profilerDestroy(&destroyParams);
+    if (errorCode != 0) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " failed at profilerDestroy() with error " << errorCode;
+    }
+  }
+
+  // start the trace collection synchronously
+  void start() override {
+    lastStartTimestampUtcNs_ =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+
+    if (pProfilerHandle_ == nullptr) {
+      return;
+    }
+
+    KinetoPlugin_ProfilerStart_Params startParams{
+        KINETO_PLUGIN_PROFILER_START_PARAMS_UNPADDED_STRUCT_SIZE};
+    startParams.pProfilerHandle = pProfilerHandle_;
+
+    int errorCode = profiler_.profilerStart(&startParams);
+    if (errorCode != 0) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " failed at profilerStart() with error " << errorCode;
+    }
+  }
+
+  // stop the trace collection synchronously
+  void stop() override {
+    lastStopTimestampUtcNs_ =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+
+    if (pProfilerHandle_ == nullptr) {
+      return;
+    }
+
+    KinetoPlugin_ProfilerStop_Params stopParams{
+        KINETO_PLUGIN_PROFILER_STOP_PARAMS_UNPADDED_STRUCT_SIZE};
+    stopParams.pProfilerHandle = pProfilerHandle_;
+
+    int errorCode = profiler_.profilerStop(&stopParams);
+    if (errorCode != 0) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " failed at profilerStop() with error " << errorCode;
+    }
+  }
+
+  void pushCorrelationId(uint64_t id) override {
+    KinetoPlugin_ProfilerPushCorrelationId_Params pushCorrelationIdParams{
+        KINETO_PLUGIN_PROFILER_PUSH_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE};
+    pushCorrelationIdParams.pProfilerHandle = pProfilerHandle_;
+    pushCorrelationIdParams.correlationId = id;
+
+    int errorCode =
+        profiler_.profilerPushCorrelationId(&pushCorrelationIdParams);
+    if (errorCode != 0) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " failed at profilerPushCorrelationId() with error "
+                 << errorCode;
+    }
+  }
+
+  void popCorrelationId() override {
+    KinetoPlugin_ProfilerPopCorrelationId_Params popCorrelationIdParams{
+        KINETO_PLUGIN_PROFILER_POP_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE};
+    popCorrelationIdParams.pProfilerHandle = pProfilerHandle_;
+
+    int errorCode = profiler_.profilerPopCorrelationId(&popCorrelationIdParams);
+    if (errorCode != 0) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " failed at profilerPopCorrelationId() with error "
+                 << errorCode;
+    }
+  }
+
+  void pushUserCorrelationId(uint64_t id) override {
+    KinetoPlugin_ProfilerPushUserCorrelationId_Params pushUserCorrelationIdParams{
+        KINETO_PLUGIN_PROFILER_PUSH_USER_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE};
+    pushUserCorrelationIdParams.pProfilerHandle = pProfilerHandle_;
+    pushUserCorrelationIdParams.userCorrelationId = id;
+
+    int errorCode =
+        profiler_.profilerPushUserCorrelationId(&pushUserCorrelationIdParams);
+    if (errorCode != 0) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " failed at profilerPushUserCorrelationId() with error "
+                 << errorCode;
+    }
+  }
+
+  void popUserCorrelationId() override {
+    KinetoPlugin_ProfilerPopUserCorrelationId_Params popUserCorrelationIdParams{
+        KINETO_PLUGIN_PROFILER_POP_USER_CORRELATION_ID_PARAMS_UNPADDED_STRUCT_SIZE};
+    popUserCorrelationIdParams.pProfilerHandle = pProfilerHandle_;
+
+    int errorCode =
+        profiler_.profilerPopUserCorrelationId(&popUserCorrelationIdParams);
+    if (errorCode != 0) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " failed at profilerPopUserCorrelationId() with error "
+                 << errorCode;
+    }
+  }
+
+  TraceStatus status() {
+    return status_;
+  }
+
+  // returns errors with this trace
+  std::vector<std::string> errors() override {
+    return {};
+  }
+
+  // processes trace activities using logger
+  void processTrace(ActivityLogger& logger) override {
+    if (pProfilerHandle_ == nullptr) {
+      return;
+    }
+
+    auto traceSpan =
+        TraceSpan(lastStartTimestampUtcNs_, lastStopTimestampUtcNs_, name_);
+    PluginTraceBuilder pluginTraceBuilder{traceSpan};
+    const KinetoPlugin_TraceBuilder traceBuilder =
+        pluginTraceBuilder.toCTraceBuilder();
+
+    KinetoPlugin_ProfilerProcessEvents_Params profilerProcessEventsParams{
+        KINETO_PLUGIN_PROFILER_PROCESS_EVENTS_PARAMS_UNPADDED_STRUCT_SIZE};
+    profilerProcessEventsParams.pProfilerHandle = pProfilerHandle_;
+    profilerProcessEventsParams.pTraceBuilder = &traceBuilder;
+
+    int errorCode =
+        profiler_.profilerProcessEvents(&profilerProcessEventsParams);
+    if (errorCode != 0) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " failed at profilerProcessEvents() with error "
+                 << errorCode;
+    }
+
+    // Take ownership of trace buffer from builder
+    traceBuffer_ = pluginTraceBuilder.getTraceBuffer();
+    deviceInfos_ = pluginTraceBuilder.getDeviceInfos();
+    resourceInfos_ = pluginTraceBuilder.getResourceInfos();
+
+    // Log events
+    for (const auto& event : traceBuffer_->activities) {
+      static_assert(
+          std::is_same<
+              std::remove_reference<decltype(event)>::type,
+              const std::unique_ptr<GenericTraceActivity>>::value,
+          "handleActivity is unsafe and relies on the caller to maintain not "
+          "only lifetime but also address stability.");
+      logger.handleActivity(*event);
+    }
+
+    return;
+  }
+
+  // returns device info used in this trace, could be nullptr
+  std::unique_ptr<DeviceInfo> getDeviceInfo() override {
+    if (deviceInfos_.empty()) {
+      return {};
+    }
+    return std::make_unique<DeviceInfo>(deviceInfos_[0]);
+  }
+
+  // returns resource info used in this trace, could be empty
+  std::vector<ResourceInfo> getResourceInfos() override {
+    return resourceInfos_;
+  }
+
+  // release ownership of the trace events and metadata
+  std::unique_ptr<CpuTraceBuffer> getTraceBuffer() override {
+    return std::move(traceBuffer_);
+  }
+
+ private:
+  std::unique_ptr<CpuTraceBuffer> traceBuffer_;
+  std::vector<DeviceInfo> deviceInfos_;
+  std::vector<ResourceInfo> resourceInfos_;
+  const KinetoPlugin_ProfilerInterface profiler_;
+  KinetoPlugin_ProfilerHandle* pProfilerHandle_ = nullptr;
+  std::string name_;
+  std::set<ActivityType> enabled_activity_types_;
+  int64_t lastStartTimestampUtcNs_ = 0;
+  int64_t lastStopTimestampUtcNs_ = 0;
+};
+
+class PluginProfiler : public IActivityProfiler {
+ public:
+  PluginProfiler(const KinetoPlugin_ProfilerInterface& profiler)
+      : profiler_(profiler), isValid_(true) {
+    isValid_ = validateProfiler();
+    if (!isValid_) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " is not valid; skipping registration";
+      return;
+    }
+
+    char profilerName[32];
+
+    std::array<
+        KinetoPlugin_ProfileEventType,
+        KINETO_PLUGIN_PROFILE_EVENT_NUM_TYPES>
+        supportedActivityTypes;
+    std::fill(
+        supportedActivityTypes.begin(),
+        supportedActivityTypes.end(),
+        KINETO_PLUGIN_PROFILE_EVENT_TYPE_INVALID);
+
+    KinetoPlugin_ProfilerQuery_Params queryParams{
+        KINETO_PLUGIN_PROFILER_QUERY_PARAMS_UNPADDED_STRUCT_SIZE};
+    queryParams.pProfilerHandle = nullptr;
+    queryParams.pProfilerName = &profilerName[0];
+    queryParams.profilerNameMaxLen = 31;
+    queryParams.pSupportedActivityTypes = &supportedActivityTypes[0];
+    queryParams.supportedActivityTypesMaxLen = supportedActivityTypes.size();
+
+    int errorCode = profiler_.profilerQuery(&queryParams);
+    if (errorCode != 0) {
+      name_.assign("N/A");
+    } else {
+      name_.assign(queryParams.pProfilerName);
+    }
+
+    supportedActivities_.clear();
+    for (size_t i = 0; i < supportedActivityTypes.size(); i++) {
+      if (supportedActivityTypes[i] !=
+          KINETO_PLUGIN_PROFILE_EVENT_TYPE_INVALID) {
+        supportedActivities_.insert(
+            convertToActivityType(supportedActivityTypes[i]));
+      }
+    }
+  }
+
+  ~PluginProfiler() = default;
+
+  const std::string& name() const override {
+    return name_;
+  }
+
+  const std::set<ActivityType>& availableActivities() const override {
+    return supportedActivities_;
+  }
+
+  std::unique_ptr<IActivityProfilerSession> configure(
+      const std::set<ActivityType>& activity_types,
+      const Config& /*config*/) override {
+    // Check if profiler is valid
+    if (!isValid_) {
+      LOG(ERROR) << "Plugin profiler " << name_
+                 << " is not valid, cannot configure";
+      return nullptr;
+    }
+
+    // Check if the plugin supports ANY of the requested activity types
+    // and compute the intersection of requested and supported types
+    std::set<ActivityType> enabledTypes;
+    for (const auto& activity_type : activity_types) {
+      if (supportedActivities_.find(activity_type) !=
+          supportedActivities_.end()) {
+        enabledTypes.insert(activity_type);
+      }
+    }
+    if (enabledTypes.empty()) {
+      LOG(INFO) << "Plugin profiler " << name_
+                << " does not support any of the requested activity types";
+      return nullptr;
+    }
+
+    // [TODO] In future evolution of API we may want to pass in Config string or
+    // a subset of config strings perhaps by searching for "PLUGIN_NAME_" in the
+    // config string
+    return std::make_unique<PluginProfilerSession>(
+        profiler_, name_, enabledTypes);
+  }
+
+  std::unique_ptr<IActivityProfilerSession> configure(
+      int64_t ts_ms,
+      int64_t duration_ms,
+      const std::set<ActivityType>& activity_types,
+      const Config& config) override {
+    return configure(activity_types, config);
+  }
+
+ private:
+  bool validateProfiler() {
+    bool isValid = true;
+
+    // Handle versioning
+    // Currently expect the exact same version
+    if (profiler_.unpaddedStructSize <
+        KINETO_PLUGIN_PROFILER_INTERFACE_UNPADDED_STRUCT_SIZE) {
+      LOG(ERROR) << "Plugin profiler has an incompatible version";
+
+      profiler_.profilerCreate =
+          [](struct KinetoPlugin_ProfilerCreate_Params*) { return -1; };
+      profiler_.profilerDestroy =
+          [](struct KinetoPlugin_ProfilerDestroy_Params*) { return -1; };
+      profiler_.profilerQuery = [](struct KinetoPlugin_ProfilerQuery_Params*) {
+        return -1;
+      };
+      profiler_.profilerStart = [](struct KinetoPlugin_ProfilerStart_Params*) {
+        return -1;
+      };
+      profiler_.profilerStop = [](struct KinetoPlugin_ProfilerStop_Params*) {
+        return -1;
+      };
+      profiler_.profilerPushCorrelationId =
+          [](struct KinetoPlugin_ProfilerPushCorrelationId_Params*) {
+            return -1;
+          };
+      profiler_.profilerPopCorrelationId =
+          [](struct KinetoPlugin_ProfilerPopCorrelationId_Params*) {
+            return -1;
+          };
+      profiler_.profilerPushUserCorrelationId =
+          [](struct KinetoPlugin_ProfilerPushUserCorrelationId_Params*) {
+            return -1;
+          };
+      profiler_.profilerPopUserCorrelationId =
+          [](struct KinetoPlugin_ProfilerPopUserCorrelationId_Params*) {
+            return -1;
+          };
+      profiler_.profilerProcessEvents =
+          [](struct KinetoPlugin_ProfilerProcessEvents_Params*) { return -1; };
+      return false;
+    }
+
+    // Check if individual function pointers are implemented
+    // For critical functions, set them to error-returning stubs if nullptr and
+    // mark as invalid
+    if (profiler_.profilerCreate == nullptr) {
+      LOG(ERROR) << "Plugin profiler profilerCreate is not implemented";
+      profiler_.profilerCreate =
+          [](struct KinetoPlugin_ProfilerCreate_Params*) { return -1; };
+      isValid = false;
+    }
+
+    if (profiler_.profilerDestroy == nullptr) {
+      LOG(ERROR) << "Plugin profiler profilerDestroy is not implemented";
+      profiler_.profilerDestroy =
+          [](struct KinetoPlugin_ProfilerDestroy_Params*) { return -1; };
+      isValid = false;
+    }
+
+    if (profiler_.profilerQuery == nullptr) {
+      LOG(ERROR) << "Plugin profiler profilerQuery is not implemented";
+      profiler_.profilerQuery = [](struct KinetoPlugin_ProfilerQuery_Params*) {
+        return -1;
+      };
+      isValid = false;
+    }
+
+    if (profiler_.profilerStart == nullptr) {
+      LOG(ERROR) << "Plugin profiler profilerStart is not implemented";
+      profiler_.profilerStart = [](struct KinetoPlugin_ProfilerStart_Params*) {
+        return -1;
+      };
+      isValid = false;
+    }
+
+    if (profiler_.profilerStop == nullptr) {
+      LOG(ERROR) << "Plugin profiler profilerStop is not implemented";
+      profiler_.profilerStop = [](struct KinetoPlugin_ProfilerStop_Params*) {
+        return -1;
+      };
+      isValid = false;
+    }
+
+    if (profiler_.profilerProcessEvents == nullptr) {
+      LOG(ERROR) << "Plugin profiler profilerProcessEvents is not implemented";
+      profiler_.profilerProcessEvents =
+          [](struct KinetoPlugin_ProfilerProcessEvents_Params*) { return -1; };
+      isValid = false;
+    }
+
+    // For correlation functions, provide default warning implementations if not
+    // provided These don't affect validity
+    if (profiler_.profilerPushCorrelationId == nullptr) {
+      LOG(INFO) << "Plugin profiler profilerPushCorrelationId is not "
+                   "implemented, using default stub";
+      profiler_.profilerPushCorrelationId =
+          [](struct KinetoPlugin_ProfilerPushCorrelationId_Params*) {
+            LOG_FIRST_N(1, WARNING)
+                << "profilerPushCorrelationId called but not "
+                   "implemented by plugin";
+            return 0;
+          };
+    }
+
+    if (profiler_.profilerPopCorrelationId == nullptr) {
+      LOG(INFO) << "Plugin profiler profilerPopCorrelationId is not "
+                   "implemented, using default stub";
+      profiler_.profilerPopCorrelationId =
+          [](struct KinetoPlugin_ProfilerPopCorrelationId_Params*) {
+            LOG_FIRST_N(1, WARNING)
+                << "profilerPopCorrelationId called but not "
+                   "implemented by plugin";
+            return 0;
+          };
+    }
+
+    if (profiler_.profilerPushUserCorrelationId == nullptr) {
+      LOG(INFO) << "Plugin profiler profilerPushUserCorrelationId is not "
+                   "implemented, using default stub";
+      profiler_.profilerPushUserCorrelationId =
+          [](struct KinetoPlugin_ProfilerPushUserCorrelationId_Params*) {
+            LOG_FIRST_N(1, WARNING)
+                << "profilerPushUserCorrelationId called but not "
+                   "implemented by plugin";
+            return 0;
+          };
+    }
+
+    if (profiler_.profilerPopUserCorrelationId == nullptr) {
+      LOG(INFO) << "Plugin profiler profilerPopUserCorrelationId is not "
+                   "implemented, using default stub";
+      profiler_.profilerPopUserCorrelationId =
+          [](struct KinetoPlugin_ProfilerPopUserCorrelationId_Params*) {
+            LOG_FIRST_N(1, WARNING)
+                << "profilerPopUserCorrelationId called but not "
+                   "implemented by plugin";
+            return 0;
+          };
+    }
+
+    return isValid;
+  }
+
+  KinetoPlugin_ProfilerInterface profiler_;
+  std::string name_;
+  std::set<ActivityType> supportedActivities_;
+  bool isValid_;
+};
+
+} // namespace libkineto

--- a/libkineto/src/dynamic_plugin/PluginTraceBuilder.h
+++ b/libkineto/src/dynamic_plugin/PluginTraceBuilder.h
@@ -1,0 +1,278 @@
+#pragma once
+
+#include "ActivityType.h"
+#include "GenericTraceActivity.h"
+#include "Logger.h"
+#include "libkineto.h"
+
+#include "KinetoDynamicPluginInterface.h"
+#include "PluginUtils.h"
+
+namespace libkineto {
+
+// Event builder provides a simple abstraction for plugins to interace with the
+// event system in kineto. This works across binaries and has to be dealt with
+// care. We do not use any C++ stdlib component across the interface and thus we
+// need to translate a few things around
+
+class PluginTraceBuilder {
+ public:
+  PluginTraceBuilder(TraceSpan span) {
+    buffer_ = std::make_unique<CpuTraceBuffer>();
+    buffer_->span = span;
+  }
+
+  // Several of these APIs do not have failure cases, but we still return an
+  // integer for future extensibility.
+
+  // returns 0 on success, -1 on failure, generally this is not expected to fail.
+  int addEvent(const KinetoPlugin_ProfileEvent* pProfileEvent) {
+    if (buffer_ == nullptr) {
+      return -1;
+    }
+
+    if (pProfileEvent == nullptr) {
+      LOG(ERROR) << "Failed to add event of nullptr";
+      return -1;
+    }
+
+    // Handle versioning
+    // Currently expect the exact same version
+    if (pProfileEvent->unpaddedStructSize <
+        KINETO_PLUGIN_PROFILER_PROCESS_EVENTS_PARAMS_UNPADDED_STRUCT_SIZE) {
+      LOG(ERROR) << "Profile event has an incompatible version";
+      return -1;
+    }
+
+    ActivityType activityType = convertToActivityType(pProfileEvent->eventType);
+
+    buffer_->emplace_activity(
+        buffer_->span, activityType /*ActivityType*/, "" /*name - set it later*/
+    );
+
+    auto& event = buffer_->activities.back();
+    event->startTime = pProfileEvent->startTimeUtcNs;
+    event->endTime = pProfileEvent->endTimeUtcNs;
+    event->id = pProfileEvent->eventId;
+    event->device = pProfileEvent->deviceId;
+    event->resource = pProfileEvent->resourceId;
+    event->threadId = pProfileEvent->threadId;
+
+    return 0;
+  }
+
+  // returns 0 on success, -1 on failure, this can happen if the last event is not set.
+  int setLastEventName(const char* pName) {
+    if (buffer_ == nullptr) {
+      return -1;
+    }
+
+    if (pName == nullptr) {
+      LOG(ERROR) << "Failed to set last event name of nullptr";
+      return -1;
+    }
+
+    if (buffer_->activities.empty()) {
+      LOG(ERROR) << "Failed to set last event flow as there is no last event";
+      return -1;
+    }
+
+    buffer_->activities.back()->activityName.assign(pName);
+    return 0;
+  }
+
+  int setLastEventFlow(const KinetoPlugin_ProfileEventFlow* pProfileEventFlow) {
+    if (buffer_ == nullptr) {
+      return -1;
+    }
+
+    if (pProfileEventFlow == nullptr) {
+      LOG(ERROR) << "Failed to set last event flow of nullptr";
+
+      return -1;
+    }
+
+    // Handle versioning
+    // Currently expect the exact same version
+    if (pProfileEventFlow->unpaddedStructSize <
+        KINETO_PLUGIN_PROFILE_EVENT_FLOW_UNPADDED_STRUCT_SIZE) {
+      LOG(ERROR) << "Profile event flow has an incompatible version";
+      return -1;
+    }
+
+    if (buffer_->activities.empty()) {
+      LOG(ERROR) << "Failed to set last event flow as there is no last event";
+      return -1;
+    }
+
+    auto& event = buffer_->activities.back();
+
+    event->flow.id = pProfileEventFlow->flowId;
+    event->flow.type = convertToLinkType(pProfileEventFlow->flowType);
+    event->flow.start = pProfileEventFlow->isStartPoint ? 1 : 0;
+
+    return 0;
+  }
+
+  // returns 0 on success, -1 on failure, this can happen if the last event is not set.
+  int addLastEventMetadata(const char* pKey, const char* pValue) {
+    if (buffer_ == nullptr) {
+      return -1;
+    }
+
+    if (pKey == nullptr || pValue == nullptr) {
+      LOG(ERROR) << "Failed to set last event metadata of nullptr";
+      return -1;
+    }
+
+    if (buffer_->activities.empty()) {
+      LOG(ERROR)
+          << "Failed to set last event metadata as there is no last event";
+      return -1;
+    }
+
+    buffer_->activities.back()->addMetadata(
+        std::string{pKey}, std::string{pValue});
+    return 0;
+  }
+
+  // returns 0 on success, -1 on failure, generally this is not expected to fail.
+  int addDeviceInfo(const KinetoPlugin_ProfileDeviceInfo* pProfileDeviceInfo) {
+    if (pProfileDeviceInfo == nullptr) {
+      LOG(ERROR) << "Failed to add device info of nullptr";
+      return -1;
+    }
+
+    // Handle versioning
+    // Currently expect the exact same version
+    if (pProfileDeviceInfo->unpaddedStructSize <
+        KINETO_PLUGIN_PROFILE_DEVICE_INFO_UNPADDED_STRUCT_SIZE) {
+      LOG(ERROR) << "Profile device info has an incompatible version";
+      return -1;
+    }
+
+    DeviceInfo deviceInfo(
+        pProfileDeviceInfo->deviceId,
+        pProfileDeviceInfo->sortIndex,
+        pProfileDeviceInfo->pName
+            ? std::string(pProfileDeviceInfo->pName)
+            : std::to_string(pProfileDeviceInfo->deviceId),
+        pProfileDeviceInfo->pLabel ? std::string(pProfileDeviceInfo->pLabel)
+                                   : "");
+
+    deviceInfos_.push_back(deviceInfo);
+
+    return 0;
+  }
+
+  // returns 0 on success, -1 on failure, generally this is not expected to fail.
+  int addResourceInfo(
+      const KinetoPlugin_ProfileResourceInfo* pProfileResourceInfo) {
+    if (pProfileResourceInfo == nullptr) {
+      LOG(ERROR) << "Failed to add resource info of nullptr";
+      return -1;
+    }
+
+    // Handle versioning
+    // Currently expect the exact same version
+    if (pProfileResourceInfo->unpaddedStructSize <
+        KINETO_PLUGIN_PROFILE_RESOURCE_INFO_UNPADDED_STRUCT_SIZE) {
+      LOG(ERROR) << "Profile resource info has an incompatible version";
+      return -1;
+    }
+
+    ResourceInfo resourceInfo(
+        pProfileResourceInfo->deviceId,
+        pProfileResourceInfo->resourceId,
+        pProfileResourceInfo->displayOrder,
+        pProfileResourceInfo->pName
+            ? std::string(pProfileResourceInfo->pName)
+            : std::to_string(pProfileResourceInfo->resourceId));
+
+    resourceInfos_.push_back(resourceInfo);
+
+    return 0;
+  }
+
+  const KinetoPlugin_TraceBuilder toCTraceBuilder() {
+    return KinetoPlugin_TraceBuilder{
+        .unpaddedStructSize = KINETO_PLUGIN_TRACE_BUILDER_UNPADDED_STRUCT_SIZE,
+        .pTraceBuilderHandle =
+            reinterpret_cast<KinetoPlugin_TraceBuilderHandle*>(this),
+        .addEvent = cAddEvent,
+        .setLastEventName = cSetLastEventName,
+        .setLastEventFlow = cSetLastEventFlow,
+        .addLastEventMetadata = cAddLastEventMetadata,
+        .addDeviceInfo = cAddDeviceInfo,
+        .addResourceInfo = cAddResourceInfo};
+  }
+
+  // release ownership of the trace events and metadata
+  std::unique_ptr<CpuTraceBuffer> getTraceBuffer() {
+    return std::move(buffer_);
+  }
+
+  std::vector<DeviceInfo> getDeviceInfos() {
+    return deviceInfos_;
+  }
+
+  std::vector<ResourceInfo> getResourceInfos() {
+    return resourceInfos_;
+  }
+
+ private:
+  static int cAddEvent(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const KinetoPlugin_ProfileEvent* pProfileEvent) {
+    auto pPluginTraceBuilder =
+        reinterpret_cast<PluginTraceBuilder*>(pTraceBuilderHandle);
+    return pPluginTraceBuilder->addEvent(pProfileEvent);
+  }
+
+  static int cSetLastEventName(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const char* name) {
+    auto pPluginTraceBuilder =
+        reinterpret_cast<PluginTraceBuilder*>(pTraceBuilderHandle);
+    return pPluginTraceBuilder->setLastEventName(name);
+  }
+
+  static int cSetLastEventFlow(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const KinetoPlugin_ProfileEventFlow* pProfileEventFlow) {
+    auto pPluginTraceBuilder =
+        reinterpret_cast<PluginTraceBuilder*>(pTraceBuilderHandle);
+    return pPluginTraceBuilder->setLastEventFlow(pProfileEventFlow);
+  }
+
+  static int cAddLastEventMetadata(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const char* pKey,
+      const char* pValue) {
+    auto pPluginTraceBuilder =
+        reinterpret_cast<PluginTraceBuilder*>(pTraceBuilderHandle);
+    return pPluginTraceBuilder->addLastEventMetadata(pKey, pValue);
+  }
+
+  static int cAddDeviceInfo(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const KinetoPlugin_ProfileDeviceInfo* pProfileDeviceInfo) {
+    auto pPluginTraceBuilder =
+        reinterpret_cast<PluginTraceBuilder*>(pTraceBuilderHandle);
+    return pPluginTraceBuilder->addDeviceInfo(pProfileDeviceInfo);
+  }
+
+  static int cAddResourceInfo(
+      KinetoPlugin_TraceBuilderHandle* pTraceBuilderHandle,
+      const KinetoPlugin_ProfileResourceInfo* pProfileResourceInfo) {
+    auto pPluginTraceBuilder =
+        reinterpret_cast<PluginTraceBuilder*>(pTraceBuilderHandle);
+    return pPluginTraceBuilder->addResourceInfo(pProfileResourceInfo);
+  }
+
+  std::unique_ptr<CpuTraceBuffer> buffer_;
+  std::vector<DeviceInfo> deviceInfos_;
+  std::vector<ResourceInfo> resourceInfos_;
+};
+
+} // namespace libkineto

--- a/libkineto/src/dynamic_plugin/PluginUtils.h
+++ b/libkineto/src/dynamic_plugin/PluginUtils.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <set>
+#include <vector>
+
+#include "ActivityType.h"
+#include "GenericTraceActivity.h"
+#include "KinetoDynamicPluginInterface.h"
+
+namespace libkineto {
+
+// Utility functions for dynamic plugins
+
+static inline ActivityType convertToActivityType(
+    KinetoPlugin_ProfileEventType type) {
+  switch (type) {
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_CPU_OP:
+      return ActivityType::CPU_OP;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_USER_ANNOTATION:
+      return ActivityType::USER_ANNOTATION;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_USER_ANNOTATION:
+      return ActivityType::GPU_USER_ANNOTATION;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_MEMCPY:
+      return ActivityType::GPU_MEMCPY;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_MEMSET:
+      return ActivityType::GPU_MEMSET;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_CONCURRENT_KERNEL:
+      return ActivityType::CONCURRENT_KERNEL;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_EXTERNAL_CORRELATION:
+      return ActivityType::EXTERNAL_CORRELATION;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_RUNTIME:
+      return ActivityType::CUDA_RUNTIME;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_DRIVER:
+      return ActivityType::CUDA_DRIVER;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_CPU_INSTANT_EVENT:
+      return ActivityType::CPU_INSTANT_EVENT;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_PYTHON_FUNCTION:
+      return ActivityType::PYTHON_FUNCTION;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_OVERHEAD:
+      return ActivityType::OVERHEAD;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_MTIA_RUNTIME:
+      return ActivityType::MTIA_RUNTIME;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_MTIA_CCP_EVENTS:
+      return ActivityType::MTIA_CCP_EVENTS;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_MTIA_INSIGHT:
+      return ActivityType::MTIA_INSIGHT;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_SYNC:
+      return ActivityType::CUDA_SYNC;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_GLOW_RUNTIME:
+      return ActivityType::GLOW_RUNTIME;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_PROFILER_RANGE:
+      return ActivityType::CUDA_PROFILER_RANGE;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_HPU_OP:
+      return ActivityType::HPU_OP;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_XPU_RUNTIME:
+      return ActivityType::XPU_RUNTIME;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_COLLECTIVE_COMM:
+      return ActivityType::COLLECTIVE_COMM;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_PM_COUNTER:
+      return ActivityType::GPU_PM_COUNTER;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_PRIVATEUSE1_RUNTIME:
+      return ActivityType::PRIVATEUSE1_RUNTIME;
+    case KINETO_PLUGIN_PROFILE_EVENT_TYPE_PRIVATEUSE1_DRIVER:
+      return ActivityType::PRIVATEUSE1_DRIVER;
+    default:
+      // use kernel type as a default
+      return ActivityType::CONCURRENT_KERNEL;
+  }
+}
+
+static inline KinetoPlugin_ProfileEventType convertFromActivityType(
+    ActivityType type) {
+  switch (type) {
+    case ActivityType::CPU_OP:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_CPU_OP;
+    case ActivityType::USER_ANNOTATION:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_USER_ANNOTATION;
+    case ActivityType::GPU_USER_ANNOTATION:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_USER_ANNOTATION;
+    case ActivityType::GPU_MEMCPY:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_MEMCPY;
+    case ActivityType::GPU_MEMSET:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_MEMSET;
+    case ActivityType::CONCURRENT_KERNEL:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_CONCURRENT_KERNEL;
+    case ActivityType::EXTERNAL_CORRELATION:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_EXTERNAL_CORRELATION;
+    case ActivityType::CUDA_RUNTIME:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_RUNTIME;
+    case ActivityType::CUDA_DRIVER:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_DRIVER;
+    case ActivityType::CPU_INSTANT_EVENT:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_CPU_INSTANT_EVENT;
+    case ActivityType::PYTHON_FUNCTION:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_PYTHON_FUNCTION;
+    case ActivityType::OVERHEAD:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_OVERHEAD;
+    case ActivityType::MTIA_RUNTIME:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_MTIA_RUNTIME;
+    case ActivityType::MTIA_CCP_EVENTS:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_MTIA_CCP_EVENTS;
+    case ActivityType::MTIA_INSIGHT:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_MTIA_INSIGHT;
+    case ActivityType::CUDA_SYNC:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_SYNC;
+    case ActivityType::GLOW_RUNTIME:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_GLOW_RUNTIME;
+    case ActivityType::CUDA_PROFILER_RANGE:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_PROFILER_RANGE;
+    case ActivityType::HPU_OP:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_HPU_OP;
+    case ActivityType::XPU_RUNTIME:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_XPU_RUNTIME;
+    case ActivityType::COLLECTIVE_COMM:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_COLLECTIVE_COMM;
+    case ActivityType::GPU_PM_COUNTER:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_PM_COUNTER;
+    case ActivityType::PRIVATEUSE1_RUNTIME:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_PRIVATEUSE1_RUNTIME;
+    case ActivityType::PRIVATEUSE1_DRIVER:
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_PRIVATEUSE1_DRIVER;
+    default:
+      // use kernel type as a default
+      return KINETO_PLUGIN_PROFILE_EVENT_TYPE_CONCURRENT_KERNEL;
+  }
+}
+
+static inline std::vector<KinetoPlugin_ProfileEventType> convertActivityTypeSet(
+    const std::set<ActivityType>& activityTypes) {
+  std::vector<KinetoPlugin_ProfileEventType> result;
+  result.reserve(activityTypes.size());
+  for (const auto& activityType : activityTypes) {
+    result.push_back(convertFromActivityType(activityType));
+  }
+  return result;
+}
+
+static inline unsigned int convertToLinkType(
+    KinetoPlugin_ProfileEventFlowType type) {
+  switch (type) {
+    case KINETO_PLUGIN_PROFILE_EVENT_FLOW_TYPE_FWD_BWD:
+      return kLinkFwdBwd;
+    case KINETO_PLUGIN_PROFILE_EVENT_FLOW_TYPE_ASYNC_CPU_GPU:
+      return kLinkAsyncCpuGpu;
+    default:
+      return 0;
+  }
+}
+
+} // namespace libkineto

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -412,6 +412,7 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
     static const std::set<libkineto::ActivityType> excludedTypes = {
         libkineto::ActivityType::GPU_MEMCPY,
         libkineto::ActivityType::GPU_MEMSET,
+        libkineto::ActivityType::GPU_PM_COUNTER,
         libkineto::ActivityType::CONCURRENT_KERNEL,
         libkineto::ActivityType::CUDA_RUNTIME,
         libkineto::ActivityType::CUDA_DRIVER,
@@ -569,6 +570,18 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
 
   // clang-format off
   ts = transToRelativeTime(ts);
+
+  if (op.type() == libkineto::ActivityType::GPU_PM_COUNTER) {
+    fmt::print(traceOf_, R"JSON(
+    {{
+      "ph": "C", "cat": "{}", "name": "{}", "pid": {}, "tid": {},
+      "ts": {}.{:03} {}
+    }},)JSON",
+            toString(op.type()), op_name, device, sanitizeTid(resource),
+            ts/1000, ts %1000, args);
+    return;
+  }
+
   fmt::print(traceOf_, R"JSON(
   {{
     "ph": "X", "cat": "{}", "name": "{}", "pid": {}, "tid": {},

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -34,6 +34,13 @@ target_link_libraries(ConfigTest PRIVATE
     ${XPU_XPUPTI_LIBRARY})
 gtest_discover_tests(ConfigTest)
 
+# DynamicPluginTest
+add_executable(DynamicPluginTest DynamicPluginTest.cpp)
+target_link_libraries(DynamicPluginTest PRIVATE
+    gtest_main
+    kineto_base kineto_api)
+gtest_discover_tests(DynamicPluginTest)
+
 if(NOT LIBKINETO_NOCUPTI)
 # CuptiActivityProfilerTest
 #[[

--- a/libkineto/test/DynamicPluginTest.cpp
+++ b/libkineto/test/DynamicPluginTest.cpp
@@ -1,0 +1,513 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+#include "include/KinetoDynamicPluginInterface.h"
+#include "src/dynamic_plugin/PluginProfiler.h"
+#include "src/output_membuf.h"
+
+using namespace KINETO_NAMESPACE;
+
+namespace {
+
+// Mock Plugin Handle - simple struct to track state
+struct MockPluginHandle {
+  bool created = false;
+  bool active = false;
+  std::string name = "MockPlugin";
+  std::vector<KinetoPlugin_ProfileEventType> enabledActivityTypes;
+};
+
+// Mock implementation of the plugin interface
+class MockPlugin {
+ public:
+  static std::vector<std::unique_ptr<MockPluginHandle>> handles;
+
+  static int getHandleCount() {
+    return handles.size();
+  }
+
+  // Reset state for clean tests
+  static void reset() {
+    handles.clear();
+  }
+
+  // Mock profilerCreate implementation
+  static int profilerCreate(KinetoPlugin_ProfilerCreate_Params* params) {
+    handles.push_back(std::make_unique<MockPluginHandle>());
+    MockPluginHandle* handle = handles.back().get();
+    handle->created = true;
+    params->pProfilerHandle =
+        reinterpret_cast<KinetoPlugin_ProfilerHandle*>(handle);
+
+    // Capture the enabled activity types
+    handle->enabledActivityTypes.clear();
+    if (params->pEnabledActivityTypes) {
+      for (size_t i = 0; i < params->enabledActivityTypesMaxLen; i++) {
+        handle->enabledActivityTypes.push_back(params->pEnabledActivityTypes[i]);
+      }
+    }
+
+    return 0;
+  }
+
+  // Mock profilerDestroy implementation
+  static int profilerDestroy(KinetoPlugin_ProfilerDestroy_Params* params) {
+    MockPluginHandle* handle =
+        reinterpret_cast<MockPluginHandle*>(params->pProfilerHandle);
+
+    // Find and remove from our tracking
+    for (auto it = handles.begin(); it != handles.end(); ++it) {
+      if (it->get() == handle) {
+        handles.erase(it);
+        break;
+      }
+    }
+    return 0;
+  }
+
+  // Mock profilerQuery implementation
+  static int profilerQuery(KinetoPlugin_ProfilerQuery_Params* params) {
+    strncpy(params->pProfilerName, "MockPlugin", params->profilerNameMaxLen);
+    params->pProfilerName[params->profilerNameMaxLen] = '\0';
+
+    // Set supported activity types - simulate a plugin that supports CUDA
+    // activities
+    if (params->pSupportedActivityTypes &&
+        params->supportedActivityTypesMaxLen > 3) {
+      params->pSupportedActivityTypes[0] =
+          KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_RUNTIME;
+      params->pSupportedActivityTypes[1] =
+          KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_DRIVER;
+      params->pSupportedActivityTypes[2] =
+          KINETO_PLUGIN_PROFILE_EVENT_TYPE_CONCURRENT_KERNEL;
+      params->pSupportedActivityTypes[3] =
+          KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_MEMCPY;
+
+      // Fill remaining slots with invalid type
+      for (size_t i = 4; i < params->supportedActivityTypesMaxLen; i++) {
+        params->pSupportedActivityTypes[i] =
+            KINETO_PLUGIN_PROFILE_EVENT_TYPE_INVALID;
+      }
+    }
+
+    return 0;
+  }
+
+  // Mock profilerStart implementation
+  static int profilerStart(KinetoPlugin_ProfilerStart_Params* params) {
+    MockPluginHandle* handle =
+        reinterpret_cast<MockPluginHandle*>(params->pProfilerHandle);
+    handle->active = true;
+    return 0;
+  }
+
+  // Mock profilerStop implementation
+  static int profilerStop(KinetoPlugin_ProfilerStop_Params* params) {
+    MockPluginHandle* handle =
+        reinterpret_cast<MockPluginHandle*>(params->pProfilerHandle);
+    handle->active = false;
+    return 0;
+  }
+
+  // Mock profilerProcessEvents implementation
+  static int profilerProcessEvents(
+      KinetoPlugin_ProfilerProcessEvents_Params* params) {
+    const KinetoPlugin_TraceBuilder* traceBuilder = params->pTraceBuilder;
+
+    // Create sample events of different types
+    int64_t baseTime = 1000000000; // 1 second in nanoseconds
+
+    // 1. Runtime activity (CUDA runtime API call)
+    KinetoPlugin_ProfileEvent runtimeEvent{
+        .unpaddedStructSize = KINETO_PLUGIN_PROFILE_EVENT_UNPADDED_STRUCT_SIZE,
+        .eventType = KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_RUNTIME,
+        .startTimeUtcNs = baseTime,
+        .endTimeUtcNs = baseTime + 5000,
+        .eventId = 1,
+        .deviceId = 0,
+        .resourceId = 123};
+    traceBuilder->addEvent(traceBuilder->pTraceBuilderHandle, &runtimeEvent);
+    traceBuilder->setLastEventName(
+        traceBuilder->pTraceBuilderHandle, "cudaLaunchKernel");
+
+    // 2. Driver activity (CUDA driver API call)
+    KinetoPlugin_ProfileEvent driverEvent{
+        .unpaddedStructSize = KINETO_PLUGIN_PROFILE_EVENT_UNPADDED_STRUCT_SIZE,
+        .eventType = KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_DRIVER,
+        .startTimeUtcNs = baseTime + 10000,
+        .endTimeUtcNs = baseTime + 15000,
+        .eventId = 2,
+        .deviceId = 0,
+        .resourceId = 124};
+    traceBuilder->addEvent(traceBuilder->pTraceBuilderHandle, &driverEvent);
+    traceBuilder->setLastEventName(
+        traceBuilder->pTraceBuilderHandle, "cuLaunchKernel");
+
+    // 3. Kernel activity (GPU kernel execution)
+    KinetoPlugin_ProfileEvent kernelEvent{
+        .unpaddedStructSize = KINETO_PLUGIN_PROFILE_EVENT_UNPADDED_STRUCT_SIZE,
+        .eventType = KINETO_PLUGIN_PROFILE_EVENT_TYPE_CONCURRENT_KERNEL,
+        .startTimeUtcNs = baseTime + 20000,
+        .endTimeUtcNs = baseTime + 50000,
+        .eventId = 3,
+        .deviceId = 0,
+        .resourceId = 1};
+    traceBuilder->addEvent(traceBuilder->pTraceBuilderHandle, &kernelEvent);
+    traceBuilder->setLastEventName(
+        traceBuilder->pTraceBuilderHandle, "test_kernel");
+
+    // 4. Memcpy activity (GPU memory copy)
+    KinetoPlugin_ProfileEvent memcpyEvent{
+        .unpaddedStructSize = KINETO_PLUGIN_PROFILE_EVENT_UNPADDED_STRUCT_SIZE,
+        .eventType = KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_MEMCPY,
+        .startTimeUtcNs = baseTime + 60000,
+        .endTimeUtcNs = baseTime + 70000,
+        .eventId = 4,
+        .deviceId = 0,
+        .resourceId = 2};
+    traceBuilder->addEvent(traceBuilder->pTraceBuilderHandle, &memcpyEvent);
+    traceBuilder->setLastEventName(
+        traceBuilder->pTraceBuilderHandle, "cudaMemcpyHtoD");
+
+    return 0;
+  }
+
+  // Get the mock profiler interface
+  static KinetoPlugin_ProfilerInterface getInterface() {
+    return KinetoPlugin_ProfilerInterface{
+        .unpaddedStructSize =
+            KINETO_PLUGIN_PROFILER_INTERFACE_UNPADDED_STRUCT_SIZE,
+        .profilerCreate = profilerCreate,
+        .profilerDestroy = profilerDestroy,
+        .profilerQuery = profilerQuery,
+        .profilerStart = profilerStart,
+        .profilerStop = profilerStop,
+        .profilerProcessEvents = profilerProcessEvents};
+  }
+};
+
+// Static member definitions
+std::vector<std::unique_ptr<MockPluginHandle>> MockPlugin::handles;
+
+} // anonymous namespace
+
+class DynamicPluginTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    MockPlugin::reset();
+  }
+
+  void TearDown() override {
+    MockPlugin::reset();
+  }
+};
+
+// Test complete plugin lifecycle through PluginProfiler
+TEST_F(DynamicPluginTest, PluginProfilerLifecycle) {
+  auto mockInterface = MockPlugin::getInterface();
+
+  // Create a PluginProfiler instance with our mock
+  PluginProfiler pluginProfiler(mockInterface);
+
+  // Test that the name is correctly retrieved
+  EXPECT_EQ(pluginProfiler.name(), "MockPlugin");
+
+  // Test that available activities are returned
+  auto activities = pluginProfiler.availableActivities();
+  EXPECT_FALSE(
+      activities
+          .empty()); // Should have at least the default CUDA_PROFILER_RANGE
+
+  // Create a profiler session which will test handle creation
+  EXPECT_EQ(MockPlugin::getHandleCount(), 0);
+  auto session = pluginProfiler.configure(activities, Config{});
+  EXPECT_NE(session, nullptr);
+  EXPECT_EQ(MockPlugin::getHandleCount(), 1);
+
+  // Verify handle was created and is in correct state
+  MockPluginHandle* handle = MockPlugin::handles[0].get();
+  EXPECT_TRUE(handle->created);
+  EXPECT_FALSE(handle->active);
+
+  // Test start profiling
+  session->start();
+  EXPECT_TRUE(handle->active);
+
+  // Verify that enabled activity types were passed to the plugin
+  EXPECT_FALSE(handle->enabledActivityTypes.empty());
+
+  // The plugin should receive the activity types we configured with
+  // (which should be the intersection of requested and supported)
+  std::set<KinetoPlugin_ProfileEventType> receivedTypes(
+      handle->enabledActivityTypes.begin(), handle->enabledActivityTypes.end());
+
+  // Verify some expected types are present
+  EXPECT_TRUE(
+      receivedTypes.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_RUNTIME) !=
+      receivedTypes.end());
+  EXPECT_TRUE(
+      receivedTypes.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_DRIVER) !=
+      receivedTypes.end());
+  EXPECT_TRUE(
+      receivedTypes.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_CONCURRENT_KERNEL) !=
+      receivedTypes.end());
+  EXPECT_TRUE(
+      receivedTypes.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_MEMCPY) !=
+      receivedTypes.end());
+
+  // Test stop profiling
+  session->stop();
+  EXPECT_FALSE(handle->active);
+
+  // Test session destruction (handle cleanup)
+  session.reset();
+  EXPECT_EQ(MockPlugin::getHandleCount(), 0);
+}
+
+// Test event builder functionality with processEvents
+TEST_F(DynamicPluginTest, EventBuilderProcessing) {
+  auto mockInterface = MockPlugin::getInterface();
+
+  // Create a PluginProfiler instance
+  PluginProfiler pluginProfiler(mockInterface);
+
+  // Create and configure a session
+  auto activities = pluginProfiler.availableActivities();
+  auto session = pluginProfiler.configure(activities, Config{});
+  EXPECT_NE(session, nullptr);
+
+  // Start profiling
+  session->start();
+
+  // Stop profiling
+  session->stop();
+
+  // Process events - this will call our mock profilerProcessEvents
+  // which creates sample events using the trace builder
+  MemoryTraceLogger logger(Config{});
+  session->processTrace(logger);
+
+  // Get the trace buffer to verify events were created
+  auto traceBuffer = session->getTraceBuffer();
+  EXPECT_NE(traceBuffer, nullptr);
+
+  // Verify we have the expected number of activities (4 events created in mock)
+  EXPECT_EQ(traceBuffer->activities.size(), 4);
+
+  // Verify the different activity types were created correctly
+  auto& activities_vec = traceBuffer->activities;
+
+  // Check runtime activity (first event)
+  EXPECT_EQ(activities_vec[0]->type(), ActivityType::CUDA_RUNTIME);
+  EXPECT_EQ(activities_vec[0]->activityName, "cudaLaunchKernel");
+  EXPECT_EQ(activities_vec[0]->startTime, 1000000000);
+  EXPECT_EQ(activities_vec[0]->endTime, 1000005000);
+  EXPECT_EQ(activities_vec[0]->id, 1);
+
+  // Check driver activity (second event)
+  EXPECT_EQ(activities_vec[1]->type(), ActivityType::CUDA_DRIVER);
+  EXPECT_EQ(activities_vec[1]->activityName, "cuLaunchKernel");
+  EXPECT_EQ(activities_vec[1]->startTime, 1000010000);
+  EXPECT_EQ(activities_vec[1]->endTime, 1000015000);
+  EXPECT_EQ(activities_vec[1]->id, 2);
+
+  // Check kernel activity (third event)
+  EXPECT_EQ(activities_vec[2]->type(), ActivityType::CONCURRENT_KERNEL);
+  EXPECT_EQ(activities_vec[2]->activityName, "test_kernel");
+  EXPECT_EQ(activities_vec[2]->startTime, 1000020000);
+  EXPECT_EQ(activities_vec[2]->endTime, 1000050000);
+  EXPECT_EQ(activities_vec[2]->id, 3);
+
+  // Check memcpy activity (fourth event)
+  EXPECT_EQ(activities_vec[3]->type(), ActivityType::GPU_MEMCPY);
+  EXPECT_EQ(activities_vec[3]->activityName, "cudaMemcpyHtoD");
+  EXPECT_EQ(activities_vec[3]->startTime, 1000060000);
+  EXPECT_EQ(activities_vec[3]->endTime, 1000070000);
+  EXPECT_EQ(activities_vec[3]->id, 4);
+}
+
+// Test configure() with activity types that intersect with plugin support
+// This tests the "ANY" logic - profiler should be enabled if it supports ANY of
+// the requested types
+TEST_F(DynamicPluginTest, ConfigureActivityTypes) {
+  auto mockInterface = MockPlugin::getInterface();
+  PluginProfiler pluginProfiler(mockInterface);
+
+  // Test that the plugin correctly reports supported activities
+  auto supportedActivities = pluginProfiler.availableActivities();
+  EXPECT_FALSE(supportedActivities.empty());
+
+  // Verify specific supported activities (based on our mock implementation)
+  EXPECT_TRUE(
+      supportedActivities.find(ActivityType::CUDA_RUNTIME) !=
+      supportedActivities.end());
+  EXPECT_TRUE(
+      supportedActivities.find(ActivityType::CUDA_DRIVER) !=
+      supportedActivities.end());
+  EXPECT_TRUE(
+      supportedActivities.find(ActivityType::CONCURRENT_KERNEL) !=
+      supportedActivities.end());
+  EXPECT_TRUE(
+      supportedActivities.find(ActivityType::GPU_MEMCPY) !=
+      supportedActivities.end());
+
+  // Test case 1: Request activities that are all supported
+  std::set<ActivityType> allSupportedTypes = {
+      ActivityType::CUDA_RUNTIME,
+      ActivityType::CUDA_DRIVER,
+      ActivityType::CONCURRENT_KERNEL,
+      ActivityType::GPU_MEMCPY};
+
+  auto session1 = pluginProfiler.configure(allSupportedTypes, Config{});
+  EXPECT_NE(session1, nullptr)
+      << "Should succeed when all requested types are supported";
+
+  // Verify that the plugin receives all the enabled activity types
+  session1->start();
+  ASSERT_EQ(MockPlugin::getHandleCount(), 1);
+  MockPluginHandle* handle1 = MockPlugin::handles[0].get();
+  EXPECT_FALSE(handle1->enabledActivityTypes.empty());
+
+  std::set<KinetoPlugin_ProfileEventType> receivedTypes1(
+      handle1->enabledActivityTypes.begin(),
+      handle1->enabledActivityTypes.end());
+
+  // Verify all 4 expected types are present
+  EXPECT_EQ(receivedTypes1.size(), 4);
+  EXPECT_TRUE(
+      receivedTypes1.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_RUNTIME) !=
+      receivedTypes1.end());
+  EXPECT_TRUE(
+      receivedTypes1.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_DRIVER) !=
+      receivedTypes1.end());
+  EXPECT_TRUE(
+      receivedTypes1.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_CONCURRENT_KERNEL) !=
+      receivedTypes1.end());
+  EXPECT_TRUE(
+      receivedTypes1.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_GPU_MEMCPY) !=
+      receivedTypes1.end());
+
+  session1->stop();
+  session1.reset();
+
+  // Test case 2: Request activities where some are supported (intersection
+  // exists)
+  std::set<ActivityType> partialSupportedTypes = {
+      ActivityType::CUDA_RUNTIME, // Supported
+      ActivityType::CPU_OP, // Not supported
+      ActivityType::CONCURRENT_KERNEL, // Supported
+      ActivityType::USER_ANNOTATION // Not supported
+  };
+
+  auto session2 = pluginProfiler.configure(partialSupportedTypes, Config{});
+  EXPECT_NE(session2, nullptr)
+      << "Should succeed when ANY requested types are supported";
+
+  // Verify that the plugin receives only the supported activity types
+  session2->start();
+  ASSERT_EQ(MockPlugin::getHandleCount(), 1);
+  MockPluginHandle* handle2 = MockPlugin::handles[0].get();
+  EXPECT_FALSE(handle2->enabledActivityTypes.empty());
+
+  std::set<KinetoPlugin_ProfileEventType> receivedTypes2(
+      handle2->enabledActivityTypes.begin(),
+      handle2->enabledActivityTypes.end());
+
+  // Should only have the 2 supported types from the requested set
+  EXPECT_EQ(receivedTypes2.size(), 2);
+  EXPECT_TRUE(
+      receivedTypes2.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_CUDA_RUNTIME) !=
+      receivedTypes2.end());
+  EXPECT_TRUE(
+      receivedTypes2.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_CONCURRENT_KERNEL) !=
+      receivedTypes2.end());
+
+  // Verify unsupported types are NOT present
+  EXPECT_TRUE(
+      receivedTypes2.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_CPU_OP) ==
+      receivedTypes2.end());
+  EXPECT_TRUE(
+      receivedTypes2.find(KINETO_PLUGIN_PROFILE_EVENT_TYPE_USER_ANNOTATION) ==
+      receivedTypes2.end());
+
+  session2->stop();
+  session2.reset();
+
+  // Test configure() with activity types that don't intersect with plugin
+  // support This tests the failure case - profiler should NOT be enabled if it
+  // supports NONE of the requested types
+
+  // Test case 3: Request activities that are completely unsupported
+  std::set<ActivityType> unsupportedTypes = {
+      ActivityType::CPU_OP,
+      ActivityType::USER_ANNOTATION,
+      ActivityType::PYTHON_FUNCTION,
+      ActivityType::OVERHEAD};
+
+  auto session3 = pluginProfiler.configure(unsupportedTypes, Config{});
+  EXPECT_EQ(session3, nullptr)
+      << "Should fail when NO requested types are supported";
+
+  // Test case 4: Request single unsupported activity type
+  std::set<ActivityType> singleUnsupportedType = {ActivityType::CPU_OP};
+
+  auto session4 = pluginProfiler.configure(singleUnsupportedType, Config{});
+  EXPECT_EQ(session4, nullptr)
+      << "Should fail with single unsupported activity type";
+
+  // Test case 5: Empty activity types set
+  std::set<ActivityType> emptyTypes = {};
+
+  auto session5 = pluginProfiler.configure(emptyTypes, Config{});
+  EXPECT_EQ(session5, nullptr) << "Should fail with empty activity types set";
+}
+
+// Test profiler validation - missing critical functions should be invalid
+TEST_F(DynamicPluginTest, ProfilerValidation) {
+  // Test case 1: Missing critical function (profilerStart) should be invalid
+  auto incompleteInterface = MockPlugin::getInterface();
+  incompleteInterface.profilerStart =
+      nullptr; // Set critical function to nullptr
+
+  PluginProfiler invalidProfiler(incompleteInterface);
+
+  // Attempting to configure should fail since profiler is invalid
+  auto activities = invalidProfiler.availableActivities();
+  auto session1 = invalidProfiler.configure(activities, Config{});
+  EXPECT_EQ(session1, nullptr)
+      << "Should fail to configure when critical function is missing";
+
+  // Test case 2: Missing only optional correlation functions should be valid
+  auto noCorrelationInterface = MockPlugin::getInterface();
+  noCorrelationInterface.profilerPushCorrelationId = nullptr;
+  noCorrelationInterface.profilerPopCorrelationId = nullptr;
+  noCorrelationInterface.profilerPushUserCorrelationId = nullptr;
+  noCorrelationInterface.profilerPopUserCorrelationId = nullptr;
+
+  PluginProfiler validProfiler(noCorrelationInterface);
+
+  // Should still be able to configure and use the profiler
+  auto activities2 = validProfiler.availableActivities();
+  auto session2 = validProfiler.configure(activities2, Config{});
+  EXPECT_NE(session2, nullptr)
+      << "Should succeed when only optional correlation functions are missing";
+
+  // Should be able to use the session normally
+  session2->start();
+  session2->stop();
+
+  // Correlation functions should use default stubs (won't crash)
+  session2->pushCorrelationId(12345);
+  session2->popCorrelationId();
+  session2->pushUserCorrelationId(67890);
+  session2->popUserCorrelationId();
+}


### PR DESCRIPTION
Credits to @zli669 for implementing this change, I am just setting this up here for contribution to kineto.

# Overview
Adds the capability to dynamically load plugins for Kineto (#1121). The core idea is to have plugin modules that can be made available as a shared object file (.so). Kineto loads all .so object files in a specified path:
```
export KINETO_PLUGIN_LIB_DIR_PATH=/foo/bar/
```
These plugins can then register themselves with kineto, start/stop profiling and return trace events to kineto.
Please look at `DynamicPluginTest.cpp` for example usage of this API.

The PR also enables counter events that can show up in the trace.

# Details
## Companion changes
First, let's address some simpler changes:
1. **Support for Performance Counter Events in Chrome Trace Format**: Adds a new activity type `GPU_PM_COUNTER`, enabling a stream of performance events to be logged by any plugin in Kineto.
2. **Environment Variable `KINETO_DISABLE_CUPTI`**: Disables using CUPTI on NVIDIA GPUs to support non-CUPTI based profiling modules. This helps avoid conflicts with CUPTI, as NVIDIA support is currently closely coupled with it.

## Dynamic Plugin changes

The Dynamic plugin interface is a generalization of the [IActivityProfiler](https://github.com/pytorch/kineto/blob/cccb043c598d8624f6a0268231ecb71625807569/libkineto/include/IActivityProfiler.h#L147) interface in Kineto. The support is implemented in three parts, recommended for review in this order:

### 1) Plugin C Interface: `libkineto/include/KinetoDynamicPluginInterface.h`
The plugin shared object must implement `KinetoPlugin_register()`, providing function pointers for trace plugin functions: start(), stop(), create(), destroy(), processEvents(). Kineto calls these function pointers.

To ensure ABI compatibility and avoid C++ compiler mismatches, a pure C interface is used. This interface includes C versions of key structures and enums like `ActivityType`, `ProfileEvent`, `Flows`, etc.

Lastly, To transfer trace data from the plugin to Kineto, an opaque C object called `KinetoTraceBuilder` is used. The key idea is the trace builder handles generating events and transferring them to kineto's Activity profiler. This ensures **there is NO dynamic memory being passed around between plugin shared object and kineto**

### 2) Shim to Internal Plugin Interface: `libkineto/src/dynamic_plugin/PluginProfiler.h`
The `PluginProfiler` class implements the IActivityProfiler interface used internally in Kineto. It controls the profiling session and generates session trace data using the function pointers from the shared object.

#### 2.2) Trace Event Builder: `libkineto/src/dynamic_plugin/PluginTraceBuilder.h`
Implements the TraceEvent builder used by the shared object plugin.

### 3) Plugin Loader: `libkineto/src/dynamic_plugin/PluginLoader.h`
Finally, the plugin loader handles the discovery of shared object plugins and dynamically loads them into the address space using standard techniques.


# Testing

## Unit Test

Added a `DynamicPlugTest` which basically tests out the PluginProfiler class and the creation/start/stop functions. It also tests the trace event builder. The unit test does not do any dynamic loading though.
Build
```
$> mkdir build && cd build
$> cmake .. &&  make
```
Test
```
$> ctest -R 'DynamicPlugin.*'
Test project /localhome/local-bcoutinho/kineto/kineto_brian/libkineto/build
    Start 15: DynamicPluginTest.PluginProfilerLifecycle
1/2 Test #15: DynamicPluginTest.PluginProfilerLifecycle ...   Passed    0.00 sec
    Start 16: DynamicPluginTest.EventBuilderProcessing
2/2 Test #16: DynamicPluginTest.EventBuilderProcessing ....   Passed    0.00 sec

100% tests passed, 0 tests failed out of 2
```

## End end test with Always On Profiling Plugin

Build PyTorch and import this branch to third_party/kineto. Base version tested on ``
I used a simple test program
Normal operation uses CUPTI
```
python3 ~/torch_samples/test_profiling_simple.py
```

Run using plugin: 
```
$> $ KINETO_LOG_LEVEL=0 KINETO_PLUGIN_LIB_DIR_PATH=$AON_KINETO_PLUGIN_LIB_DIR_PATH KINETO_DISABLE_CUPTI=1 python3 ~/torch_samples/test_profiling_simple.py
Using device: cuda
INFO:2025-10-03 21:48:26 384669:384669 init.cpp:164] Setting initCupti = 0 from environment KINETO_DISABLE_CUPTI=1

INFO:2025-10-03 21:48:26 384669:384669 PluginLoader.h:127] Found symbol KinetoPlugin_register() from /home/bcoutinho/aon_kineto_plugin_build/c36614826/libAonKinetoPlugin.so
*********************************************
***** [AON] KinetoPlugin_register(). *******
*********************************************
INFO:2025-10-03 21:48:26 384669:384669 CuptiActivityProfiler.cpp:244] CUDA versions. CUPTI: 130001; Runtime: 13000; Driver: 13000
*********************************************
******** [AON] [PLUGIN] query(). *********
*********************************************
Adding supported activities  Log file: /tmp/libkineto_activities_384669.json
  Trace start time: 2025-10-03 21:48:33
  Trace duration: 500ms
  Warmup duration: 5s
  Max GPU buffer size: 128MB
  Enabled activities: cpu_op,user_annotation,gpu_user_annotation,gpu_memcpy,gpu_memset,kernel,external_correlation,cuda_runtime,cuda_driver,cpu_instant_event,python_function,overhead,xpu_runtime,privateuse1_runtime,privateuse1_driver
INFO:2025-10-03 21:48:26 384669:384669 CuptiActivityProfiler.cpp:1017] [Profiler = AON Profiler] Evaluating whether to run child profiler.
*********************************************
******** [AON] [PLUGIN] create(). ********
*********************************************
INFO:2025-10-03 21:48:29 384669:384669 CuptiActivityProfiler.cpp:1025] [Profiler = AON Profiler] Running child profiler AON Profiler for 500 ms
...
INFO:2025-10-03 21:48:29 384669:384669 CuptiActivityProfiler.cpp:1242] Starting child profiler session
*********************************************
******** [AON] [PLUGIN] start(). *********
*********************************************
INFO:2025-10-03 21:48:29 384669:384669 CuptiActivityProfiler.cpp:1279] Stopping child profiler session
*********************************************
******** [AON] [PLUGIN] stop(). **********
*********************************************
STAGE:2025-10-03 21:48:29 384669:384669 ActivityProfilerController.cpp:396] Completed Stage: Collection
INFO:2025-10-03 21:48:29 384669:384669 CuptiActivityProfiler.cpp:293] Processing 1 CPU buffers
INFO:2025-10-03 21:48:29 384669:384669 CuptiActivityProfiler.cpp:394] Processing child profiler trace
*********************************************
***** [AON] [PLUGIN] processEvents(). *******
*********************************************
...
```
I can open the trace and find events added by plugin
```
  {
    "ph": "X", "cat": "kernel", "name": "_Z13gemmk1_kernelIifLi256ELi5ELb0ELb0ELb0ELb0E30cublasGemvTensorStridedBatchedIKfES2_S0_IfEfLi0EEv18cublasGemmk1ParamsIT0_T7_T8_T9_T10_N8biasTypeINS8_10value_typeES9_E4typeEE<<<(1, 1, 1), (256, 1, 1)>>>", "pid": 0, "tid": 7,
    "ts": 0.000, "dur": 0.000,
    "args": {
      "isImmediateLaunch": true, "hesCorrelationId": 2155942657, "apiCorrelationId": 8459009
    }
  },
```