### PR TITLE
Remove verbose CUDA event logging causing malformed JSON traces

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -694,8 +694,6 @@ void CuptiActivityProfiler::handleCudaEventActivity(
     recordDevice(device_id);
   }
 
-  VLOG(2) << "Logging CUDA event activity device = " << device_id
-          << " stream = " << activity->streamId;
   cuda_event_activity.log(*logger);
   setGpuActivityPresent(true);
 }


### PR DESCRIPTION
Summary:
PyTorch profiler trace files were being generated with malformed JSON, causing
parsing errors in tools like Durin, HTA, and trace analyzers. The error
manifested as `IncompleteJSONError` with unescaped double quotes in the INFO
array breaking JSON syntax.

**Root Cause:**
A VLOG(2) statement in handleCudaEventActivity() logged metadata like:
  "Logging CUDA event activity device = X stream = Y"

When these verbose log messages were captured in the trace's INFO array
alongside the actual CUDA event activity data (which contains JSON metadata
with quotes like "event_id", "stream", etc.), it created malformed JSON that
could not be parsed. (https://www.internalfb.com/intern/everpaste/?handle=GEyeLSN2LmNJboACAD-bM5uHkvxDbsIXAAAz)

**Fix:**
Remove the redundant VLOG statement (lines 696-697) from 
CuptiActivityProfiler.cpp. CUDA events are still properly logged via the 
activity logger (cuda_event_activity.log(*logger)), just without the verbose 
logging that was polluting the trace output.


**Impact:**
- Trace files will now have valid JSON that can be parsed by all tools
- No functional change to event tracking or profiling capabilities
- Reduces noise in trace INFO arrays

Fixes issues reported in:
- https://fb.workplace.com/groups/ai.efficiency.tools.users/permalink/2209012929584173/
- https://fb.workplace.com/groups/ai.efficiency.tools.users/permalink/2199835460501920/

Reviewed By: sanrise

Differential Revision: D87880944


