### PR TITLE
Fix Broken Process Description

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -508,7 +508,8 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
     }
     const auto& processGroupDesc =
         collectiveRecord->getMetadataValue(kProcessGroupDesc);
-    if (!processGroupName.empty() && !processGroupDesc.empty()) {
+    if (processGroupDesc.size() >= 2 && processGroupDesc.front() == '"' &&
+        processGroupDesc.back() == '"') {
       if (!arg_values.empty()) {
         arg_values.append(",");
       }


### PR DESCRIPTION
Summary: The process description can sometimes be white space or some invalid string that is causing JSON to fail. Add this patch to potentially fix that by checking it starts and ends with /"

Differential Revision: D90121337


