### PR TITLE
Fix 'enviroment' -> 'environment' in comments, docs, and display strings

### DIFF
--- a/libkineto/src/plugin/xpupti/FindSYCLToolkit.cmake
+++ b/libkineto/src/plugin/xpupti/FindSYCLToolkit.cmake
@@ -44,7 +44,7 @@ if(NOT SYCL_ROOT)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   if(NOT EXISTS "${SYCL_CMPLR_FULL_PATH}")
-    message(WARNING "Cannot find ENV{CMPLR_ROOT} or icpx, please setup SYCL compiler Tool kit enviroment before building!!")
+    message(WARNING "Cannot find ENV{CMPLR_ROOT} or icpx, please setup SYCL compiler Tool kit environment before building!!")
     return()
   endif()
 


### PR DESCRIPTION
Summary:
Fix misspelling of "environment" in comments, documentation, JSDoc comments, help text, echo strings, log messages, and description strings across fbcode/ and xplat/. All changes are limited to non-functional text — no identifiers or API-facing strings are affected.

Skipped: generated code (generated), third-party code (TVM, WebRTC, Boost, VS Code extensions), GraphQL schema identifiers, exported type/context names (CosplayEnviromentContext), public method names, Manifold paths, URL paths, icon glyph names, and spelling dictionary entries.

Differential Revision: D92873933


