### PR TITLE
Add Roctracer Fallback to Device Utils

### DIFF
--- a/libkineto/src/DeviceUtil.h
+++ b/libkineto/src/DeviceUtil.h
@@ -48,7 +48,11 @@
 
 #elif defined(HAS_ROCTRACER)
 #include <hip/hip_runtime.h>
+#ifndef ROCTRACER_FALLBACK
 #include <rocprofiler-sdk/version.h>
+#else
+#include <roctracer.h>
+#endif
 
 #define CUDA_CALL(call)                                   \
   {                                                       \


### PR DESCRIPTION
Summary: We accidentally forgot to add the fallback here which might prevent PyTorch from building roctracer if the version is below 6.4. Let's add the case directly in the util file

Differential Revision: D85574902


