### PR TITLE
Use viable/strict branch for PyTorch in libkineto CUDA workflow

### DIFF
--- a/.github/workflows/libkineto_cuda.yml
+++ b/.github/workflows/libkineto_cuda.yml
@@ -83,7 +83,7 @@ jobs:
           container_name=$(docker ps -lq)
           docker exec -t -w "/" "${container_name}" bash -c "
             set -eux
-            git clone --recursive https://github.com/pytorch/pytorch.git
+            git clone --recursive --branch viable/strict https://github.com/pytorch/pytorch.git
           "
 
       - name: Replace PyTorch's Kineto with PR version


### PR DESCRIPTION
Summary: Changed the PyTorch clone step in the GitHub Actions workflow to use the viable/strict branch instead of main. This ensures testing against a more stable, vetted version of PyTorch rather than the potentially unstable main branch, reducing test flakiness and unexpected breakages.

Differential Revision: D88903924


