### PR TITLE
Enable CUPTI teardown by default for CUDA 12.6+

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -29,7 +29,15 @@ constexpr size_t kBufSize(4 * 1024 * 1024);
 #ifdef HAS_CUPTI
 inline bool cuptiTearDown_() {
   auto teardown_env = getenv("TEARDOWN_CUPTI");
-  return teardown_env != nullptr && strcmp(teardown_env, "1") == 0;
+  if (teardown_env != nullptr) {
+    return strcmp(teardown_env, "1") == 0;
+  }
+  // Default: enable teardown for CUDA 12.6+, disable for older versions
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 12060
+  return true;
+#else
+  return false;
+#endif
 }
 
 inline bool cuptiLazyInit_() {


### PR DESCRIPTION
Summary: Previously, CUPTI teardown (calling cuptiFinalize() after profiling) was only enabled when the TEARDOWN_CUPTI=1 env var was explicitly set. This meant users on CUDA 12.6+ still experienced post-profiling QPS degradation unless they knew to set the env var. This change makes teardown the default for CUDA 12.6+, where it is known to work reliably, while keeping it off by default for older versions. The TEARDOWN_CUPTI env var continues to override the default in either direction for all CUDA versions.

Differential Revision: D93661386


