### PR TITLE
Refactor of handling version metadata parameters for devices and add XPU support

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -190,7 +190,7 @@ target_include_directories(kineto_base PUBLIC
       $<BUILD_INTERFACE:${ROCM_INCLUDE_DIRS}>)
 
 if(DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
-  target_include_directories(kineto_base PUBLIC ${XPUPTI_INCLUDE_DIR})
+  target_include_directories(kineto_base SYSTEM PUBLIC ${XPUPTI_INCLUDE_DIR})
 endif()
 if(DEFINED LIBKINETO_NOAIUPTI AND NOT LIBKINETO_NOAIUPTI)
   target_include_directories(kineto_base PUBLIC ${AIU_INCLUDE_DIR})

--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -38,6 +38,7 @@ def get_libkineto_xpupti_srcs(with_api = True):
         "src/plugin/xpupti/XpuptiActivityApi.cpp",
         "src/plugin/xpupti/XpuptiActivityProfiler.cpp",
         "src/plugin/xpupti/XpuptiActivityHandlers.cpp",
+        "src/plugin/xpupti/XpuptiVersionLogger.cpp",
     ] + (get_libkineto_cpu_only_srcs(with_api))
 
 def get_libkineto_aiupti_srcs(with_api = True):
@@ -70,6 +71,7 @@ def get_libkineto_cpu_only_srcs(with_api = True):
         "src/init.cpp",
         "src/output_csv.cpp",
         "src/output_json.cpp",
+        "src/VersionLogger.cpp",
     ] + (get_libkineto_api_srcs() if with_api else [])
 
 def get_libkineto_public_headers():

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -40,6 +40,7 @@
 #include "TraceSpan.h"
 #include "libkineto.h"
 #include "output_base.h"
