### PR TITLE
[1/n] Add generalized event types and GPU Performance Monitoring counter event support

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -14,96 +14,100 @@
 
 namespace libkineto {
 
-// Note : All activity types are not enabled by default. Please add them
-// at correct position in the enum
 enum class ActivityType {
-  // Activity types enabled by default
-  CPU_OP = 0, // cpu side ops
-  USER_ANNOTATION = 1,
-  GPU_USER_ANNOTATION = 2,
-  GPU_MEMCPY = 3,
-  GPU_MEMSET = 4,
-  CONCURRENT_KERNEL = 5, // on-device kernels
-  EXTERNAL_CORRELATION = 6,
-  CUDA_RUNTIME = 7, // host side cuda runtime events
-  CUDA_DRIVER = 8, // host side cuda driver events
-  CPU_INSTANT_EVENT = 9, // host side point-like events
-  PYTHON_FUNCTION = 10,
-  OVERHEAD = 11, // CUPTI induced overhead events sampled from its overhead API.
-  MTIA_RUNTIME = 12, // host side MTIA runtime events
-  MTIA_CCP_EVENTS = 13, // MTIA ondevice CCP events
-  MTIA_INSIGHT = 14, // MTIA Insight Events
-  CUDA_SYNC = 15, // synchronization events between runtime and kernels
-  CUDA_EVENT = 16, // CUDA event activities (cudaEventRecord, etc.)
-  MTIA_COUNTERS = 17, // MTIA hardware counter events (HBM, cache, DPE, SFU)
+  // -------------------------------------------------------------------------
+  // Accelerator-Agnostic Event Types
+  // -------------------------------------------------------------------------
+  // These are the canonical event types that work across all accelerators.
+  // Prefer using these over device-specific types for better extensibility
+  // and maintainability.
 
-  // Optional Activity types
-  GLOW_RUNTIME = 18, // host side glow runtime events
-  CUDA_PROFILER_RANGE = 19, // CUPTI Profiler range for performance metrics
-  HPU_OP = 20, // HPU host side runtime event
-  XPU_RUNTIME = 21, // host side xpu runtime events
-  XPU_DRIVER = 22, // host side xpu driver events
-  COLLECTIVE_COMM = 23, // collective communication
+  CPU_OP = 0, // CPU-side ops (e.g., from PyTorch)
+  USER_ANNOTATION, // User-defined annotations
+  GPU_USER_ANNOTATION, // GPU-side user annotations
+  GPU_MEMCPY, // Memory copy operations
+  GPU_MEMSET, // Memory set operations
+  CONCURRENT_KERNEL, // On-device kernel execution
+  EXTERNAL_CORRELATION, // Correlation with external events
+  RUNTIME, // Host-side runtime events
+  DRIVER, // Host-side driver events
+  CPU_INSTANT_EVENT, // Host-side point-like events
+  PYTHON_FUNCTION, // Python function calls
+  OVERHEAD, // Profiler-induced overhead events
+  COLLECTIVE_COMM, // Collective communication operations
+  GPU_PM_COUNTER, // Performance monitoring counters
 
-  // PRIVATEUSE1 Activity types are used for custom backends.
-  // The corresponding device type is `DeviceType::PrivateUse1` in PyTorch.
-  PRIVATEUSE1_RUNTIME = 24, // host side privateUse1 runtime events
-  PRIVATEUSE1_DRIVER = 25, // host side privateUse1 driver events
+  // -------------------------------------------------------------------------
+  // Device-Specific Event Types
+  // -------------------------------------------------------------------------
+  // These events don't fit into the accelerator-agnostic categories above.
+  // Use sparingly; prefer agnostic types when possible.
 
-  ENUM_COUNT = 26, // This is to add buffer and not used for any profiling logic. Add
-  // your new type before it.
-  OPTIONAL_ACTIVITY_TYPE_START = GLOW_RUNTIME,
+  MTIA_INSIGHT, // MTIA Insight events
+  CUDA_SYNC, // CUDA synchronization events
+  CUDA_EVENT, // CUDA event activities (cudaEventRecord, etc.)
+  CUDA_PROFILER_RANGE, // CUPTI Profiler range for performance metrics
+
+  // -------------------------------------------------------------------------
+  ENUM_COUNT, // Sentinel value; add new types above this line
+
+  // -------------------------------------------------------------------------
+  // Aliased Event Types (Deprecated)
+  // -------------------------------------------------------------------------
+  // These are aliases to accelerator-agnostic types for backward compatibility.
+  // Do NOT add new aliases. We aim to remove these in the future.
+
+  CUDA_RUNTIME = RUNTIME,
+  CUDA_DRIVER = DRIVER,
+  MTIA_RUNTIME = RUNTIME,
+  MTIA_CCP_EVENTS = CONCURRENT_KERNEL,
+  MTIA_COUNTERS = GPU_PM_COUNTER,
+  GLOW_RUNTIME = RUNTIME,
+  HPU_OP = RUNTIME,
+  XPU_RUNTIME = RUNTIME,
+  XPU_DRIVER = DRIVER,
+
+  // PrivateUse1: Custom backend activity types
+  // Corresponds to DeviceType::PrivateUse1 in PyTorch.
+  PRIVATEUSE1_RUNTIME = RUNTIME,
+  PRIVATEUSE1_DRIVER = DRIVER,
 };
 
 // Return an array of all activity types except COUNT
 constexpr int activityTypeCount = (int)ActivityType::ENUM_COUNT;
-constexpr int defaultActivityTypeCount = (int)ActivityType::OPTIONAL_ACTIVITY_TYPE_START;
 
-// These definitions are not part of the public Kineto API. They are inlined
-// here because some build configurations include this header
-// without linking libkineto, and toString() must resolve at compile time.
-struct _ActivityTypeName {
-  const char* name;
-  ActivityType type;
-};
-
-inline constexpr std::array<_ActivityTypeName, activityTypeCount + 1> _activityTypeNames{{
-    {"cpu_op", ActivityType::CPU_OP},
-    {"user_annotation", ActivityType::USER_ANNOTATION},
-    {"gpu_user_annotation", ActivityType::GPU_USER_ANNOTATION},
-    {"gpu_memcpy", ActivityType::GPU_MEMCPY},
-    {"gpu_memset", ActivityType::GPU_MEMSET},
-    {"kernel", ActivityType::CONCURRENT_KERNEL},
-    {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
-    {"cuda_runtime", ActivityType::CUDA_RUNTIME},
-    {"cuda_driver", ActivityType::CUDA_DRIVER},
-    {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
-    {"python_function", ActivityType::PYTHON_FUNCTION},
-    {"overhead", ActivityType::OVERHEAD},
-    {"mtia_runtime", ActivityType::MTIA_RUNTIME},
-    {"mtia_ccp_events", ActivityType::MTIA_CCP_EVENTS},
-    {"mtia_insight", ActivityType::MTIA_INSIGHT},
-    {"cuda_sync", ActivityType::CUDA_SYNC},
-    {"cuda_event", ActivityType::CUDA_EVENT},
-    {"mtia_counters", ActivityType::MTIA_COUNTERS},
-    {"glow_runtime", ActivityType::GLOW_RUNTIME},
-    {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
-    {"hpu_op", ActivityType::HPU_OP},
-    {"xpu_runtime", ActivityType::XPU_RUNTIME},
-    {"xpu_driver", ActivityType::XPU_DRIVER},
-    {"collective_comm", ActivityType::COLLECTIVE_COMM},
-    {"privateuse1_runtime", ActivityType::PRIVATEUSE1_RUNTIME},
-    {"privateuse1_driver", ActivityType::PRIVATEUSE1_DRIVER},
-    {"ENUM_COUNT", ActivityType::ENUM_COUNT},
-}};
-
-inline const char* toString(ActivityType t) {
-  return _activityTypeNames[static_cast<int>(t)].name;
-}
-
+const char* toString(ActivityType t);
 ActivityType toActivityType(const std::string& str);
 
-std::array<ActivityType, activityTypeCount> activityTypes();
-std::array<ActivityType, defaultActivityTypeCount> defaultActivityTypes();
+// Return an array of all activity types, note does not return aliases.
+const std::array<ActivityType, activityTypeCount> activityTypes();
+
+// Default activity types that are enabled by default during profiling
+inline constexpr std::array defaultActivityTypesArray = {
+    ActivityType::CPU_OP,
+    ActivityType::USER_ANNOTATION,
+    ActivityType::GPU_USER_ANNOTATION,
+    ActivityType::GPU_MEMCPY,
+    ActivityType::GPU_MEMSET,
+    ActivityType::CONCURRENT_KERNEL,
+    ActivityType::EXTERNAL_CORRELATION,
+    ActivityType::RUNTIME,
+    ActivityType::DRIVER,
+    ActivityType::CPU_INSTANT_EVENT,
+    ActivityType::PYTHON_FUNCTION,
+    ActivityType::OVERHEAD,
+    ActivityType::GPU_PM_COUNTER,
+    ActivityType::MTIA_RUNTIME,
+    ActivityType::MTIA_CCP_EVENTS,
+    ActivityType::MTIA_INSIGHT,
+    ActivityType::CUDA_SYNC,
+    ActivityType::CUDA_EVENT,
+};
+
+constexpr int defaultActivityTypeCount = defaultActivityTypesArray.size();
+
+constexpr auto defaultActivityTypes() {
+  return defaultActivityTypesArray;
+}
 
 } // namespace libkineto

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -12,34 +12,84 @@
 
 namespace libkineto {
 
+struct ActivityTypeName {
+  const char* name;
+  ActivityType type;
+};
+
+// Canonical names for each unique ActivityType value, ordered by enum value.
+// This array is used for toString() via direct indexing.
+static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{{
+    // Accelerator-Agnostic Event Types
+    {"cpu_op", ActivityType::CPU_OP},
+    {"user_annotation", ActivityType::USER_ANNOTATION},
+    {"gpu_user_annotation", ActivityType::GPU_USER_ANNOTATION},
+    {"gpu_memcpy", ActivityType::GPU_MEMCPY},
+    {"gpu_memset", ActivityType::GPU_MEMSET},
+    {"kernel", ActivityType::CONCURRENT_KERNEL},
+    {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
+    {"runtime", ActivityType::RUNTIME},
+    {"driver", ActivityType::DRIVER},
+    {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
+    {"python_function", ActivityType::PYTHON_FUNCTION},
+    {"overhead", ActivityType::OVERHEAD},
+    {"collective_comm", ActivityType::COLLECTIVE_COMM},
+    {"gpu_pm_counter", ActivityType::GPU_PM_COUNTER},
+    // Accelerator-Specific Event Types
+    {"mtia_insight", ActivityType::MTIA_INSIGHT},
+    {"cuda_sync", ActivityType::CUDA_SYNC},
+    {"cuda_event", ActivityType::CUDA_EVENT},
+    {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
+    {"ENUM_COUNT", ActivityType::ENUM_COUNT},
+}};
+
 static constexpr bool matchingOrder(int idx = 0) {
-  return _activityTypeNames[idx].type == ActivityType::ENUM_COUNT ||
-      ((idx == static_cast<int>(_activityTypeNames[idx].type)) &&
+  return map[idx].type == ActivityType::ENUM_COUNT ||
+      ((idx == static_cast<int>(map[idx].type)) &&
        matchingOrder(idx + 1));
 }
 static_assert(matchingOrder(), "ActivityTypeName map is out of order");
 
+// Alias names for backward compatibility in toActivityType().
+// These map old/alternate string names to their canonical ActivityType.
+static constexpr std::array<ActivityTypeName, 11> aliasMap{{
+    {"cuda_runtime", ActivityType::CUDA_RUNTIME},
+    {"cuda_driver", ActivityType::CUDA_DRIVER},
+    {"mtia_runtime", ActivityType::MTIA_RUNTIME},
+    {"mtia_ccp_events", ActivityType::MTIA_CCP_EVENTS},
+    {"mtia_counters", ActivityType::MTIA_COUNTERS},
+    {"glow_runtime", ActivityType::GLOW_RUNTIME},
+    {"hpu_op", ActivityType::HPU_OP},
+    {"xpu_runtime", ActivityType::XPU_RUNTIME},
+    {"xpu_driver", ActivityType::XPU_DRIVER},
+    {"privateuse1_runtime", ActivityType::PRIVATEUSE1_RUNTIME},
+    {"privateuse1_driver", ActivityType::PRIVATEUSE1_DRIVER},
+}};
+
+const char* toString(ActivityType t) {
+  return map[(int)t].name;
+}
+
 ActivityType toActivityType(const std::string& str) {
+  // Search canonical names first
   for (int i = 0; i < activityTypeCount; i++) {
-    if (str == _activityTypeNames[i].name) {
-      return _activityTypeNames[i].type;
+    if (str == map[i].name) {
+      return map[i].type;
+    }
+  }
+  // Search alias names for backward compatibility
+  for (const auto& alias : aliasMap) {
+    if (str == alias.name) {
+      return alias.type;
     }
   }
   throw std::invalid_argument(fmt::format("Invalid activity type: {}", str));
 }
 
-std::array<ActivityType, activityTypeCount> activityTypes() {
+const std::array<ActivityType, activityTypeCount> activityTypes() {
   std::array<ActivityType, activityTypeCount> res;
   for (int i = 0; i < activityTypeCount; i++) {
-    res[i] = _activityTypeNames[i].type;
-  }
-  return res;
-}
-
-std::array<ActivityType, defaultActivityTypeCount> defaultActivityTypes() {
-  std::array<ActivityType, defaultActivityTypeCount> res;
-  for (int i = 0; i < defaultActivityTypeCount; i++) {
-    res[i] = _activityTypeNames[i].type;
+    res[i] = map[i].type;
   }
   return res;
 }

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -789,6 +789,7 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
     static const std::set<libkineto::ActivityType> excludedTypes = {
         libkineto::ActivityType::GPU_MEMCPY,
         libkineto::ActivityType::GPU_MEMSET,
+        libkineto::ActivityType::GPU_PM_COUNTER,
         libkineto::ActivityType::CONCURRENT_KERNEL,
         libkineto::ActivityType::CUDA_RUNTIME,
         libkineto::ActivityType::CUDA_DRIVER,
@@ -851,6 +852,18 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
   sanitizeForNonReadableChars(op_name);
 
   ts = transToRelativeTime(ts);
+
+  if (op.type() == libkineto::ActivityType::GPU_PM_COUNTER) {
+    writeCounterEvent(
+        /*cat=*/toString(op.type()),
+        /*name=*/op_name,
+        /*pid=*/device,
+        /*tid=*/sanitizeTid(resource),
+        /*ts=*/ts,
+        /*args=*/args);
+    return;
+  }
+
   writeCompleteEvent(
       /*cat=*/toString(op.type()),
       /*name=*/op_name,

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -86,6 +86,7 @@ TEST(ParseTest, ActivityTypes) {
   EXPECT_TRUE(cfg.parse("ACTIVITY_TYPES="));
   EXPECT_FALSE(cfg.parse("=ACTIVITY_TYPES="));
 
+  // Default activity types
   EXPECT_EQ(
       cfg.selectedActivityTypes(),
       std::set<ActivityType>(
@@ -142,6 +143,32 @@ TEST(ParseTest, ActivityTypes) {
       std::set<ActivityType>(
           {ActivityType::PRIVATEUSE1_RUNTIME,
            ActivityType::PRIVATEUSE1_DRIVER}));
+
+  // Generic events
+  EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES = runtime, driver, kernel"));
+  EXPECT_EQ(
+      cfg2.selectedActivityTypes(),
+      std::set<ActivityType>(
+          {ActivityType::RUNTIME,
+           ActivityType::DRIVER,
+           ActivityType::CONCURRENT_KERNEL}));
+
+  // Generic events match aliases
+  EXPECT_TRUE(
+      cfg2.selectedActivityTypes().count(ActivityType::CUDA_RUNTIME) > 0);
+  EXPECT_TRUE(
+      cfg2.selectedActivityTypes().count(ActivityType::CUDA_DRIVER) > 0);
+  EXPECT_TRUE(
+      cfg2.selectedActivityTypes().count(ActivityType::MTIA_RUNTIME) > 0);
+  EXPECT_TRUE(
+      cfg2.selectedActivityTypes().count(ActivityType::MTIA_CCP_EVENTS) > 0);
+  EXPECT_TRUE(
+      cfg2.selectedActivityTypes().count(ActivityType::XPU_RUNTIME) > 0);
+  EXPECT_TRUE(
+      cfg2.selectedActivityTypes().count(ActivityType::PRIVATEUSE1_RUNTIME) >
+      0);
+  EXPECT_TRUE(
+      cfg2.selectedActivityTypes().count(ActivityType::PRIVATEUSE1_DRIVER) > 0);
 }
 
 TEST(ParseTest, SamplePeriod) {

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -331,7 +331,7 @@ TEST(CuptiActivityProfiler, AsyncTrace) {
   CuptiActivityProfiler profiler(activities, /*cpu only*/ true);
 
   char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  mkstemps(filename, 5);
+  close(mkstemps(filename, 5));
 
   Config cfg;
 
@@ -424,7 +424,7 @@ TEST(CuptiActivityProfiler, AsyncTraceUsingIter) {
     CuptiActivityProfiler profiler(activities, /*cpu only*/ true);
 
     char filename[] = "/tmp/libkineto_testXXXXXX.json";
-    mkstemps(filename, 5);
+    close(mkstemps(filename, 5));
 
     Config cfg;
 
@@ -645,7 +645,7 @@ TEST_F(CuptiActivityProfilerTest, SyncTrace) {
 
 #ifdef __linux__
   char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  mkstemps(filename, 5);
+  close(mkstemps(filename, 5));
   trace.save(filename);
   // Check that the expected file was written and that it has some content
   int fd = open(filename, O_RDONLY);
@@ -800,7 +800,7 @@ TEST_F(CuptiActivityProfilerTest, SyncEventCorrIdOutOfOrder) {
 
 #ifdef __linux__
   char filename[] = "/tmp/libkineto_out_of_order_XXXXXX.json";
-  mkstemps(filename, 5);
+  close(mkstemps(filename, 5));
   trace.save(filename);
   LOG(INFO) << "Trace exported to: " << filename;
 #endif
@@ -941,7 +941,7 @@ TEST_F(CuptiActivityProfilerTest, GpuNCCLCollectiveTest) {
 #ifdef __linux__
   // Test saved output can be loaded as JSON
   char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  mkstemps(filename, 5);
+  close(mkstemps(filename, 5));
   LOG(INFO) << "Logging to tmp file: " << filename;
   trace.save(filename);
 
@@ -1100,7 +1100,7 @@ TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
   EXPECT_TRUE(profiler.isActive());
 
   char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  mkstemps(filename, 5);
+  close(mkstemps(filename, 5));
   LOG(INFO) << "Logging to tmp file " << filename;
 
   // process trace
@@ -1186,7 +1186,7 @@ TEST(CuptiActivityProfiler, MetadataJsonFormatingTest) {
   CuptiActivityProfiler profiler(activities, /*cpu only*/ true);
 
   char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  mkstemps(filename, 5);
+  close(mkstemps(filename, 5));
 
   Config cfg;
 
@@ -1326,7 +1326,7 @@ TEST_F(CuptiActivityProfilerTest, JsonGPUIDSortTest) {
 #ifdef __linux__
   // Test saved output can be loaded as JSON
   char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  mkstemps(filename, 5);
+  close(mkstemps(filename, 5));
   LOG(INFO) << "Logging to tmp file: " << filename;
   trace.save(filename);
 


### PR DESCRIPTION
# Overview

Originally, this was part 1 of splitting PR #1148. It supports a new kind of GPU Counter events that will be published to the timeline as a time series. In the process I realized we should add more generic event types for accelerators rather than being tied to CUDA specific naming. This has historically lead to each new accelerator adding it's own events which is maintenance burden.
1. **Generalized Accelerator Event types**:  Add generic event types in the `ActivityType` enum. There are now aliases in the enum class definition for older events like `CUDA_RUNTIME`, `MTIA_RUNTIME` to name a few. The dynamic plugin will leverage generic events so upstream source code changes will not be required for new accelerators.
2. **GPU PM Counter Event Type**: This enables supporting a performance counter event stream. Counter events can be serialized in [ChromeTrace format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0) and will be rendered as time series in the UI. 

# Details

## Accelerator-Agnostic Event Types

The change reorganizes the `ActivityType` enum class to introduce generic, accelerator-agnostic event types that work across all hardware backends (CUDA, MTIA, HPU, XPU, etc.). Device-specific types are now deprecated aliases pointing to their generic counterparts. There are few corner case exceptions like `MTIA_INSIGHT`, `CUDA_SYNC`, see the header.

### New Generic Event Types

| Event Type | Description | Replaces (Deprecated Aliases) |
|------------|-------------|-------------------------------|
| `RUNTIME` | Host-side runtime events from any accelerator backend | `CUDA_RUNTIME`, `MTIA_RUNTIME`, `GLOW_RUNTIME`, `XPU_RUNTIME`, `PRIVATEUSE1_RUNTIME`, `HPU_OP` |
| `DRIVER` | Host-side driver events from any accelerator backend | `CUDA_DRIVER`, `PRIVATEUSE1_DRIVER` |
| `CONCURRENT_KERNEL` | On-device kernel execution across all accelerators | `MTIA_CCP_EVENTS` |
| `GPU_PM_COUNTER` | Performance monitoring counters for hardware profiling | *(new)* |

### Guidance for future use of ActivityTypes
Existing code using deprecated aliases will continue to work, but new code should use the generic types:
```cpp
// ❌ Deprecated (still works for backward compatibility)
ActivityType::CUDA_RUNTIME
ActivityType::MTIA_RUNTIME

// ✅ Preferred
ActivityType::RUNTIME
```
I have not changed the usage of these types in the code base yet. That can happen in a follow up change.

### Notes
* Old string names like "cuda_runtime" still parse correctly via aliasMap, and old enum values like ActivityType::CUDA_RUNTIME still compile (as aliases).
* `defaultActivityTypesArray` is now constexpr, enabling compile-time evaluation and eliminating runtime overhead.

## GPU PM Counter Events

This is a straightforward change to emit [Chrome Trace counter events](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.msg3086636uq)] for counters obtained from the GPU. The event can be leveraged by any accelerator backend.

The values of the counters are embedded as key/val pairs in the output json
```
{..., "name": "ctr", "ph": "C", "ts":  0, "args": {"my_counter":  42}},
```

# Testing
```
make test
// or
ctest -R ActivityTypes
```

The `ParseTest.ActivityTypes` validates that aliases in the Config string are correctly converted to the underlying base type. Since the enum class uses aliases all existing code in kineto that uses the original activity types continues to compile and work as expected.
The test above also checks default activity types are unchanged
https://github.com/pytorch/kineto/blob/main/libkineto/test/ConfigTest.cpp#L89-L108
