### PR TITLE
Use 64 bit integers for RoctracerLogger::maxBufferSize_ instead of 32 bit

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -394,7 +394,7 @@ class Config : public AbstractConfig {
     return customConfig_;
   }
 
-  uint32_t maxEvents() const {
+  uint64_t maxEvents() const {
     return maxEvents_;
   }
 
@@ -533,7 +533,7 @@ class Config : public AbstractConfig {
   std::string customConfig_;
 
   // Roctracer settings
-  uint32_t maxEvents_{5000000};
+  uint64_t maxEvents_{5000000};
 };
 
 constexpr char kUseDaemonEnvVar[] = "KINETO_USE_DAEMON";

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -442,7 +442,7 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   } else if (!name.compare(kRequestGroupTraceID)) {
     requestGroupTraceID_ = val;
   } else if (!name.compare(kRoctracerSetMaxEvents)) {
-    maxEvents_ = toInt32(val);
+    maxEvents_ = toInt64(val);
   }
 
   // TODO: Deprecate Client Interface

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -175,7 +175,7 @@ void RoctracerActivityApi::clearActivities() {
   d->clearLogs();
 }
 
-void RoctracerActivityApi::setMaxEvents(uint32_t maxEvents) {
+void RoctracerActivityApi::setMaxEvents(uint64_t maxEvents) {
 #ifdef HAS_ROCTRACER
   d->setMaxEvents(maxEvents);
 #endif

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -45,7 +45,7 @@ class RoctracerActivityApi {
   void clearActivities();
   void flushActivities();
   void teardownContext() {}
-  void setMaxEvents(uint32_t maxEvents);
+  void setMaxEvents(uint64_t maxEvents);
 
   virtual int processActivities(
       std::function<void(const roctracerBase*)> handler,

--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -311,7 +311,7 @@ void RoctracerLogger::activity_callback(
   }
 }
 
-void RoctracerLogger::setMaxEvents(uint32_t maxBufferSize) {
+void RoctracerLogger::setMaxEvents(uint64_t maxBufferSize) {
 #ifdef HAS_ROCTRACER
   RoctracerLogger* dis = &singleton();
   std::lock_guard<std::mutex> lock(dis->rowsMutex_);

--- a/libkineto/src/RoctracerLogger.h
+++ b/libkineto/src/RoctracerLogger.h
@@ -267,7 +267,7 @@ class RoctracerLogger {
   void startLogging();
   void stopLogging();
   void clearLogs();
-  void setMaxEvents(uint32_t maxBufferSize);
+  void setMaxEvents(uint64_t maxBufferSize);
 
  private:
   bool registered_{false};
@@ -285,7 +285,7 @@ class RoctracerLogger {
   ApiIdList loggedIds_;
 
   // Api callback data
-  uint32_t maxBufferSize_{5000000}; // 5M GPU runtime/kernel events.
+  uint64_t maxBufferSize_{5000000}; // 5M GPU runtime/kernel events.
   std::vector<roctracerBase*> rows_;
   std::mutex rowsMutex_;
 


### PR DESCRIPTION
The Roctracer has a limit on the max number of GPU events before it stops tracing. This limit was stored in a uint32_t variable maxBufferSize_. This limit can be changed using ROCTRACER_MAX_EVENTS, which is parsed as a signed int32_t. This means that there is still a hard limit on the number of GPU events at just over 2.1 billion (2^31 − 1). This may sound like an unreasonable number of events in a single trace, but I think users should at least be given the option to do so. And right now, it's impossible given the 32bit types.

This pull requests changes the relevant types to 64 bit integers. [For extra context, the maxBufferSize_ is being compared to a size_t and logged here.](https://github.com/pytorch/kineto/blob/main/libkineto/src/RoctracerLogger.cpp#L84)