### PR TITLE
update clang-tidy to reflect current usage

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,10 +40,14 @@ CheckOptions:
     value: camelBack
   - key: readability-identifier-naming.VariableCase
     value: camelBack
-  - key: readability-identifier-naming.ConstantCase
-    value: UPPER_CASE
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k
+  - key: readability-identifier-naming.StaticConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.StaticConstantPrefix
+    value: k
   - key: readability-identifier-naming.ParameterCase
     value: camelBack
-  - key: readability-identifier-naming.EnumConstantCase
-    value: UPPER_CASE
 ...


### PR DESCRIPTION
Summary: Updates `.clang-tidy` to reflect our actual constant usage. That is, global and static constants are in the form `kConstantValue`, not `CONSTANT_VALUE`. Also makes sure this does not apply to local constants.

Differential Revision: D91502998


