### PR TITLE
Clear GPU activities during warmup for iteration-based profiling (#1255)

### DIFF
--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -833,11 +833,27 @@ time_point<system_clock> GenericActivityProfiler::performRunLoopStep(
     case RunloopState::Warmup:
       VLOG(1) << "State: Warmup";
       warmup_done = derivedConfig_->isWarmupDone(now, currentIter);
-      // Flushing can take a while so avoid doing it close to the start time
-      if (!cpuOnly_ && currentIter < 0 &&
-          (derivedConfig_->isProfilingByIteration() ||
-           nextWakeupTime < derivedConfig_->profileStartTime())) {
-        clearGpuActivities();
+      {
+        // Flushing GPU activities can take a while so avoid doing it close to
+        // the start time. Clear during warmup in the following cases:
+        // 1. Iteration-based flow: called from application step() API
+        //    (currentIter >= 0) with iteration profiling enabled
+        // 2. Timestamp-based flow: called from periodic runloop
+        //    (currentIter < 0) when not close to profile start time
+        // 3. Iteration config with periodic runloop: always safe to clear
+        const bool isIterationBasedFlow =
+            derivedConfig_->isProfilingByIteration() && currentIter >= 0;
+        const bool isTimestampBasedFlowSafeToFlush =
+            !derivedConfig_->isProfilingByIteration() && currentIter < 0 &&
+            nextWakeupTime < derivedConfig_->profileStartTime();
+        const bool isIterationConfigWithPeriodicRunloop =
+            derivedConfig_->isProfilingByIteration() && currentIter < 0;
+
+        if (!cpuOnly_ &&
+            (isIterationBasedFlow || isTimestampBasedFlowSafeToFlush ||
+             isIterationConfigWithPeriodicRunloop)) {
+          clearGpuActivities();
+        }
       }
 
       if (isGpuCollectionStopped()) {


### PR DESCRIPTION
Summary:
## Problem
In `RunloopState::Warmup`, Kineto only cleared GPU activities for timestamp-driven flow (`currentIter < 0`), but not for iteration-driven flow (`currentIter >= 0`).

For long iteration-based warmup phases, warmup GPU events can accumulate in backend buffers.  
This can lead to dropping events from the active window (identified on ROCm/roctracer, where traces ended up CPU-only).

## Root Cause
`GenericActivityProfiler::performRunLoopStep()` did not clear warmup GPU activities in iteration-based mode.

## Fix
In the warmup branch, clear GPU activities when:
- profiling is iteration-based, and
- `currentIter >= 0`

to avoid warmup-only GPU events consuming buffer capacity before active collection starts.


Reviewed By: sraikund16

Differential Revision: D92984177

Pulled By: divyanshk


