### PR TITLE
Introduce callback registry for callback management

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -13,6 +13,7 @@ def get_libkineto_cupti_srcs(with_api = True):
     return [
         "src/CuptiActivityApi.cpp",
         "src/CuptiCallbackApi.cpp",
+        "src/CuptiCallbackRegistry.cpp",
         "src/CuptiEventApi.cpp",
         "src/CuptiMetricApi.cpp",
         "src/CuptiRangeProfiler.cpp",

--- a/libkineto/src/CuptiCallbackRegistry.cpp
+++ b/libkineto/src/CuptiCallbackRegistry.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CuptiCallbackRegistry.h"
+
+namespace KINETO_NAMESPACE {
+
+CuptiCallbackRegistry& CuptiCallbackRegistry::instance() {
+  static CuptiCallbackRegistry instance;
+  return instance;
+}
+
+const std::unordered_map<uint32_t, CuptiCallbackRegistry::CallbackProps>*
+CuptiCallbackRegistry::getMapForDomain(CallbackDomain domain) const {
+  switch (domain) {
+    case CallbackDomain::RUNTIME:
+      return &runtimeCallbacks_;
+    case CallbackDomain::DRIVER:
+      return &driverCallbacks_;
+    default:
+      return nullptr;
+  }
+}
+
+void CuptiCallbackRegistry::registerCallback(
+    CallbackDomain domain,
+    uint32_t cbid,
+    bool requiresFlowCorrelation,
+    bool isBlocklisted) {
+  CallbackProps props{requiresFlowCorrelation, isBlocklisted};
+  switch (domain) {
+    case CallbackDomain::RUNTIME:
+      runtimeCallbacks_[cbid] = props;
+      break;
+    case CallbackDomain::DRIVER:
+      driverCallbacks_[cbid] = props;
+      break;
+    default:
+      break;
+  }
+}
+
+void CuptiCallbackRegistry::registerCallbackRange(
+    CallbackDomain domain,
+    uint32_t startCbid,
+    uint32_t endCbid,
+    bool requiresFlowCorrelation) {
+  callbackRanges_.push_back(
+      {domain, CallbackRange{startCbid, endCbid, requiresFlowCorrelation}});
+}
+
+CuptiCallbackRegistry::CuptiCallbackRegistry() {
+  // =========================================================================
+  // RUNTIME API - Kernel Launches
+  // =========================================================================
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/
+      CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernelMultiDevice_v9000,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+#if defined(CUPTI_API_VERSION) && CUPTI_API_VERSION >= 18
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+#endif
+
+  // =========================================================================
+  // RUNTIME API - CUDA Graph Operations
+  // =========================================================================
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  // =========================================================================
+  // RUNTIME API - Synchronization Operations
+  // =========================================================================
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaStreamSynchronize_v3020,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaDeviceSynchronize_v3020,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaStreamWaitEvent_v3020,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+  // =========================================================================
+  // RUNTIME API - Memory Operations (range-based)
+  // =========================================================================
+  registerCallbackRange(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*startCbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaMemcpy_v3020,
+      /*endCbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaMemset2DAsync_v3020,
+      /*requiresFlowCorrelation=*/true);
+
+  // =========================================================================
+  // RUNTIME API - Blocklisted (noisy) Callbacks
+  // =========================================================================
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaGetDevice_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaSetDevice_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaGetLastError_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaEventCreate_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaEventCreateWithFlags_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  registerCallback(
+      /*domain=*/CallbackDomain::RUNTIME,
+      /*cbid=*/CUPTI_RUNTIME_TRACE_CBID_cudaEventDestroy_v3020,
+      /*requiresFlowCorrelation=*/false,
+      /*isBlocklisted=*/true);
+
+  // =========================================================================
+  // DRIVER API - Kernel Launches
+  // =========================================================================
+  registerCallback(
+      /*domain=*/CallbackDomain::DRIVER,
+      /*cbid=*/CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11060
+  registerCallback(
+      /*domain=*/CallbackDomain::DRIVER,
+      /*cbid=*/CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx,
+      /*requiresFlowCorrelation=*/true,
+      /*isBlocklisted=*/false);
+#endif
+}
+
+bool CuptiCallbackRegistry::requiresFlowCorrelation(
+    CallbackDomain domain,
+    uint32_t cbid) const {
+  // Check explicit callbacks first
+  const auto* map = getMapForDomain(domain);
+  if (map != nullptr) {
+    auto it = map->find(cbid);
+    if (it != map->end()) {
+      return it->second.requiresFlowCorrelation;
+    }
+  }
+  // Check ranges (for memory operations)
+  for (const auto& [rangeDomain, range] : callbackRanges_) {
+    if (rangeDomain == domain && cbid >= range.startCbid &&
+        cbid <= range.endCbid) {
+      return range.requiresFlowCorrelation;
+    }
+  }
+  return false;
+}
+
+bool CuptiCallbackRegistry::isBlocklisted(CallbackDomain domain, uint32_t cbid)
+    const {
+  const auto* map = getMapForDomain(domain);
+  if (map != nullptr) {
+    auto it = map->find(cbid);
+    if (it != map->end()) {
+      return it->second.isBlocklisted;
+    }
+  }
+  return false;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiCallbackRegistry.h
+++ b/libkineto/src/CuptiCallbackRegistry.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include <cupti.h>
+
+namespace KINETO_NAMESPACE {
+
+// Domain of the CUPTI callback
+enum class CallbackDomain : uint8_t {
+  RUNTIME, // CUDA Runtime API (cudaXxx functions)
+  DRIVER, // CUDA Driver API (cuXxx functions)
+};
+
+// CuptiCallbackRegistry: Central registry for CUPTI callback metadata
+//
+// This class provides a single source of truth for all CUPTI callback
+// properties, replacing scattered hardcoded checks throughout the codebase.
+//
+// The registry is initialized lazily on first access via instance().
+// All callbacks are registered in the constructor with their properties.
+//
+// Usage:
+//   auto& registry = CuptiCallbackRegistry::instance();
+//   if (registry.requiresFlowCorrelation(CallbackDomain::RUNTIME, cbid)) {
+//     // Create flow correlation
+//   }
+//
+class CuptiCallbackRegistry {
+ public:
+  // Get the singleton instance (lazy initialization on first call)
+  static CuptiCallbackRegistry& instance();
+
+  // Disable copy/move
+  CuptiCallbackRegistry(const CuptiCallbackRegistry&) = delete;
+  CuptiCallbackRegistry& operator=(const CuptiCallbackRegistry&) = delete;
+  CuptiCallbackRegistry(CuptiCallbackRegistry&&) = delete;
+  CuptiCallbackRegistry& operator=(CuptiCallbackRegistry&&) = delete;
+
+  // Check if a callback requires flow correlation (CPU->GPU arrows in trace)
+  bool requiresFlowCorrelation(CallbackDomain domain, uint32_t cbid) const;
+
+  // Check if a callback is blocklisted (should be filtered from traces)
+  bool isBlocklisted(CallbackDomain domain, uint32_t cbid) const;
+
+ private:
+  CuptiCallbackRegistry();
+  ~CuptiCallbackRegistry() = default;
+
+  // Properties stored per callback
+  struct CallbackProps {
+    bool requiresFlowCorrelation;
+    bool isBlocklisted;
+  };
+
+  // Range of callbacks (for memory operations)
+  struct CallbackRange {
+    uint32_t startCbid;
+    uint32_t endCbid; // inclusive
+    bool requiresFlowCorrelation;
+  };
+
+  // Register a callback
+  void registerCallback(
+      CallbackDomain domain,
+      uint32_t cbid,
+      bool requiresFlowCorrelation,
+      bool isBlocklisted);
+
+  // Register a range of callbacks
+  void registerCallbackRange(
+      CallbackDomain domain,
+      uint32_t startCbid,
+      uint32_t endCbid,
+      bool requiresFlowCorrelation);
+
+  // Storage per domain
+  std::unordered_map<uint32_t, CallbackProps> runtimeCallbacks_;
+  std::unordered_map<uint32_t, CallbackProps> driverCallbacks_;
+
+  // Ranges for callbacks that use range-based matching
+  std::vector<std::pair<CallbackDomain, CallbackRange>> callbackRanges_;
+
+  // Helper to get the appropriate map
+  const std::unordered_map<uint32_t, CallbackProps>* getMapForDomain(
+      CallbackDomain domain) const;
+};
+
+} // namespace KINETO_NAMESPACE


### PR DESCRIPTION
### Summary
**Central source of truth** — Consolidates scattered CUPTI callback metadata (flow correlation, blocklist status) into a single registry. This will replace hardcoded checks throughout the codebase.

**Minimal API** — Exposes only 2 methods: requiresFlowCorrelation(domain, cbid) for CPU→GPU trace arrows and isBlocklisted(domain, cbid) for filtering noisy callbacks. Although we can add more, the overall idea should be to keep it minimal.

**O(1) lookups** — Uses separate std::unordered_map per domain (RUNTIME/DRIVER) with range support for memory operations, initialized lazily as a singleton.

**Usage** — TBD but this would be initialized before the profiling stage when deciding which callbacks to hook on to; and then used later when activity buffers are collected and are to be processed. 

This PR in itself brings no material change to kineto. Future PR will refactor files to make use of this registry.

Note: this is different from `CuptiCallbackApi`'s `registerCallback` which register generic function pointers to be called when CUPTI fires. With `CuptiCallbackRegistry`, we want to store metadata/properties about CUPTI callbacks to help with post-processing (filtering, flow correlation checks, etc).  