### PR TITLE
Reduce the verbosity of logs that indicate failure to get OD config.

### DIFF
--- a/libkineto/src/IpcFabricConfigClient.cpp
+++ b/libkineto/src/IpcFabricConfigClient.cpp
@@ -176,8 +176,8 @@ std::string IpcFabricConfigClient::getLibkinetoOndemandConfig(int32_t type) {
 
   try {
     if (!fabricManager_->sync_send(*msg, std::string(kDynoIpcName))) {
-      LOG(ERROR) << "Failed to send config type=" << type
-                 << " to dyno: IPC sync_send fail";
+      VLOG(1) << "Failed to send config type=" << type
+              << " to dyno: IPC sync_send fail";
       free(req);
       req = nullptr;
       return "";


### PR DESCRIPTION
Summary: When we enable ondemand tracing in MSL, these logs show up a lot due to issues like D84573484. While we are fixing those, also increasing the log level for these so as to not be a nuisance for people who enable KINETO_USE_DAEMON=1 (ondemand tracing).

Differential Revision: D86722299


