### PR TITLE
Do not cause config getters to create IPC clients

### DIFF
--- a/libkineto/src/DaemonConfigLoader.cpp
+++ b/libkineto/src/DaemonConfigLoader.cpp
@@ -17,11 +17,12 @@
 namespace KINETO_NAMESPACE {
 
 // TODO : implications of this singleton being thread safe on forks?
-IpcFabricConfigClient* DaemonConfigLoader::getConfigClient() {
-  if (!configClient) {
-    configClient = std::make_unique<IpcFabricConfigClient>();
+IpcFabricConfigClient* DaemonConfigLoader::getConfigClient(
+    bool createIfNotFound) {
+  if (!configClient_ && createIfNotFound) {
+    configClient_ = std::make_unique<IpcFabricConfigClient>();
   }
-  return configClient.get();
+  return configClient_.get();
 }
 
 std::string DaemonConfigLoader::readBaseConfig() {
@@ -64,7 +65,7 @@ int DaemonConfigLoader::gpuContextCount(uint32_t device) {
 
 void DaemonConfigLoader::setCommunicationFabric(bool enabled) {
   LOG(INFO) << "Setting communication fabric enabled = " << enabled;
-  auto configClient = getConfigClient();
+  auto configClient = getConfigClient(true);
 
   if (!configClient) {
     LOG(WARNING) << "Failed to read config: No dyno config client";

--- a/libkineto/src/DaemonConfigLoader.h
+++ b/libkineto/src/DaemonConfigLoader.h
@@ -56,12 +56,12 @@ class DaemonConfigLoader : public IDaemonConfigLoader {
 
   void setCommunicationFabric(bool enabled) override;
 
-  IpcFabricConfigClient* getConfigClient();
+  IpcFabricConfigClient* getConfigClient(bool createIfNotFound = false);
 
   static void registerFactory();
 
  private:
-  std::unique_ptr<IpcFabricConfigClient> configClient;
+  std::unique_ptr<IpcFabricConfigClient> configClient_;
 };
 #endif // __linux__
 


### PR DESCRIPTION
Summary:
We may be too flexible when it comes to init'ing the IPCConfigClient if one is not found. As we have observed in prod it can cause some unknown behaviors.

So let's step back and on first principals make the flow more strict.

We always expect DaemonConfigLoader.registerFactory() to be called before any config loader thread starts, this is by design and should happen in the main thread. There on, every config_loader update thread should attempt at reading the config (if available) if the configClient exists, if it doesn't exist there is already good error handling and logging that we should leverage.

The worst thing that can happen here is one iteration of the background thread for reading config will miss a profiling config and log the error, that's far more better than debugging race conditions

Differential Revision: D84078972


