### PR TITLE
Remove superfluous logging

### DIFF
--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -107,7 +107,6 @@ inline int64_t CudaEventActivity::resourceId() const {
 
 inline void CudaEventActivity::log(ActivityLogger& logger) const {
   logger.handleActivity(*this);
-  LOG(INFO) << "CudaEventActivity: " << name() << " " << metadataJson();
 }
 
 inline const std::string CudaEventActivity::metadataJson() const {


### PR DESCRIPTION
Summary: Added logging for Event Record events in a previous PR but this clogs logging and can cause traces to not open.

Differential Revision: D87020156


