### PR TITLE
Add ACTIVITIES_ENABLE_CUDA_SYNC to Kineto OD config

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -236,6 +236,10 @@ class Config : public AbstractConfig {
     activitiesCudaSyncWaitEvents_ = enable;
   }
 
+  [[nodiscard]] bool activitiesEnableCudaSyncEvents() const {
+    return activitiesEnableCudaSyncEvents_;
+  }
+
   // Timestamp at which the profiling to start, requested by the user.
   [[nodiscard]] std::chrono::time_point<std::chrono::system_clock>
   requestTimestamp() const {
@@ -471,6 +475,7 @@ class Config : public AbstractConfig {
   std::chrono::seconds activitiesWarmupDuration_;
   int activitiesWarmupIterations_;
   bool activitiesCudaSyncWaitEvents_;
+  bool activitiesEnableCudaSyncEvents_;
 
   // Enable Profiler Config Options
   // Temporarily disable shape collection until we re-roll out the feature for

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -80,6 +80,9 @@ constexpr char kActivitiesMaxGpuBufferSizeKey[] =
     "ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB";
 constexpr char kActivitiesDisplayCudaSyncWaitEvents[] =
     "ACTIVITIES_DISPLAY_CUDA_SYNC_WAIT_EVENTS";
+// Enable all events of type CUpti_ActivitySynchronizationType.
+constexpr char kActivitiesEnableCudaSyncEvents[] =
+    "ACTIVITIES_ENABLE_CUDA_SYNC_EVENTS";
 
 // Client Interface
 // TODO: keep supporting these older config options, deprecate in the future
@@ -245,6 +248,7 @@ Config::Config()
       activitiesWarmupDuration_(kDefaultActivitiesWarmupDurationSecs),
       activitiesWarmupIterations_(0),
       activitiesCudaSyncWaitEvents_(true),
+      activitiesEnableCudaSyncEvents_(true),
       activitiesDuration_(kDefaultActivitiesProfileDurationMSecs),
       activitiesRunIterations_(0),
       activitiesOnDemandTimestamp_(milliseconds(0)),
@@ -440,6 +444,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     activitiesWarmupIterations_ = toInt32(val);
   } else if (!name.compare(kActivitiesDisplayCudaSyncWaitEvents)) {
     activitiesCudaSyncWaitEvents_ = toBool(val);
+  } else if (!name.compare(kActivitiesEnableCudaSyncEvents)) {
+    activitiesEnableCudaSyncEvents_ = toBool(val);
   } else if (!name.compare(kRequestTraceID)) {
     requestTraceID_ = val;
   } else if (!name.compare(kRequestGroupTraceID)) {
@@ -576,6 +582,10 @@ void Config::validate(
     selectDefaultActivityTypes();
   }
   setActivityDependentConfig();
+
+  if (!activitiesEnableCudaSyncEvents()) {
+    selectedActivityTypes_.erase(ActivityType::CUDA_SYNC);
+  }
 }
 
 void Config::setReportPeriod(milliseconds msecs) {


### PR DESCRIPTION
Summary:
We currently don't have a way to disable cuda_sync events in OD.

In auto-trace, cuda_sync events are disabled by default, while they are enabled by default in OD. There is an existing ACTIVITIES_DISPLAY_CUDA_SYNC_WAIT_EVENTS option in OD, but setting this to false only disables CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT.

To avoid changing default behavior in OD, the flag defaults to True.

Differential Revision: D92274056


