### PR TITLE
Default to time based config for ondemand profiling in training when iterations don't exist

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -310,18 +310,34 @@ void ActivityProfilerController::scheduleTrace(const Config& config) {
     LOG(WARNING) << "Ignored request - profiler busy";
     return;
   }
+
   int64_t currentIter = iterationCount_;
+  std::unique_ptr<Config> configToSchedule;
+
   if (config.hasProfileStartIteration() && currentIter < 0) {
-    LOG(WARNING) << "Ignored profile iteration count based request as "
-                 << "application is not updating iteration count";
-    return;
+    // Special case: daemon config with activitiesDuration set
+    if (config.activitiesDuration().count() > 0) {
+      LOG(INFO) << "Config with duration-based profiling, "
+                << "ignoring iteration count requirement";
+      // Continue with modified config - clone and set profileStartIteration to
+      // -1
+      configToSchedule = config.clone();
+      configToSchedule->setProfileStartIteration(-1);
+    } else {
+      LOG(WARNING) << "Ignored profile iteration count based request as "
+                   << "application is not updating iteration count";
+      return;
+    }
+  } else {
+    configToSchedule = config.clone();
   }
 
+  // Common scheduling logic
   bool newConfigScheduled = false;
   if (!asyncRequestConfig_) {
     std::lock_guard<std::mutex> lock(asyncConfigLock_);
     if (!asyncRequestConfig_) {
-      asyncRequestConfig_ = config.clone();
+      asyncRequestConfig_ = std::move(configToSchedule);
       newConfigScheduled = true;
     }
   }


### PR DESCRIPTION
Summary:
In ActivityProfilerController.cpp scheduleTrace is only called through ondemand tracing flow. prepare_trace is what the API (kineto_shim) calls. So in the ondemand tracing path, if we see both time based and iteration based tracing in the config, fallback to time based; since in ondemand tracing that is more reliable. 

The context here is that in ondemand flow, which relies on no code-instrumention via the torch.profiler context manager in python, the step function is likely not getting called and in those cases we don't want to ignore an ondemand config that has active duration ms set in the config.

Differential Revision: D82772039


