### PR TITLE
ensure architecture isolation through build system

### DIFF
--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -15,25 +15,17 @@
 #include <mutex>
 #include <set>
 
-#ifdef HAS_CUPTI
 #include <cupti.h>
-#endif
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "ActivityType.h"
 #include "CuptiActivityBuffer.h"
-#ifdef HAS_CUPTI
 #include "CuptiCallbackApi.h"
-#endif
 
 namespace KINETO_NAMESPACE {
 
 using namespace libkineto;
-
-#ifndef HAS_CUPTI
-using CUpti_Activity = void;
-#endif
 
 class CuptiActivityApi {
  public:
@@ -90,7 +82,6 @@ class CuptiActivityApi {
   std::atomic<uint32_t> tearingDown_{0};
   bool externalCorrelationEnabled_{false};
 
-#ifdef HAS_CUPTI
   int processActivitiesForBuffer(
       uint8_t* buf,
       size_t validSize,
@@ -105,10 +96,8 @@ class CuptiActivityApi {
       uint8_t* buffer,
       size_t /* unused */,
       size_t validSize);
-#endif // HAS_CUPTI
 
  protected:
-#ifdef HAS_CUPTI
   void bufferRequested(uint8_t** buffer, size_t* size, size_t* maxNumRecords);
   void bufferCompleted(
       CUcontext ctx,
@@ -116,7 +105,6 @@ class CuptiActivityApi {
       uint8_t* buffer,
       size_t /* unused */,
       size_t validSize);
-#endif
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifdef HAS_CUPTI
-
 #include "CuptiActivityProfiler.h"
 #include <cupti.h>
 #include <fmt/format.h>
@@ -526,5 +524,3 @@ void CuptiActivityProfiler::handleCuptiActivity(
 }
 
 } // namespace KINETO_NAMESPACE
-
-#endif // HAS_CUPTI

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-// TODO DEVICE_AGNOSTIC: The build system should be strict enough that we don't
-//                       need this guard in the header file.
-#ifdef HAS_CUPTI
-
 #include <cupti.h>
 #include "CuptiActivity.h"
 #include "CuptiActivityApi.h"
@@ -75,5 +71,3 @@ class CuptiActivityProfiler : public GenericActivityProfiler {
 uint32_t contextIdtoDeviceId(uint32_t contextId);
 
 } // namespace KINETO_NAMESPACE
-
-#endif // HAS_CUPTI

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -8,11 +8,9 @@
 
 #pragma once
 
-#include <atomic>
-#ifdef HAS_CUPTI
 #include <cupti.h>
-#endif
 #include <array>
+#include <atomic>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -74,7 +72,6 @@ class CuptiCallbackApi {
     return initSuccess_;
   }
 
-#ifdef HAS_CUPTI
   CUptiResult getCuptiStatus() const {
     return lastCuptiStatus_;
   }
@@ -82,7 +79,6 @@ class CuptiCallbackApi {
   CUpti_SubscriberHandle getCuptiSubscriber() const {
     return subscriber_;
   }
-#endif
 
   bool registerCallback(
       CUpti_CallbackDomain domain,
@@ -144,10 +140,8 @@ class CuptiCallbackApi {
   using ReaderLockGuard = std::shared_lock<ReaderWriterLock>;
   using WriteLockGuard = std::unique_lock<ReaderWriterLock>;
   ReaderWriterLock callbackLock_;
-#ifdef HAS_CUPTI
   CUptiResult lastCuptiStatus_;
   CUpti_SubscriberHandle subscriber_{nullptr};
-#endif
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiNvPerfMetric.cpp
+++ b/libkineto/src/CuptiNvPerfMetric.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifdef HAS_CUPTI
 #include <cuda_runtime_api.h>
 #if defined(USE_CUPTI_RANGE_PROFILER) && defined(CUDART_VERSION) && \
     CUDART_VERSION > 10000 && CUDART_VERSION < 12060
@@ -14,7 +13,6 @@
 #include <nvperf_host.h>
 #include <nvperf_target.h>
 #endif // cuda version > 10.00 and < 11.04
-#endif // HAS_CUPTI
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude

--- a/libkineto/src/CuptiRangeProfiler.cpp
+++ b/libkineto/src/CuptiRangeProfiler.cpp
@@ -310,9 +310,7 @@ CuptiRangeProfilerInit::CuptiRangeProfilerInit() {
   // register config
   CuptiRangeProfilerConfig::registerFactory();
 
-#ifdef HAS_CUPTI
   success = CuptiRBProfilerSession::staticInit();
-#endif
 
   if (!success) {
     return;

--- a/libkineto/src/CuptiRangeProfilerApi.cpp
+++ b/libkineto/src/CuptiRangeProfilerApi.cpp
@@ -6,15 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <cstdio>
-#include <cstdlib>
-#include "ILoggerObserver.h"
-#ifdef HAS_CUPTI
 #include <cupti.h>
 #include <nvperf_host.h>
-#endif // HAS_CUPTI
+#include <cstdio>
+#include <cstdlib>
 #include <mutex>
 #include <unordered_map>
+#include "ILoggerObserver.h"
 
 #include "Demangle.h"
 #include "DeviceUtil.h"

--- a/libkineto/src/CuptiRangeProfilerApi.h
+++ b/libkineto/src/CuptiRangeProfilerApi.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#ifdef HAS_CUPTI
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 // Using CUDA 11 and above due to usage of API:
@@ -21,7 +20,6 @@
 #define HAS_CUPTI_RANGE_PROFILER 1
 #endif // CUDART_VERSION > 10.00 and CUDA_VERSION >= 11.00 and CUDA_VERSION
        // <= 12.06
-#endif // HAS_CUPTI
 
 #if HAS_CUPTI_RANGE_PROFILER
 #include <cupti.h>


### PR DESCRIPTION
We make two related refactors:

1. Small changes to the build system so that CUPTI files are only compiled when CUPTI is available. That is, we do not compile any CUPTI files for CPU-only or ROCm builds.
2. In those CUPTI files, we remove all of the `#ifdef HAS_CUPTI` guards. Those are redundant now that we ensure inclusion through the build system.

Note that we still have these guards in `ActivityProfilerController.cpp` because it has the architecture-specific `profiler_` variable. It still needs access to the architecture specific headers.

Differential Revision: D93528473


