### PR TITLE
Add ACTIVITIES_DISABLE_EXTERNAL_CORRELATION to Kineto OD config

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -236,6 +236,10 @@ class Config : public AbstractConfig {
     activitiesCudaSyncWaitEvents_ = enable;
   }
 
+  [[nodiscard]] bool activitiesDisableExternalCorrelation() const {
+    return activitiesDisableExternalCorrelation_;
+  }
+
   // Timestamp at which the profiling to start, requested by the user.
   [[nodiscard]] std::chrono::time_point<std::chrono::system_clock>
   requestTimestamp() const {
@@ -471,6 +475,7 @@ class Config : public AbstractConfig {
   std::chrono::seconds activitiesWarmupDuration_;
   int activitiesWarmupIterations_;
   bool activitiesCudaSyncWaitEvents_;
+  bool activitiesDisableExternalCorrelation_;
 
   // Enable Profiler Config Options
   // Temporarily disable shape collection until we re-roll out the feature for

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -80,6 +80,8 @@ constexpr char kActivitiesMaxGpuBufferSizeKey[] =
     "ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB";
 constexpr char kActivitiesDisplayCudaSyncWaitEvents[] =
     "ACTIVITIES_DISPLAY_CUDA_SYNC_WAIT_EVENTS";
+constexpr char kActivitiesDisableExternalCorrelation[] =
+    "ACTIVITIES_DISABLE_EXTERNAL_CORRELATION";
 
 // Client Interface
 // TODO: keep supporting these older config options, deprecate in the future
@@ -245,6 +247,7 @@ Config::Config()
       activitiesWarmupDuration_(kDefaultActivitiesWarmupDurationSecs),
       activitiesWarmupIterations_(0),
       activitiesCudaSyncWaitEvents_(true),
+      activitiesDisableExternalCorrelation_(false),
       activitiesDuration_(kDefaultActivitiesProfileDurationMSecs),
       activitiesRunIterations_(0),
       activitiesOnDemandTimestamp_(milliseconds(0)),
@@ -440,6 +443,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     activitiesWarmupIterations_ = toInt32(val);
   } else if (!name.compare(kActivitiesDisplayCudaSyncWaitEvents)) {
     activitiesCudaSyncWaitEvents_ = toBool(val);
+  } else if (!name.compare(kActivitiesDisableExternalCorrelation)) {
+    activitiesDisableExternalCorrelation_ = toBool(val);
   } else if (!name.compare(kRequestTraceID)) {
     requestTraceID_ = val;
   } else if (!name.compare(kRequestGroupTraceID)) {
@@ -576,6 +581,10 @@ void Config::validate(
     selectDefaultActivityTypes();
   }
   setActivityDependentConfig();
+
+  if (activitiesDisableExternalCorrelation()) {
+    selectedActivityTypes_.erase(ActivityType::EXTERNAL_CORRELATION);
+  }
 }
 
 void Config::setReportPeriod(milliseconds msecs) {


### PR DESCRIPTION
Summary:
This option is currently supported in Auto-trace under experimental_config -> disable_external_correlation. In this diff, we add support for this in the OD flow by popping EXTERNAL_CORRELATION from the activity types list if it's set to True.

In the auto-trace flow, if disable_external_correlation is True, there is logic to stop pushing/popping correlation ids on [function enter/exit](https://www.internalfb.com/code/fbsource/[062f9c6489e6]/fbcode/caffe2/torch/csrc/profiler/collection.cpp?lines=346). However we don't currently explicitly remove this activity type. To align with OD logic introduced in the diff, in kineto_shim.cpp I also start popping EXTERNAL_CORRELATION from the activity type list. This should(?) be a no-op, because if EXTERNAL_CORRELATION is not in the activity list, then `externalCorrelationEnable_=False` in (x)ActivityApi and we will also not [push/pop correlation IDs](https://www.internalfb.com/code/fbsource/[51042021f958]/fbcode/kineto/libkineto/src/CuptiActivityApi.cpp?lines=69). The logic is the same, just in a different layer.

Differential Revision: D91512438