+#include "VersionLogger.h"
 
 namespace KINETO_NAMESPACE {
 
@@ -244,11 +245,6 @@ class CuptiActivityProfiler {
     metadata_[key] = value;
   }
 
-  void addVersionMetadata(const std::string& key, const std::string& value) {
-    std::lock_guard<std::recursive_mutex> guard(mutex_);
-    versionMetadata_[key] = value;
-  }
-
   void addChildActivityProfiler(std::unique_ptr<IActivityProfiler> profiler) {
     std::lock_guard<std::recursive_mutex> guard(mutex_);
     profilers_.push_back(std::move(profiler));
@@ -318,8 +314,6 @@ class CuptiActivityProfiler {
     int64_t overhead;
     int cntr;
   };
-
-  void logGpuVersions();
 
   void startTraceInternal(
       const std::chrono::time_point<std::chrono::system_clock>& now);
@@ -569,8 +563,8 @@ class CuptiActivityProfiler {
   // Trace metadata
   std::unordered_map<std::string, std::string> metadata_;
 
-  // Version metadata
-  std::unordered_map<std::string, std::string> versionMetadata_;
+  // version logger for device software versions
+  std::unique_ptr<DeviceVersionLogger> versionLogger_;
 
   // child activity profilers
   std::vector<std::unique_ptr<IActivityProfiler>> profilers_;

--- a/libkineto/src/VersionLogger.cpp
+++ b/libkineto/src/VersionLogger.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <VersionLogger.h>
+
+#ifdef HAS_XPUPTI
+#include "plugin/xpupti/XpuptiVersionLogger.h"
+#endif
+
+namespace KINETO_NAMESPACE {
+
+void CudaVersionLogger::logAndRecordVersions() {
+#ifdef HAS_CUPTI
+  // check Nvidia versions
+  uint32_t cuptiVersion = 0;
+  int cudaRuntimeVersion = 0, cudaDriverVersion = 0;
+  CUPTI_CALL(cuptiGetVersion(&cuptiVersion));
+  CUDA_CALL(cudaRuntimeGetVersion(&cudaRuntimeVersion));
+  CUDA_CALL(cudaDriverGetVersion(&cudaDriverVersion));
+  LOG(INFO) << "CUDA versions. CUPTI: " << cuptiVersion
+            << "; Runtime: " << cudaRuntimeVersion
+            << "; Driver: " << cudaDriverVersion;
+
+  LOGGER_OBSERVER_ADD_METADATA("cupti_version", std::to_string(cuptiVersion));
+  LOGGER_OBSERVER_ADD_METADATA(
+      "cuda_runtime_version", std::to_string(cudaRuntimeVersion));
+  LOGGER_OBSERVER_ADD_METADATA(
+      "cuda_driver_version", std::to_string(cudaDriverVersion));
+  addVersionMetadata("cupti_version", std::to_string(cuptiVersion));
+  addVersionMetadata(
+      "cuda_runtime_version", std::to_string(cudaRuntimeVersion));
+  addVersionMetadata("cuda_driver_version", std::to_string(cudaDriverVersion));
+#endif
+};
+
+void HipVersionLogger::logAndRecordVersions() {
+#ifdef HAS_ROCTRACER
+  uint32_t majorVersion = roctracer_version_major();
+  uint32_t minorVersion = roctracer_version_minor();
+  std::string roctracerVersion =
+      std::to_string(majorVersion) + "." + std::to_string(minorVersion);
+  int hipRuntimeVersion = 0, hipDriverVersion = 0;
+  CUDA_CALL(hipRuntimeGetVersion(&hipRuntimeVersion));
+  CUDA_CALL(hipDriverGetVersion(&hipDriverVersion));
+  LOG(INFO) << "HIP versions. Roctracer: " << roctracerVersion
+            << "; Runtime: " << hipRuntimeVersion
+            << "; Driver: " << hipDriverVersion;
+
+  LOGGER_OBSERVER_ADD_METADATA("roctracer_version", roctracerVersion);
+  LOGGER_OBSERVER_ADD_METADATA(
+      "hip_runtime_version", std::to_string(hipRuntimeVersion));
+  LOGGER_OBSERVER_ADD_METADATA(
+      "hip_driver_version", std::to_string(hipDriverVersion));
+  addVersionMetadata("roctracer_version", roctracerVersion);
+  addVersionMetadata("hip_runtime_version", std::to_string(hipRuntimeVersion));
+  addVersionMetadata("hip_driver_version", std::to_string(hipDriverVersion));
+#endif
+}
+
+std::unique_ptr<DeviceVersionLogger> selectDeviceVersionLogger(
+    std::recursive_mutex& mutex) {
+#ifdef HAS_CUPTI
+  return std::make_unique<CudaVersionLogger>(mutex);
+#elif HAS_ROCTRACER
+  return std::make_unique<HipVersionLogger>(mutex);
+#elif HAS_XPUPTI
+  return std::make_unique<XpuVersionLogger>(mutex);
+#else
+  return nullptr;
+#endif
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/VersionLogger.h
+++ b/libkineto/src/VersionLogger.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace KINETO_NAMESPACE {
+
+class DeviceVersionLogger {
+ public:
+  DeviceVersionLogger(std::recursive_mutex& mutex) : mutex_(mutex) {};
+  virtual ~DeviceVersionLogger() = default;
+  virtual void logAndRecordVersions() = 0;
+  std::unordered_map<std::string, std::string> getVersionMetadata() {
+    return versionMetadata_;
+  }
+
+ protected:
+  void addVersionMetadata(const std::string& key, const std::string& value) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    versionMetadata_[key] = value;
+  }
+
+ private:
+  std::unordered_map<std::string, std::string> versionMetadata_;
+  std::recursive_mutex& mutex_;
+};
+
+class CudaVersionLogger : public DeviceVersionLogger {
+ public:
+  CudaVersionLogger(std::recursive_mutex& mutex) : DeviceVersionLogger(mutex) {}
+  void logAndRecordVersions() override;
+};
+
+class HipVersionLogger : public DeviceVersionLogger {
+ public:
+  HipVersionLogger(std::recursive_mutex& mutex) : DeviceVersionLogger(mutex) {}
+  void logAndRecordVersions() override;
+};
+
+std::unique_ptr<DeviceVersionLogger> selectDeviceVersionLogger(
+    std::recursive_mutex& mutex);
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/plugin/xpupti/CMakeLists.txt
+++ b/libkineto/src/plugin/xpupti/CMakeLists.txt
@@ -42,11 +42,15 @@ if(TARGET Pti::pti_view)
     # find dependent lib
     set(XPU_xpupti_LIBRARY ${SYCL_LIBRARY})
     list(APPEND XPU_xpupti_LIBRARY ${PTI_LIBRARY})
-    set(XPU_xpupti_LIBRARY ${XPU_xpupti_LIBRARY} PARENT_SCOPE)
 
     # find dependent include
     list(APPEND XPUPTI_INCLUDE_DIR ${PTI_INCLUDE_DIR})
     set(XPUPTI_INCLUDE_DIR ${XPUPTI_INCLUDE_DIR} PARENT_SCOPE)
+
+    # find level zero library
+    find_library(LEVEL_ZERO_LIBRARY ze_loader)
+    list(APPEND XPU_xpupti_LIBRARY ${LEVEL_ZERO_LIBRARY})
+    set(XPU_xpupti_LIBRARY ${XPU_xpupti_LIBRARY} PARENT_SCOPE)
 
     set(XPUPTI_BUILD_FLAG "-DHAS_XPUPTI" PARENT_SCOPE)
 

--- a/libkineto/src/plugin/xpupti/XpuptiVersionLogger.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiVersionLogger.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <level_zero/ze_api.h>
+#include <plugin/xpupti/XpuptiVersionLogger.h>
+#include <pti/pti_view.h>
+#include <sycl/version.hpp>
+namespace KINETO_NAMESPACE {
+namespace {
+
+std::string getLevelZeroVersion() {
+  uint32_t version = 0;
+  auto result = zeInit(0);
+  if (result == ZE_RESULT_SUCCESS) {
+    uint32_t driverCount = 0;
+    zeDriverGet(&driverCount, nullptr);
+    if (driverCount > 0) {
+      ze_driver_handle_t driver;
+      zeDriverGet(&driverCount, &driver);
+      ze_api_version_t apiVersion;
+      zeDriverGetApiVersion(driver, &apiVersion);
+
+      return std::to_string(ZE_MAJOR_VERSION(apiVersion)) + "." +
+          std::to_string(ZE_MINOR_VERSION(apiVersion));
+    }
+  }
+  return "unknown";
+}
+
+} // namespace
+
+void XpuVersionLogger::logAndRecordVersions() {
+  std::string ptiVersion = "\"" + std::string(ptiVersionString()) + "\"";
+  addVersionMetadata("pti_version", ptiVersion);
+
+  addVersionMetadata("level_zero_version", getLevelZeroVersion());
+
+  std::string syclCompilerVersion = std::to_string(__SYCL_COMPILER_VERSION);
+  addVersionMetadata("sycl_compiler_version", syclCompilerVersion);
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/plugin/xpupti/XpuptiVersionLogger.h
+++ b/libkineto/src/plugin/xpupti/XpuptiVersionLogger.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <VersionLogger.h>
+
+namespace KINETO_NAMESPACE {
+
+class XpuVersionLogger : public DeviceVersionLogger {
+ public:
+  XpuVersionLogger(std::recursive_mutex& mutex) : DeviceVersionLogger(mutex) {}
+  void logAndRecordVersions() override;
+};
+
+} // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Refactor of existing `CuptiActivityProfiler::logGpuVersions` and extracting it into separate class `DeviceVersionLogger` which should be overwritten by each device. Such approach allow for much easier creating support for this feature for various devices, it allow also to keep the device specific code separated from the rest of code.

PR converts existing CUDA and ROCTRACER implementations to new format and add support for XPU devices via `XpuVersionLogger` class. 

For XPU following information will be added to logs:
```
      "pti_version": "<version>",
      "level_zero_version": <version>,
      "sycl_compiler_version": <version>,
```