### PR TITLE
Add ADJUST_PROFILER_STEP to Kineto OD config

### DIFF
--- a/libkineto/include/ClientInterface.h
+++ b/libkineto/include/ClientInterface.h
@@ -15,7 +15,7 @@ class ClientInterface {
  public:
   virtual ~ClientInterface() = default;
   virtual void init() = 0;
-  virtual void prepare(bool, bool, bool, bool, bool) = 0;
+  virtual void prepare(bool, bool, bool, bool, bool, bool) = 0;
   virtual void start() = 0;
   virtual void stop() = 0;
   virtual void start_memory_profile() = 0;

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -205,6 +205,10 @@ class Config : public AbstractConfig {
     return enableWithModules_;
   }
 
+  [[nodiscard]] bool isAdjustProfilerStepEnabled() const {
+    return enableAdjustProfilerStep_;
+  }
+
   // Trace for this long
   [[nodiscard]] std::chrono::milliseconds activitiesDuration() const {
     return activitiesDuration_;
@@ -480,6 +484,7 @@ class Config : public AbstractConfig {
   bool enableWithStack_{false};
   bool enableWithFlops_{false};
   bool enableWithModules_{false};
+  bool enableAdjustProfilerStep_{false};
 
   // Profile for specified iterations and duration
   std::chrono::milliseconds activitiesDuration_;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -93,6 +93,7 @@ constexpr char kProfileProfileMemory[] = "PROFILE_PROFILE_MEMORY";
 constexpr char kProfileWithStack[] = "PROFILE_WITH_STACK";
 constexpr char kProfileWithFlops[] = "PROFILE_WITH_FLOPS";
 constexpr char kProfileWithModules[] = "PROFILE_WITH_MODULES";
+constexpr char kProfileAdjustProfilerStep[] = "ADJUST_PROFILER_STEP";
 
 constexpr char kActivitiesWarmupIterationsKey[] =
     "ACTIVITIES_WARMUP_ITERATIONS";
@@ -466,6 +467,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     enableWithFlops_ = toBool(val);
   } else if (!name.compare(kProfileWithModules)) {
     enableWithModules_ = toBool(val);
+  } else if (!name.compare(kProfileAdjustProfilerStep)) {
+    enableAdjustProfilerStep_ = toBool(val);
   }
 
   // Common

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -1166,7 +1166,8 @@ void CuptiActivityProfiler::configure(
         config_->isProfileMemoryEnabled(),
         config_->isWithStackEnabled(),
         config_->isWithFlopsEnabled(),
-        config_->isWithModulesEnabled());
+        config_->isWithModulesEnabled(),
+        config_->isAdjustProfilerStepEnabled());
   }
 
   if (derivedConfig_->isProfilingByIteration()) {


### PR DESCRIPTION
Summary: This option is available in auto-trace (under ExperimentalConfig -> adjust_profiler_step) but not in OD. This diff adds ADJUST_PROFILER_STEP to OD to bring the two closer to parity.

Differential Revision: D91430608


