### PR TITLE
Handle cuMem_ driver trace activities

### DIFF
--- a/libkineto/src/CuptiActivity.cpp
+++ b/libkineto/src/CuptiActivity.cpp
@@ -291,13 +291,9 @@ inline const std::string RuntimeActivity::metadataJson() const {
       activity_.correlationId);
 }
 
-// TODO: remove isKernelLaunchApi after updating CuptiActivityProfiler.cpp
-inline bool isKernelLaunchApi(const CUpti_ActivityAPI& activity_) {
-  return activity_.cbid == CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11060
-      || activity_.cbid == CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx
-#endif
-      ;
+inline bool isTrackedDriverCbid(const CUpti_ActivityAPI& activity_) {
+  return CuptiCbidRegistry::instance().isRegistered(
+      CallbackDomain::DRIVER, activity_.cbid);
 }
 
 inline bool DriverActivity::flowStart() const {
@@ -314,18 +310,8 @@ inline const std::string DriverActivity::metadataJson() const {
 }
 
 inline const std::string DriverActivity::name() const {
-  // currently only cuLaunchKernel/cuLaunchKernelEx is expected
-  assert(isKernelLaunchApi(activity_));
-  // not yet implementing full name matching
-  if (activity_.cbid == CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel) {
-    return "cuLaunchKernel";
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11060
-  } else if (activity_.cbid == CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx) {
-    return "cuLaunchKernelEx";
-#endif
-  } else {
-    return "Unknown"; // should not reach here
-  }
+  return CuptiCbidRegistry::instance().getName(
+      CallbackDomain::DRIVER, activity_.cbid);
 }
 
 template <class T>

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -271,7 +271,7 @@ void CuptiActivityProfiler::handleDriverActivity(
     const CUpti_ActivityAPI* activity,
     ActivityLogger* logger) {
   // we only want to collect cuLaunchKernel events, for triton kernel launches
-  if (!isKernelLaunchApi(*activity)) {
+  if (!isTrackedDriverCbid(*activity)) {
     // XXX should we count other driver events?
     return;
   }

--- a/libkineto/src/CuptiCbidRegistry.h
+++ b/libkineto/src/CuptiCbidRegistry.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -55,6 +56,14 @@ class CuptiCbidRegistry {
   // Check if a callback ID is blocklisted (should be filtered from traces)
   [[nodiscard]] bool isBlocklisted(CallbackDomain domain, uint32_t cbid);
 
+  // Check if a callback ID is registered
+  [[nodiscard]] bool isRegistered(CallbackDomain domain, uint32_t cbid);
+
+  // Get the name for a callback ID (returns "unknown" if not found)
+  [[nodiscard]] const std::string& getName(
+      CallbackDomain domain,
+      uint32_t cbid);
+
  private:
   CuptiCbidRegistry();
   ~CuptiCbidRegistry() = default;
@@ -63,6 +72,7 @@ class CuptiCbidRegistry {
   struct CbidProperties {
     bool requiresFlowCorrelation;
     bool isBlocklisted;
+    std::string name;
   };
 
   // Range of callback IDs (for memory operations)
@@ -79,6 +89,14 @@ class CuptiCbidRegistry {
       uint32_t cbid,
       bool requiresFlowCorrelation,
       bool isBlocklisted);
+
+  // Register a callback ID with a name
+  void registerCallback(
+      CallbackDomain domain,
+      uint32_t cbid,
+      bool requiresFlowCorrelation,
+      bool isBlocklisted,
+      const std::string& name);
 
   // Register a range of callback IDs
   void registerCallbackRange(


### PR DESCRIPTION
Summary:
Adds support in Kineto for the following driver trace activities: cuMemCreate, cuMemMap, cuMemUnmap, cuMemRelease, cuMemExportToShareableHandle/ImportFromShareableHandle

Using D56638653 as a reference

Also adds `isRegistered` and `getName` as perhaps a way to more easily manage these driver cbids. So if we want to add a new activity then we can just add a new entry to the registry.

Differential Revision: D93610352


