### PR TITLE
Roctracer: enable logging of hipEventRecord

### DIFF
--- a/libkineto/src/RoctracerLogger.cpp
+++ b/libkineto/src/RoctracerLogger.cpp
@@ -332,7 +332,6 @@ void RoctracerLogger::startLogging() {
     loggedIds_.add("__hipPushCallConfiguration");
     loggedIds_.add("__hipPopCallConfiguration");
     loggedIds_.add("hipCtxSetCurrent");
-    loggedIds_.add("hipEventRecord");
     loggedIds_.add("hipEventQuery");
     loggedIds_.add("hipGetDeviceProperties");
     loggedIds_.add("hipPeekAtLastError");


### PR DESCRIPTION
HipEventRecord events were being intentionally suppressed.  These are useful for looking at cross stream interactions.
This better matches the cupti supressions here: https://github.com/pytorch/kineto/blob/main/libkineto/src/CuptiActivityProfiler.cpp#L570