### PR TITLE
Split ActivityProfilerController into Sync and Async Handlers (#1269)

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -69,6 +69,8 @@ def get_libkineto_cpu_only_srcs(with_api = True):
         "src/GenericActivityProfiler.cpp",
         "src/ActivityProfilerController.cpp",
         "src/ActivityProfilerProxy.cpp",
+        "src/AsyncActivityProfilerHandler.cpp",
+        "src/SyncActivityProfilerHandler.cpp",
         "src/ActivityType.cpp",
         "src/Config.cpp",
         "src/ConfigLoader.cpp",

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -8,14 +8,10 @@
 
 #include "ActivityProfilerController.h"
 
-#include <chrono>
 #include <functional>
-#include <thread>
 #include <utility>
 
 #include "ActivityLoggerFactory.h"
-#include "ActivityTrace.h"
-
 // TODO DEVICE_AGNOSTIC: Move the device decision out of C++ files to be
 //                       determined entirely by the build process. For the
 //                       controller, we'll need some registration mechanism.
@@ -34,7 +30,6 @@
 
 #endif
 
-#include "ThreadUtil.h"
 #include "output_json.h"
 #include "output_membuf.h"
 
@@ -94,21 +89,16 @@ ActivityProfilerController::ActivityProfilerController(
   // directly by the GenericActivityProfiler.
   profiler_ = std::make_unique<GenericActivityProfiler>(cpuOnly);
 #endif
+
+  syncHandler_ = std::make_unique<SyncActivityProfilerHandler>(
+      *profiler_, syncTraceActive_);
+  asyncHandler_ = std::make_unique<AsyncActivityProfilerHandler>(
+      *profiler_, syncTraceActive_);
   configLoader_.addHandler(ConfigLoader::ConfigKind::ActivityProfiler, this);
 }
 
 ActivityProfilerController::~ActivityProfilerController() {
   configLoader_.removeHandler(ConfigLoader::ConfigKind::ActivityProfiler, this);
-  for (auto profilerThread : profilerThreads_) {
-    if (profilerThread) {
-      // signaling termination of the profiler loop
-      stopRunloop_ = true;
-      profilerThread->join();
-      delete profilerThread;
-      profilerThread = nullptr;
-    }
-  }
-
 #if !USE_GOOGLE_LOG
   for (auto& collector : loggerCollectors_) {
     Logger::removeLoggerObserver(collector.get());
@@ -124,7 +114,7 @@ static ActivityLoggerFactory initLoggerFactory() {
   return factory;
 }
 
-static ActivityLoggerFactory& loggerFactory() {
+ActivityLoggerFactory& ActivityProfilerController::loggerFactory() {
   static ActivityLoggerFactory factory = initLoggerFactory();
   return factory;
 }
@@ -135,7 +125,8 @@ void ActivityProfilerController::addLoggerFactory(
   loggerFactory().addProtocol(protocol, std::move(factory));
 }
 
-static std::unique_ptr<ActivityLogger> makeLogger(const Config& config) {
+std::unique_ptr<ActivityLogger> ActivityProfilerController::makeLogger(
+    const Config& config) {
   if (config.activitiesLogToMemory()) {
     return std::make_unique<MemoryTraceLogger>(config);
   }
@@ -154,267 +145,6 @@ void ActivityProfilerController::setInvariantViolationsLoggerFactory(
   invariantViolationsLoggerFactory() = factory();
 }
 
-bool ActivityProfilerController::canAcceptConfig() {
-  return !profiler_->isActive();
-}
-
-void ActivityProfilerController::acceptConfig(const Config& config) {
-  VLOG(1) << "acceptConfig";
-  if (config.activityProfilerEnabled()) {
-    scheduleTrace(config);
-  }
-}
-
-bool ActivityProfilerController::shouldActivateTimestampConfig(
-    const std::chrono::time_point<std::chrono::system_clock>& now) {
-  if (asyncRequestConfig_->hasProfileStartIteration()) {
-    return false;
-  }
-  if (asyncRequestConfig_->memoryProfilerEnabled()) {
-    return false;
-  }
-  // Note on now + Config::kControllerIntervalMsecs:
-  // Profiler interval does not align perfectly up to startTime - warmup.
-  // Waiting until the next tick won't allow sufficient time for the
-  // profiler to warm up. So check if we are very close to the warmup time
-  // and trigger warmup.
-  if (now + Config::kControllerIntervalMsecs >=
-      (asyncRequestConfig_->requestTimestamp() -
-       asyncRequestConfig_->activitiesWarmupDuration())) {
-    LOG(INFO)
-        << "Received on-demand activity trace request by "
-        << " profile timestamp = "
-        << asyncRequestConfig_->requestTimestamp().time_since_epoch().count();
-    return true;
-  }
-  return false;
-}
-
-bool ActivityProfilerController::shouldActivateIterationConfig(
-    int64_t currentIter) {
-  if (!asyncRequestConfig_->hasProfileStartIteration()) {
-    return false;
-  }
-  if (asyncRequestConfig_->memoryProfilerEnabled()) {
-    return false;
-  }
-  auto rootIter = asyncRequestConfig_->startIterationIncludingWarmup();
-  // Keep waiting, it is not time to start yet.
-  if (currentIter < rootIter) {
-    return false;
-  }
-
-  LOG(INFO) << "Received on-demand activity trace request by "
-               " profile start iteration = "
-            << asyncRequestConfig_->profileStartIteration()
-            << ", current iteration = " << currentIter;
-  // Re-calculate the start iter if requested iteration is in the past.
-  if (currentIter > rootIter) {
-    auto newProfileStart =
-        currentIter + asyncRequestConfig_->activitiesWarmupIterations();
-    // Use Start Iteration Round Up if it is present.
-    if (asyncRequestConfig_->profileStartIterationRoundUp() > 0) {
-      // round up to nearest multiple
-      auto divisor = asyncRequestConfig_->profileStartIterationRoundUp();
-      auto rem = newProfileStart % divisor;
-      newProfileStart += ((rem == 0) ? 0 : divisor - rem);
-      LOG(INFO) << "Rounding up profiler start iteration to : "
-                << newProfileStart;
-      asyncRequestConfig_->setProfileStartIteration(newProfileStart);
-      if (currentIter != asyncRequestConfig_->startIterationIncludingWarmup()) {
-        // Ex. Current 9, start 8, warmup 5, roundup 100. Resolves new start
-        // to 100, with warmup starting at 95. So don't start now.
-        return false;
-      }
-    } else {
-      LOG(INFO) << "Start iteration updated to : " << newProfileStart;
-      asyncRequestConfig_->setProfileStartIteration(newProfileStart);
-    }
-  }
-  return true;
-}
-
-void ActivityProfilerController::profilerLoop() {
-  setThreadName("Kineto Activity Profiler");
-  VLOG(0) << "Entering activity profiler loop";
-
-  auto now = system_clock::now();
-  auto next_wakeup_time = now + Config::kControllerIntervalMsecs;
-
-  while (!stopRunloop_) {
-    now = system_clock::now();
-
-    while (now < next_wakeup_time) {
-      /* sleep override */
-      std::this_thread::sleep_for(next_wakeup_time - now);
-      now = system_clock::now();
-    }
-
-    // Perform Double-checked locking to reduce overhead of taking lock.
-    if (asyncRequestConfig_ && !profiler_->isActive()) {
-      std::lock_guard<std::mutex> lock(asyncConfigLock_);
-      if (asyncRequestConfig_ && !profiler_->isActive() &&
-          shouldActivateTimestampConfig(now)) {
-        activateConfig(now);
-      }
-    }
-
-    while (next_wakeup_time < now) {
-      next_wakeup_time += Config::kControllerIntervalMsecs;
-    }
-
-    // Use syncTraceActive_ so we don't step into the loop while sync trace is
-    // running
-    if (profiler_->isActive() && !profiler_->isCollectingMemorySnapshot() &&
-        !syncTraceActive_) {
-      next_wakeup_time = profiler_->performRunLoopStep(now, next_wakeup_time);
-      VLOG(1) << "Profiler loop: "
-              << duration_cast<milliseconds>(system_clock::now() - now).count()
-              << "ms";
-    }
-  }
-
-  VLOG(0) << "Exited activity profiling loop";
-}
-
-void ActivityProfilerController::memoryProfilerLoop() {
-  while (!stopRunloop_) {
-    // Perform Double-checked locking to reduce overhead of taking lock.
-    if (asyncRequestConfig_ && !profiler_->isActive()) {
-      std::lock_guard<std::mutex> lock(asyncConfigLock_);
-      if (asyncRequestConfig_ && !profiler_->isActive() &&
-          asyncRequestConfig_->memoryProfilerEnabled()) {
-        logger_ = makeLogger(*asyncRequestConfig_);
-        auto path = asyncRequestConfig_->activitiesLogFile();
-        auto profile_time = asyncRequestConfig_->profileMemoryDuration();
-        auto config = asyncRequestConfig_->clone();
-        asyncRequestConfig_ = nullptr;
-        profiler_->performMemoryLoop(
-            path, profile_time, logger_.get(), *config);
-      }
-    }
-  }
-}
-
-void ActivityProfilerController::step() {
-  // Do not remove this copy to currentIter. Otherwise count is not
-  // guaranteed.
-  int64_t currentIter = ++iterationCount_;
-  VLOG(0) << "Step called , iteration  = " << currentIter;
-
-  // Perform Double-checked locking to reduce overhead of taking lock.
-  if (asyncRequestConfig_ && !profiler_->isActive()) {
-    std::lock_guard<std::mutex> lock(asyncConfigLock_);
-    auto now = system_clock::now();
-    if (asyncRequestConfig_ && !profiler_->isActive() &&
-        shouldActivateIterationConfig(currentIter)) {
-      activateConfig(now);
-    }
-  }
-  if (profiler_->isActive() && !profiler_->isCollectingMemorySnapshot()) {
-    auto now = system_clock::now();
-    auto next_wakeup_time = now + Config::kControllerIntervalMsecs;
-    profiler_->performRunLoopStep(now, next_wakeup_time, currentIter);
-  }
-}
-
-// This function should only be called when holding the configLock_.
-void ActivityProfilerController::activateConfig(
-    std::chrono::time_point<std::chrono::system_clock> now) {
-  logger_ = makeLogger(*asyncRequestConfig_);
-  profiler_->setLogger(logger_.get());
-  LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND();
-  profiler_->configure(*asyncRequestConfig_, now);
-  asyncRequestConfig_ = nullptr;
-}
-
-void ActivityProfilerController::scheduleTrace(const Config& config) {
-  VLOG(1) << "scheduleTrace";
-  if (profiler_->isActive()) {
-    LOG(WARNING) << "Ignored request - profiler busy";
-    return;
-  }
-
-  int64_t currentIter = iterationCount_;
-  std::unique_ptr<Config> configToSchedule;
-
-  if (config.hasProfileStartIteration() && currentIter < 0) {
-    // Special case: daemon config with activitiesDuration set
-    if (config.activitiesDuration().count() > 0) {
-      LOG(INFO) << "Config with duration-based profiling, "
-                << "ignoring iteration count requirement";
-      // Continue with modified config - clone and set profileStartIteration to
-      // -1
-      configToSchedule = config.clone();
-      configToSchedule->setProfileStartIteration(-1);
-    } else {
-      LOG(WARNING) << "Ignored profile iteration count based request as "
-                   << "application is not updating iteration count";
-      return;
-    }
-  } else {
-    configToSchedule = config.clone();
-  }
-
-  // Common scheduling logic
-  bool newConfigScheduled = false;
-  if (!asyncRequestConfig_) {
-    std::lock_guard<std::mutex> lock(asyncConfigLock_);
-    if (!asyncRequestConfig_) {
-      asyncRequestConfig_ = std::move(configToSchedule);
-      newConfigScheduled = true;
-    }
-  }
-  if (!newConfigScheduled) {
-    LOG(WARNING) << "Ignored request - another profile request is pending.";
-    return;
-  }
-
-  // start a profilerLoop() thread to handle request
-
-  if (config.memoryProfilerEnabled()) {
-    auto thread_type = ThreadType::MEMORY_SNAPSHOT;
-    if (!profilerThreads_[thread_type]) {
-      profilerThreads_[thread_type] = new std::thread(
-          &ActivityProfilerController::memoryProfilerLoop, this);
-    }
-  } else {
-    auto thread_type = ThreadType::KINETO;
-    if (!profilerThreads_[thread_type]) {
-      profilerThreads_[thread_type] =
-          new std::thread(&ActivityProfilerController::profilerLoop, this);
-    }
-  }
-}
-
-void ActivityProfilerController::prepareTrace(const Config& config) {
-  // Requests from ActivityProfilerApi have higher priority than
-  // requests from other sources (signal, daemon).
-  // Cancel any ongoing request and refuse new ones.
-  auto now = system_clock::now();
-  syncTraceActive_ = true;
-  if (profiler_->isActive()) {
-    LOG(WARNING) << "Cancelling current trace request in order to start "
-                 << "higher priority synchronous request";
-    if (libkineto::api().client()) {
-      libkineto::api().client()->stop();
-    }
-    profiler_->stopTrace(now);
-    profiler_->reset();
-  }
-
-  profiler_->configure(config, now);
-}
-
-void ActivityProfilerController::toggleCollectionDynamic(const bool enable) {
-  profiler_->toggleCollectionDynamic(enable);
-}
-
-void ActivityProfilerController::startTrace() {
-  UST_LOGGER_MARK_COMPLETED(kWarmUpStage);
-  USDT_EMIT_START_TRACE();
-  profiler_->startTrace(std::chrono::system_clock::now());
-}
 bool ActivityProfilerController::isActive() {
   return profiler_->isActive();
 }
@@ -449,29 +179,6 @@ void ActivityProfilerController::popUserCorrelationId() {
   profiler_->popUserCorrelationId();
 }
 
-std::unique_ptr<ActivityTraceInterface> ActivityProfilerController::
-    stopTrace() {
-  profiler_->stopTrace(std::chrono::system_clock::now());
-  USDT_EMIT_STOP_TRACE();
-  UST_LOGGER_MARK_COMPLETED(kCollectionStage);
-  auto logger = std::make_unique<MemoryTraceLogger>(profiler_->config());
-  profiler_->processTrace(*logger);
-  // Will follow up with another patch for logging URLs when ActivityTrace
-  // is moved.
-  UST_LOGGER_MARK_COMPLETED(kPostProcessingStage);
-
-  // Logger Metadata contains a map of LOGs collected in Kineto
-  //   logger_level -> List of log lines
-  // This will be added into the trace as metadata.
-  std::unordered_map<std::string, std::vector<std::string>> loggerMD =
-      profiler_->getLoggerMetadata();
-  logger->setLoggerMetadata(std::move(loggerMD));
-
-  profiler_->reset();
-  syncTraceActive_ = false;
-  return std::make_unique<ActivityTrace>(std::move(logger), loggerFactory());
-}
-
 void ActivityProfilerController::addMetadata(
     const std::string& key,
     const std::string& value) {
@@ -487,6 +194,35 @@ void ActivityProfilerController::logInvariantViolation(
     invariantViolationsLoggerFactory()->logInvariantViolation(
         profile_id, assertion, error, group_profile_id);
   }
+}
+
+// Async-only functions
+bool ActivityProfilerController::canAcceptConfig() {
+  return asyncHandler_->canAcceptConfig();
+}
+void ActivityProfilerController::acceptConfig(const Config& config) {
+  asyncHandler_->acceptConfig(config);
+}
+void ActivityProfilerController::scheduleTrace(const Config& config) {
+  asyncHandler_->scheduleTrace(config);
+}
+void ActivityProfilerController::step() {
+  asyncHandler_->step();
+}
+
+// Sync-only functions
+void ActivityProfilerController::prepareTrace(const Config& config) {
+  syncHandler_->prepareTrace(config);
+}
+void ActivityProfilerController::toggleCollectionDynamic(const bool enable) {
+  syncHandler_->toggleCollectionDynamic(enable);
+}
+void ActivityProfilerController::startTrace() {
+  syncHandler_->startTrace();
+}
+std::unique_ptr<ActivityTraceInterface> ActivityProfilerController::
+    stopTrace() {
+  return syncHandler_->stopTrace();
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -12,8 +12,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <mutex>
-#include <thread>
 #include <vector>
 
 // TODO(T90238193)
@@ -21,17 +19,14 @@
 #include "ActivityLoggerFactory.h"
 #include "ActivityProfilerInterface.h"
 #include "ActivityTraceInterface.h"
+#include "AsyncActivityProfilerHandler.h"
 #include "ConfigLoader.h"
 #include "GenericActivityProfiler.h"
 #include "InvariantViolations.h"
 #include "LoggerCollector.h"
+#include "SyncActivityProfilerHandler.h"
 
 namespace KINETO_NAMESPACE {
-enum ThreadType {
-  KINETO = 0,
-  MEMORY_SNAPSHOT,
-  THREAD_MAX_COUNT // Number of enum entries (used for array sizing)
-};
 
 class Config;
 
@@ -88,24 +83,18 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
 
   void popUserCorrelationId();
 
+  static std::unique_ptr<ActivityLogger> makeLogger(const Config& config);
+
+  static ActivityLoggerFactory& loggerFactory();
+
  private:
-  bool shouldActivateIterationConfig(int64_t currentIter);
-  bool shouldActivateTimestampConfig(const std::chrono::time_point<std::chrono::system_clock>& now);
-  void profilerLoop();
-  void memoryProfilerLoop();
-  void activateConfig(std::chrono::time_point<std::chrono::system_clock> now);
-
-  std::unique_ptr<Config> asyncRequestConfig_;
-  std::mutex asyncConfigLock_;
-
   std::unique_ptr<GenericActivityProfiler> profiler_;
-  std::unique_ptr<ActivityLogger> logger_;
   std::vector<std::shared_ptr<LoggerCollector>> loggerCollectors_;
-  std::thread* profilerThreads_[ThreadType::THREAD_MAX_COUNT] = {nullptr};
-  std::atomic_bool stopRunloop_{false};
   std::atomic_bool syncTraceActive_{false};
-  std::atomic<std::int64_t> iterationCount_{-1};
   ConfigLoader& configLoader_;
+
+  std::unique_ptr<SyncActivityProfilerHandler> syncHandler_;
+  std::unique_ptr<AsyncActivityProfilerHandler> asyncHandler_;
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/AsyncActivityProfilerHandler.cpp
+++ b/libkineto/src/AsyncActivityProfilerHandler.cpp
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "AsyncActivityProfilerHandler.h"
+
+#include <chrono>
+
+#include "ActivityProfilerController.h"
+#include "Config.h"
+#include "GenericActivityProfiler.h"
+#include "Logger.h"
+#include "ThreadUtil.h"
+#include "output_membuf.h"
+
+using namespace std::chrono;
+
+namespace KINETO_NAMESPACE {
+
+AsyncActivityProfilerHandler::AsyncActivityProfilerHandler(
+    GenericActivityProfiler& profiler,
+    std::atomic_bool& syncTraceActive)
+    : profiler_(profiler), syncTraceActive_(syncTraceActive) {}
+
+AsyncActivityProfilerHandler::~AsyncActivityProfilerHandler() {
+  for (auto& profilerThread : profilerThreads_) {
+    if (profilerThread != nullptr) {
+      // signaling termination of the profiler loop
+      stopRunloop_ = true;
+      profilerThread->join();
+      profilerThread.reset();
+    }
+  }
+}
+
+bool AsyncActivityProfilerHandler::canAcceptConfig() {
+  return !profiler_.isActive();
+}
+
+void AsyncActivityProfilerHandler::acceptConfig(const Config& config) {
+  VLOG(1) << "acceptConfig";
+  if (config.activityProfilerEnabled()) {
+    scheduleTrace(config);
+  }
+}
+
+void AsyncActivityProfilerHandler::scheduleTrace(const Config& config) {
+  VLOG(1) << "scheduleTrace";
+  if (profiler_.isActive()) {
+    LOG(WARNING) << "Ignored request - profiler busy";
+    return;
+  }
+
+  int64_t currentIter = iterationCount_;
+  std::unique_ptr<Config> configToSchedule;
+
+  if (config.hasProfileStartIteration() && currentIter < 0) {
+    // Special case: daemon config with activitiesDuration set
+    if (config.activitiesDuration().count() > 0) {
+      LOG(INFO) << "Config with duration-based profiling, "
+                << "ignoring iteration count requirement";
+      // Continue with modified config - clone and set profileStartIteration to
+      // -1
+      configToSchedule = config.clone();
+      configToSchedule->setProfileStartIteration(-1);
+    } else {
+      LOG(WARNING) << "Ignored profile iteration count based request as "
+                   << "application is not updating iteration count";
+      return;
+    }
+  } else {
+    configToSchedule = config.clone();
+  }
+
+  // Common scheduling logic
+  bool newConfigScheduled = false;
+  if (!asyncRequestConfig_) {
+    std::lock_guard<std::mutex> lock(asyncConfigLock_);
+    if (!asyncRequestConfig_) {
+      asyncRequestConfig_ = std::move(configToSchedule);
+      newConfigScheduled = true;
+    }
+  }
+  if (!newConfigScheduled) {
+    LOG(WARNING) << "Ignored request - another profile request is pending.";
+    return;
+  }
+
+  // start a profilerLoop() thread to handle request
+
+  if (config.memoryProfilerEnabled()) {
+    auto thread_type = ThreadType::MEMORY_SNAPSHOT;
+    if (profilerThreads_[thread_type] == nullptr) {
+      profilerThreads_[thread_type] = std::make_unique<std::thread>(
+          &AsyncActivityProfilerHandler::memoryProfilerLoop, this);
+    }
+  } else {
+    auto thread_type = ThreadType::KINETO;
+    if (profilerThreads_[thread_type] == nullptr) {
+      profilerThreads_[thread_type] = std::make_unique<std::thread>(
+          &AsyncActivityProfilerHandler::profilerLoop, this);
+    }
+  }
+}
+
+void AsyncActivityProfilerHandler::step() {
+  // Snapshot the incremented iteration count once so this step invocation uses
+  // a consistent value for activation checks, logging, and run-loop stepping.
+  int64_t currentIter = ++iterationCount_;
+  VLOG(0) << "Step called , iteration  = " << currentIter;
+
+  // Perform Double-checked locking to reduce overhead of taking lock.
+  if (asyncRequestConfig_ && !profiler_.isActive()) {
+    std::lock_guard<std::mutex> lock(asyncConfigLock_);
+    auto now = system_clock::now();
+    if (asyncRequestConfig_ && !profiler_.isActive() &&
+        shouldActivateIterationConfig(currentIter)) {
+      activateConfig(now);
+    }
+  }
+  if (profiler_.isActive() && !profiler_.isCollectingMemorySnapshot()) {
+    auto now = system_clock::now();
+    auto next_wakeup_time = now + Config::kControllerIntervalMsecs;
+    profiler_.performRunLoopStep(now, next_wakeup_time, currentIter);
+  }
+}
+
+bool AsyncActivityProfilerHandler::shouldActivateTimestampConfig(
+    const std::chrono::time_point<std::chrono::system_clock>& now) {
+  if (asyncRequestConfig_->hasProfileStartIteration()) {
+    return false;
+  }
+  if (asyncRequestConfig_->memoryProfilerEnabled()) {
+    return false;
+  }
+  // Note on now + Config::kControllerIntervalMsecs:
+  // Profiler interval does not align perfectly up to startTime - warmup.
+  // Waiting until the next tick won't allow sufficient time for the
+  // profiler to warm up. So check if we are very close to the warmup time
+  // and trigger warmup.
+  if (now + Config::kControllerIntervalMsecs >=
+      (asyncRequestConfig_->requestTimestamp() -
+       asyncRequestConfig_->activitiesWarmupDuration())) {
+    LOG(INFO)
+        << "Received on-demand activity trace request by "
+        << " profile timestamp = "
+        << asyncRequestConfig_->requestTimestamp().time_since_epoch().count();
+    return true;
+  }
+  return false;
+}
+
+bool AsyncActivityProfilerHandler::shouldActivateIterationConfig(
+    int64_t currentIter) {
+  if (!asyncRequestConfig_->hasProfileStartIteration()) {
+    return false;
+  }
+  if (asyncRequestConfig_->memoryProfilerEnabled()) {
+    return false;
+  }
+  auto rootIter = asyncRequestConfig_->startIterationIncludingWarmup();
+  // Keep waiting, it is not time to start yet.
+  if (currentIter < rootIter) {
+    return false;
+  }
+
+  LOG(INFO) << "Received on-demand activity trace request by "
+               " profile start iteration = "
+            << asyncRequestConfig_->profileStartIteration()
+            << ", current iteration = " << currentIter;
+  // Re-calculate the start iter if requested iteration is in the past.
+  if (currentIter > rootIter) {
+    int64_t newProfileStart =
+        currentIter + asyncRequestConfig_->activitiesWarmupIterations();
+    // Use Start Iteration Round Up if it is present.
+    if (asyncRequestConfig_->profileStartIterationRoundUp() > 0) {
+      // round up to nearest multiple
+      int64_t divisor = asyncRequestConfig_->profileStartIterationRoundUp();
+      int64_t rem = newProfileStart % divisor;
+      newProfileStart += ((rem == 0) ? 0 : divisor - rem);
+      LOG(INFO) << "Rounding up profiler start iteration to : "
+                << newProfileStart;
+      asyncRequestConfig_->setProfileStartIteration(
+          static_cast<int>(newProfileStart));
+      if (currentIter != asyncRequestConfig_->startIterationIncludingWarmup()) {
+        // Ex. Current 9, start 8, warmup 5, roundup 100. Resolves new start
+        // to 100, with warmup starting at 95. So don't start now.
+        return false;
+      }
+    } else {
+      LOG(INFO) << "Start iteration updated to : " << newProfileStart;
+      asyncRequestConfig_->setProfileStartIteration(
+          static_cast<int>(newProfileStart));
+    }
+  }
+  return true;
+}
+
+void AsyncActivityProfilerHandler::profilerLoop() {
+  setThreadName("Kineto Activity Profiler");
+  VLOG(0) << "Entering activity profiler loop";
+
+  auto now = system_clock::now();
+  auto next_wakeup_time = now + Config::kControllerIntervalMsecs;
+
+  while (!stopRunloop_) {
+    now = system_clock::now();
+
+    while (now < next_wakeup_time) {
+      /* sleep override */
+      std::this_thread::sleep_for(next_wakeup_time - now);
+      now = system_clock::now();
+    }
+
+    // Perform Double-checked locking to reduce overhead of taking lock.
+    if (asyncRequestConfig_ && !profiler_.isActive()) {
+      std::lock_guard<std::mutex> lock(asyncConfigLock_);
+      if (asyncRequestConfig_ && !profiler_.isActive() &&
+          shouldActivateTimestampConfig(now)) {
+        activateConfig(now);
+      }
+    }
+
+    while (next_wakeup_time < now) {
+      next_wakeup_time += Config::kControllerIntervalMsecs;
+    }
+
+    // Use syncTraceActive_ so we don't step into the loop while sync trace is
+    // running
+    if (profiler_.isActive() && !profiler_.isCollectingMemorySnapshot() &&
+        !syncTraceActive_) {
+      next_wakeup_time = profiler_.performRunLoopStep(now, next_wakeup_time);
+      VLOG(1) << "Profiler loop: "
+              << duration_cast<milliseconds>(system_clock::now() - now).count()
+              << "ms";
+    }
+  }
+
+  VLOG(0) << "Exited activity profiling loop";
+}
+
+void AsyncActivityProfilerHandler::memoryProfilerLoop() {
+  while (!stopRunloop_) {
+    // Perform Double-checked locking to reduce overhead of taking lock.
+    if (asyncRequestConfig_ && !profiler_.isActive()) {
+      std::lock_guard<std::mutex> lock(asyncConfigLock_);
+      if (asyncRequestConfig_ && !profiler_.isActive() &&
+          asyncRequestConfig_->memoryProfilerEnabled()) {
+        logger_ = ActivityProfilerController::makeLogger(*asyncRequestConfig_);
+        auto path = asyncRequestConfig_->activitiesLogFile();
+        auto profile_time = asyncRequestConfig_->profileMemoryDuration();
+        auto config = asyncRequestConfig_->clone();
+        asyncRequestConfig_ = nullptr;
+        profiler_.performMemoryLoop(path, profile_time, logger_.get(), *config);
+      }
+    }
+  }
+}
+
+// This function should only be called when holding the configLock_.
+void AsyncActivityProfilerHandler::activateConfig(
+    std::chrono::time_point<std::chrono::system_clock> now) {
+  logger_ = ActivityProfilerController::makeLogger(*asyncRequestConfig_);
+  profiler_.setLogger(logger_.get());
+  LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND();
+  profiler_.configure(*asyncRequestConfig_, now);
+  asyncRequestConfig_ = nullptr;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/AsyncActivityProfilerHandler.h
+++ b/libkineto/src/AsyncActivityProfilerHandler.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "ActivityLoggerFactory.h"
+#include "GenericActivityProfiler.h"
+
+namespace KINETO_NAMESPACE {
+
+enum ThreadType {
+  KINETO = 0,
+  MEMORY_SNAPSHOT,
+  THREAD_MAX_COUNT // Number of enum entries (used for array sizing)
+};
+
+class Config;
+
+class AsyncActivityProfilerHandler {
+ public:
+  explicit AsyncActivityProfilerHandler(GenericActivityProfiler& profiler, std::atomic_bool& syncTraceActive);
+  AsyncActivityProfilerHandler(const AsyncActivityProfilerHandler&) = delete;
+  AsyncActivityProfilerHandler& operator=(const AsyncActivityProfilerHandler&) = delete;
+  AsyncActivityProfilerHandler(AsyncActivityProfilerHandler&&) = delete;
+  AsyncActivityProfilerHandler& operator=(AsyncActivityProfilerHandler&&) = delete;
+  ~AsyncActivityProfilerHandler();
+
+  bool canAcceptConfig();
+  void acceptConfig(const Config& config);
+  void scheduleTrace(const Config& config);
+  void step();
+
+ private:
+  bool shouldActivateIterationConfig(int64_t currentIter);
+  bool shouldActivateTimestampConfig(const std::chrono::time_point<std::chrono::system_clock>& now);
+  void profilerLoop();
+  void memoryProfilerLoop();
+  void activateConfig(std::chrono::time_point<std::chrono::system_clock> now);
+
+  std::unique_ptr<Config> asyncRequestConfig_;
+  std::mutex asyncConfigLock_;
+  std::array<std::unique_ptr<std::thread>, ThreadType::THREAD_MAX_COUNT> profilerThreads_;
+  std::atomic_bool stopRunloop_{false};
+  std::atomic<std::int64_t> iterationCount_{-1};
+
+  GenericActivityProfiler& profiler_;
+  std::atomic_bool& syncTraceActive_;
+  std::unique_ptr<ActivityLogger> logger_;
+};
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/SyncActivityProfilerHandler.cpp
+++ b/libkineto/src/SyncActivityProfilerHandler.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "SyncActivityProfilerHandler.h"
+
+#include <chrono>
+
+#include "ActivityProfilerController.h"
+#include "ActivityTrace.h"
+#include "Config.h"
+#include "GenericActivityProfiler.h"
+#include "Logger.h"
+#include "libkineto.h"
+#include "output_membuf.h"
+
+using namespace std::chrono;
+
+namespace KINETO_NAMESPACE {
+
+SyncActivityProfilerHandler::SyncActivityProfilerHandler(
+    GenericActivityProfiler& profiler,
+    std::atomic_bool& syncTraceActive)
+    : profiler_(profiler), syncTraceActive_(syncTraceActive) {}
+
+void SyncActivityProfilerHandler::prepareTrace(const Config& config) {
+  // Requests from ActivityProfilerApi have higher priority than
+  // requests from other sources (signal, daemon).
+  // Cancel any ongoing request and refuse new ones.
+  auto now = system_clock::now();
+  syncTraceActive_ = true;
+  if (profiler_.isActive()) {
+    LOG(WARNING) << "Cancelling current trace request in order to start "
+                 << "higher priority synchronous request";
+    if (libkineto::api().client()) {
+      libkineto::api().client()->stop();
+    }
+
+    profiler_.stopTrace(now);
+    profiler_.reset();
+  }
+
+  profiler_.configure(config, now);
+}
+
+void SyncActivityProfilerHandler::startTrace() {
+  UST_LOGGER_MARK_COMPLETED(kWarmUpStage);
+  USDT_EMIT_START_TRACE();
+  profiler_.startTrace(std::chrono::system_clock::now());
+}
+
+std::unique_ptr<ActivityTraceInterface> SyncActivityProfilerHandler::
+    stopTrace() {
+  profiler_.stopTrace(std::chrono::system_clock::now());
+  USDT_EMIT_STOP_TRACE();
+  UST_LOGGER_MARK_COMPLETED(kCollectionStage);
+  auto logger = std::make_unique<MemoryTraceLogger>(profiler_.config());
+  profiler_.processTrace(*logger);
+  // Will follow up with another patch for logging URLs when ActivityTrace
+  // is moved.
+  UST_LOGGER_MARK_COMPLETED(kPostProcessingStage);
+
+  // Logger Metadata contains a map of LOGs collected in Kineto
+  //   logger_level -> List of log lines
+  // This will be added into the trace as metadata.
+  std::unordered_map<std::string, std::vector<std::string>> loggerMD =
+      profiler_.getLoggerMetadata();
+  logger->setLoggerMetadata(std::move(loggerMD));
+
+  profiler_.reset();
+  syncTraceActive_ = false;
+  return std::make_unique<ActivityTrace>(
+      std::move(logger), ActivityProfilerController::loggerFactory());
+}
+
+void SyncActivityProfilerHandler::toggleCollectionDynamic(const bool enable) {
+  profiler_.toggleCollectionDynamic(enable);
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/SyncActivityProfilerHandler.h
+++ b/libkineto/src/SyncActivityProfilerHandler.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+
+#include "ActivityTraceInterface.h"
+#include "GenericActivityProfiler.h"
+
+namespace KINETO_NAMESPACE {
+
+class Config;
+
+class SyncActivityProfilerHandler {
+ public:
+  explicit SyncActivityProfilerHandler(GenericActivityProfiler& profiler, std::atomic_bool& syncTraceActive);
+  SyncActivityProfilerHandler(const SyncActivityProfilerHandler&) = delete;
+  SyncActivityProfilerHandler& operator=(const SyncActivityProfilerHandler&) = delete;
+  SyncActivityProfilerHandler(SyncActivityProfilerHandler&&) = delete;
+  SyncActivityProfilerHandler& operator=(SyncActivityProfilerHandler&&) = delete;
+  ~SyncActivityProfilerHandler() = default;
+
+  void prepareTrace(const Config& config);
+  void toggleCollectionDynamic(const bool enable);
+  void startTrace();
+  std::unique_ptr<ActivityTraceInterface> stopTrace();
+
+ private:
+  GenericActivityProfiler& profiler_;
+  std::atomic_bool& syncTraceActive_;
+};
+} // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Summary:

Part 1 of a refactor to improve safety and readability around sync/async profiling.

This is a straightforward (no-op) split that creates Sync/AsyncActivityProfilerHandler, which contains the methods which belonged to the ActivityProfilerController but are only used for one type of tracing. The original methods in the controller become thin wrappers that forward the request to the appropriate handler.

Reviewed By: scotts

Differential Revision: D92550422
