### PR TITLE
[easy] Rename variable in disablePtiActivities

### DIFF
--- a/libkineto/src/plugin/aiupti/AiuptiActivityApi.cpp
+++ b/libkineto/src/plugin/aiupti/AiuptiActivityApi.cpp
@@ -271,33 +271,33 @@ void AiuptiActivityApi::enableAiuptiActivities(
 void AiuptiActivityApi::disablePtiActivities(
     const std::set<ActivityType>& selected_activities) {
 #ifdef HAS_AIUPTI
-  bool activityEnabled = false;
+  bool activityDisabled = false;
   for (const auto& activity : selected_activities) {
     if (activity == ActivityType::GPU_MEMCPY) {
       AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY));
       AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY2));
       AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
-      activityEnabled = true;
+      activityDisabled = true;
     }
     if (activity == ActivityType::GPU_MEMSET) {
       AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMORY));
-      activityEnabled = true;
+      activityDisabled = true;
     }
     if (activity == ActivityType::CONCURRENT_KERNEL) {
       AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_CMPT));
-      activityEnabled = true;
+      activityDisabled = true;
     }
     if (activity == ActivityType::PRIVATEUSE1_RUNTIME) {
       AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_RUNTIME));
-      activityEnabled = true;
+      activityDisabled = true;
     }
     if (activity == ActivityType::PRIVATEUSE1_DRIVER) {
       AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_DRIVER));
-      activityEnabled = true;
+      activityDisabled = true;
     }
   }
 
-  if (activityEnabled == false) {
+  if (activityDisabled == false) {
     const char* env_value = std::getenv("ProfilerActivity");
     if (env_value != nullptr && std::string(env_value) == "PrivateUse1") {
       AIUPTI_CALL(aiuptiActivityDisable(AIUPTI_ACTIVITY_KIND_MEMCPY));


### PR DESCRIPTION
In `disablePtiActivities`, we should have `activityDisabled` instead of `activityEnabled` to track activity status.