### PR TITLE
update clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,10 +13,10 @@ Checks: >
   -google-readability-todo,
   -google-runtime-references,
   misc-*,
-  -misc-const-correctness
+  -misc-const-correctness,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
-  -misc-include-cleaner
+  -misc-include-cleaner,
   modernize-*,
   -modernize-use-trailing-return-type,
   -modernize-avoid-c-arrays,


### PR DESCRIPTION
Summary: I tried to improve things with D91920269, but we're still seeing some of these warnings. Maybe the lack of commas are the problem?

Reviewed By: ryanzhang22

Differential Revision: D93742159


