### PR TITLE
update clang-tidy to reflect current code base

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,8 +13,10 @@ Checks: >
   -google-readability-todo,
   -google-runtime-references,
   misc-*,
+  -misc-const-correctness
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
+  -misc-include-cleaner
   modernize-*,
   -modernize-use-trailing-return-type,
   -modernize-avoid-c-arrays,
@@ -37,9 +39,9 @@ CheckOptions:
   - key: readability-identifier-naming.StructCase
     value: CamelCase
   - key: readability-identifier-naming.FunctionCase
-    value: camelBack
+    value: aNy_CasE
   - key: readability-identifier-naming.VariableCase
-    value: camelBack
+    value: aNy_CasE
   - key: readability-identifier-naming.GlobalConstantCase
     value: CamelCase
   - key: readability-identifier-naming.GlobalConstantPrefix
@@ -49,5 +51,5 @@ CheckOptions:
   - key: readability-identifier-naming.StaticConstantPrefix
     value: k
   - key: readability-identifier-naming.ParameterCase
-    value: camelBack
+    value: aNy_CasE
 ...


### PR DESCRIPTION
Summary:
We're still getting a lot of lint noise. I think these changes will fix most of it.

I do think it would be good if we could choose either `camelCase` or `snake_case` for these values that I've changed. But in the current code base, since they're mixed, folks are getting lots of lint warnings to just using existing variables.

Choosing either `camelCase` or `snake_case` for these should be paired with a diff that updates the code base accordingly.

Differential Revision: D91920269


