### PR TITLE
Add Cuda Event to Kineto Trace

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -34,6 +34,7 @@ enum class ActivityType {
   MTIA_CCP_EVENTS, // MTIA ondevice CCP events
   MTIA_INSIGHT, // MTIA Insight Events
   CUDA_SYNC, // synchronization events between runtime and kernels
+  CUDA_EVENT, // CUDA event activities (cudaEventRecord, etc.)
 
   // Optional Activity types
   GLOW_RUNTIME, // host side glow runtime events

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -34,6 +34,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{
      {"mtia_ccp_events", ActivityType::MTIA_CCP_EVENTS},
      {"mtia_insight", ActivityType::MTIA_INSIGHT},
      {"cuda_sync", ActivityType::CUDA_SYNC},
+     {"cuda_event", ActivityType::CUDA_EVENT},
      {"glow_runtime", ActivityType::GLOW_RUNTIME},
      {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
      {"hpu_op", ActivityType::HPU_OP},

--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -93,6 +93,38 @@ inline const std::string CudaSyncActivity::metadataJson() const {
   return "";
 }
 
+inline const std::string CudaEventActivity::name() const {
+  return "cudaEvent";
+}
+
+inline int64_t CudaEventActivity::deviceId() const {
+  return contextIdtoDeviceId(raw().contextId);
+}
+
+inline int64_t CudaEventActivity::resourceId() const {
+  return static_cast<int32_t>(raw().streamId);
+}
+
+inline void CudaEventActivity::log(ActivityLogger& logger) const {
+  logger.handleActivity(*this);
+  LOG(INFO) << "CudaEventActivity: " << name() << " " << metadataJson();
+}
+
+inline const std::string CudaEventActivity::metadataJson() const {
+  const CUpti_ActivityCudaEventType& event = raw();
+  // clang-format off
+  return fmt::format(R"JSON(
+      "event_id": {},
+      "stream": {}, "correlation": {},
+      "device": {}, "context": {})JSON",
+      event.eventId,
+      static_cast<int32_t>(event.streamId),
+      event.correlationId,
+      deviceId(),
+      event.contextId);
+  // clang-format on
+}
+
 template <class T>
 inline void GpuActivity<T>::log(ActivityLogger& logger) const {
   logger.handleActivity(*this);

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -365,6 +365,9 @@ void CuptiActivityApi::enableCuptiActivities(
       externalCorrelationEnabled_ = true;
     }
     if (activity == ActivityType::CUDA_SYNC) {
+#if CUDA_VERSION >= 13000
+      CUPTI_CALL(cuptiActivityEnableCudaEventDeviceTimestamps(true));
+#endif
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
     }
     if (activity == ActivityType::CUDA_RUNTIME) {

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -401,7 +401,9 @@ class CuptiActivityProfiler {
   void handleOverheadActivity(
       const CUpti_ActivityOverhead* activity,
       ActivityLogger* logger);
-  void handleCudaEventActivity(const CUpti_ActivityCudaEvent* activity);
+  void handleCudaEventActivity(
+      const CUpti_ActivityCudaEventType* activity,
+      ActivityLogger* logger);
   void handleCudaSyncActivity(
       const CUpti_ActivitySynchronization* activity,
       ActivityLogger* logger);

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -102,6 +102,7 @@ TEST(ParseTest, ActivityTypes) {
            ActivityType::CUDA_RUNTIME,
            ActivityType::CUDA_DRIVER,
            ActivityType::CUDA_SYNC,
+           ActivityType::CUDA_EVENT,
            ActivityType::MTIA_RUNTIME,
            ActivityType::MTIA_INSIGHT,
            ActivityType::MTIA_CCP_EVENTS}));


### PR DESCRIPTION
Summary:
Adds event for CUDA 13.0+.

For 12.8 they add the event but there is no way of turning on timestamps.

Differential Revision: D84963573


