### PR TITLE
Add PyTorch integration test to Kineto CI workflow

### DIFF
--- a/.github/workflows/libkineto_cuda.yml
+++ b/.github/workflows/libkineto_cuda.yml
@@ -78,6 +78,54 @@ jobs:
 
           docker exec -t -w "/kineto/build_static" "${container_name}" bash -c "make test"
 
+      - name: Clone PyTorch
+        run: |
+          container_name=$(docker ps -lq)
+          docker exec -t -w "/" "${container_name}" bash -c "
+            set -eux
+            git clone --recursive https://github.com/pytorch/pytorch.git
+          "
+
+      - name: Replace PyTorch's Kineto with PR version
+        run: |
+          container_name=$(docker ps -lq)
+          docker exec -t -w "/pytorch" "${container_name}" bash -c "
+            set -eux
+            rm -rf third_party/kineto
+            ln -s /kineto third_party/kineto
+          "
+
+      - name: Build PyTorch from source
+        run: |
+          container_name=$(docker ps -lq)
+          docker exec -t -w "/pytorch" "${container_name}" bash -c "
+            set -eux
+            pip install -r requirements.txt
+            export USE_CUDA=1
+            export BUILD_TEST=1
+            python setup.py develop
+          "
+
+      - name: Run PyTorch profiler tests
+        run: |
+          container_name=$(docker ps -lq)
+          docker exec -t -w "/pytorch" "${container_name}" bash -c "
+            set -eux
+            # TODO: Dynamically add/remove tests to the exclusion list based on their
+            # status on trunk instead of maintaining a hardcoded list of known failures.
+            # This will prevent the list from becoming stale as tests get fixed upstream.
+            python -m pytest test/profiler/ -v \
+              --deselect=test/profiler/test_memory_profiler.py::TestDataFlow::test_data_flow_graph_complicated \
+              --deselect=test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_sequential_fwd_bwd \
+              --deselect=test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd \
+              --deselect=test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd_step \
+              --deselect=test/profiler/test_profiler.py::TestProfiler::test_kineto \
+              --deselect=test/profiler/test_profiler.py::TestProfiler::test_user_annotation \
+              --deselect=test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize \
+              --deselect=test/profiler/test_profiler.py::TestExperimentalUtils::test_profiler_debug_autotuner \
+              --deselect=test/profiler/test_torch_tidy.py::TestTorchTidyProfiler::test_tensorimpl_invalidation_scalar_args
+          "
+
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
         if: always()


### PR DESCRIPTION
Summary: Enhance the libkineto CI workflow to build PyTorch from source with the PR's Kineto changes and run test/test_profiler.py. This ensures Kineto changes are validated in the full PyTorch context before merging, catching integration issues early. The workflow clones PyTorch, replaces its bundled Kineto submodule with the PR version via symlink, compiles PyTorch with CUDA support, and runs the profiler tests on the same A10G GPU instance.

Differential Revision: D88682098


