### PR TITLE
Add PT_PROFILER env vars to trace metadata

### DIFF
--- a/libkineto/include/EnvMetadata.h
+++ b/libkineto/include/EnvMetadata.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fmt/core.h>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <unordered_map>
+
+namespace libkineto {
+
+enum class EnvVar : std::uint8_t {
+  PT_PROFILER_JOB_NAME,
+  PT_PROFILER_JOB_VERSION,
+  PT_PROFILER_JOB_ATTEMPT_INDEX,
+};
+
+inline const std::unordered_map<EnvVar, const char*> K_ENV_VAR_MAP = {
+    {EnvVar::PT_PROFILER_JOB_NAME, "PT_PROFILER_JOB_NAME"},
+    {EnvVar::PT_PROFILER_JOB_VERSION, "PT_PROFILER_JOB_VERSION"},
+    {EnvVar::PT_PROFILER_JOB_ATTEMPT_INDEX, "PT_PROFILER_JOB_ATTEMPT_INDEX"},
+};
+
+// Returns a map of (env_var_name, env_value) for all environment variables
+// that are currently set. Only includes entries where the env var exists.
+inline std::unordered_map<std::string, std::string> getEnvMetadata() {
+  std::unordered_map<std::string, std::string> result;
+  for (const auto& [key, name] : K_ENV_VAR_MAP) {
+    if (const char* val = std::getenv(name)) {
+      result[name] = fmt::format("\"{}\"", val);
+    }
+  }
+  return result;
+}
+
+} // namespace libkineto

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -111,6 +111,9 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   void metadataToJSON(
       const std::unordered_map<std::string, std::string>& metadata);
 
+  std::unordered_map<std::string, std::string> addEnvVarsToMetadata(
+      const std::unordered_map<std::string, std::string>& metadata);
+
   void sanitizeStrForJSON(std::string& value);
 
   void addOnDemandDistMetadata();

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -11,13 +11,17 @@
 #include <folly/json/json.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <stdlib.h> // NOLINT(modernize-deprecated-headers) required for setenv unsetenv
+
 #include <strings.h>
-#include <time.h>
 #include <chrono>
+#include <cstdint>
+#include <cstdio>
 
 #ifdef __linux__
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #endif
 
 #include "include/Config.h"
@@ -952,11 +956,16 @@ TEST_F(CuptiActivityProfilerTest, BufferSizeLimitTestWarmup) {
 }
 
 TEST(CuptiActivityProfiler, MetadataJsonFormatingTest) {
-  // Check for Json string sanitation
+  // Check for Json string sanitation and env var injection
   // based on AsyncTrace test
   std::vector<std::string> log_modules(
       {"CuptiActivityProfiler.cpp", "output_json.cpp"});
   SET_LOG_VERBOSITY_LEVEL(1, log_modules);
+
+  // Set environment variables for testing
+  setenv("PT_PROFILER_JOB_NAME", "test_training_job", 1);
+  setenv("PT_PROFILER_JOB_VERSION", "2", 1);
+  setenv("PT_PROFILER_JOB_ATTEMPT_INDEX", "5", 1);
 
   MockCuptiActivities activities;
   CuptiActivityProfiler profiler(activities, /*cpu only*/ true);
@@ -1019,6 +1028,7 @@ TEST(CuptiActivityProfiler, MetadataJsonFormatingTest) {
   }
   std::string jsonStr(
       (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  folly::dynamic jsonData = folly::parseJson(jsonStr);
 
   auto countSubstrings = [](const std::string& source,
                             const std::string& substring) {
@@ -1035,7 +1045,17 @@ TEST(CuptiActivityProfiler, MetadataJsonFormatingTest) {
   EXPECT_EQ(3, countSubstrings(jsonStr, keyPrefix));
   EXPECT_EQ(2, countSubstrings(jsonStr, "metadata value"));
   EXPECT_EQ(1, countSubstrings(jsonStr, "/test/metadata/path"));
+
+  // Verify injected env vars are in trace metadata with correct values
+  EXPECT_EQ(jsonData["PT_PROFILER_JOB_NAME"].asString(), "test_training_job");
+  EXPECT_EQ(jsonData["PT_PROFILER_JOB_VERSION"].asString(), "2");
+  EXPECT_EQ(jsonData["PT_PROFILER_JOB_ATTEMPT_INDEX"].asString(), "5");
 #endif
+
+  // Clean up environment variables
+  unsetenv("PT_PROFILER_JOB_NAME");
+  unsetenv("PT_PROFILER_JOB_VERSION");
+  unsetenv("PT_PROFILER_JOB_ATTEMPT_INDEX");
 }
 
 TEST_F(CuptiActivityProfilerTest, JsonGPUIDSortTest) {


### PR DESCRIPTION
Summary: This diffs adds a way to add env variables to the trace metadata if they're available.

Reviewed By: sanrise

Differential Revision: D89235949


