### PR TITLE
Fix racy initialization with KINETO_USE_DAEMON=1

### DIFF
--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -42,8 +42,12 @@ static bool initialized = false;
 
 static void initProfilers() {
   if (!initialized) {
+    // Caution: `initProfilerIfRegistered` spawns the `updateConfigThread`, so
+    // either:
+    // 1. Ensure nothing the main thread does not do anything which could race
+    // with the `updateConfigThread` (current invariant)
+    // 2. Guard the raceable data appropriately
     libkineto::api().initProfilerIfRegistered();
-    libkineto::api().configLoader().initBaseConfig();
     initialized = true;
     VLOG(0) << "libkineto profilers activated";
   }


### PR DESCRIPTION
## Summary:
The  current state of `initProfilers` leads to data races in several different places during kineto's initialization.
```
static void initProfilers() {
  if (!initialized) {
    libkineto::api().initProfilerIfRegistered(); // spawns thread that calls `updateBaseConfig`
    libkineto::api().configLoader().initBaseConfig(); // calls `updateBaseConfig`
    initialized = true;
    VLOG(0) << "libkineto profilers activated";
  }
}
```
The root-cause is `libkineto::api().initProfilerIfRegistered()` spawns a thread on `updateConfigThread` that periodically calls `updateBaseConfig`
while `libkineto::api().configLoader().initBaseConfig()` on the main thread also calls `updateBaseConfig` (this is basically all it does afaict)

this can lead to racing in the initialization of "singletons" in multiple spots, the most relevant I've seen so far:
1. `DaemonConfigLoader::getConfigClient()` (cause of [this reported crash](https://github.com/pytorch/pytorch/issues/163545)
2. `ConfigLoader::daemonConfigLoader()`


It appears `initBaseConfig` was added >4 years ago as a temporary workaround for an event profiler bug ([ref](https://github.com/pytorch/kineto/commit/61a7083bb2687c187dac6a3054ac75bd6eb3d3bc)). 

Given that the event profiler is no longer supported ([ref](https://github.com/pytorch/kineto/commit/61a7083bb2687c187dac6a3054ac75bd6eb3d3bc)) we should be able to remove this.

Differential Revision: D84663094


## Test Plan
```
> cat example.py
import torch
```

```
> KINETO_USE_DAEMON=1 python example.py
INFO:2025-10-14 23:39:49 1639604:1639604 init.cpp:139] Registering daemon config loader, cpuOnly =  0
INFO:2025-10-14 23:39:49 1639604:1639604 CuptiActivityProfiler.cpp:243] CUDA versions. CUPTI: 26; Runtime: 12080; Driver: 12080
```

Observe registration of process in dynolog's logs

I ran this 100 times and observed 0 crashes (previously was seeing crashes ~80-90% of the time)