### PR TITLE
[BUG] Clear GPU activities during warmup for iteration-based profiling

### DIFF
--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -833,14 +833,12 @@ time_point<system_clock> GenericActivityProfiler::performRunLoopStep(
     case RunloopState::Warmup:
       VLOG(1) << "State: Warmup";
       warmup_done = derivedConfig_->isWarmupDone(now, currentIter);
-      if (!cpuOnly_ && derivedConfig_->isProfilingByIteration() &&
-          currentIter >= 0) {
-        clearGpuActivities();
-      }
-      // Flushing can take a while so avoid doing it close to the start time
-      if (!cpuOnly_ && currentIter < 0 &&
+      // Flushing can take a while so avoid doing it close to the start time.
+      // For iteration-based profiling, always clear to avoid accumulating
+      // warmup data. For time-based profiling, only clear well before start.
+      if (!cpuOnly_ &&
           (derivedConfig_->isProfilingByIteration() ||
-           nextWakeupTime < derivedConfig_->profileStartTime())) {
+           (currentIter < 0 && nextWakeupTime < derivedConfig_->profileStartTime()))) {
         clearGpuActivities();
       }
 


### PR DESCRIPTION
## Problem
In `RunloopState::Warmup`, Kineto only cleared GPU activities for timestamp-driven flow (`currentIter < 0`), but not for iteration-driven flow (`currentIter >= 0`).

For long iteration-based warmup phases, warmup GPU events can accumulate in backend buffers.  
This can lead to dropping events from the active window (identified on ROCm/roctracer, where traces ended up CPU-only).

## Root Cause
`GenericActivityProfiler::performRunLoopStep()` did not clear warmup GPU activities in iteration-based mode.

## Fix
In the warmup branch, clear GPU activities when:
- profiling is iteration-based, and
- `currentIter >= 0`

to avoid warmup-only GPU events consuming buffer capacity before active collection starts.