### PR TITLE
Fix repeated thread creation in CuptiActivityApi::teardownContext

### DIFF
--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -87,6 +87,7 @@ class CuptiActivityApi {
   std::unique_ptr<CuptiActivityBufferMap> readyGpuTraceBuffers_;
   std::mutex mutex_;
   std::atomic<uint32_t> tracingEnabled_{0};
+  std::atomic<uint32_t> tearingDown_{0};
   bool externalCorrelationEnabled_{false};
 
 #ifdef HAS_CUPTI


### PR DESCRIPTION
Running the following code causes a core dump:

```python
import os
os.environ["TEARDOWN_CUPTI"] = "1"

import torch

x = torch.randn(1024, 1024).cuda()

for i in range(5):
    with torch.profiler.profile() as p:
        y = x @ x

for i in range(5):
    y = x @ x
```

The issue occurs when we try to perform consecutive profiling sessions. In CuptiActivityApi::teardownContext, the next thread might be created before the previous thread finishes its work, so we need to prevent thread duplication.