### PR TITLE
Move RoctracerActivity.h includes to cpp file

### DIFF
--- a/libkineto/src/RocmActivityProfiler.cpp
+++ b/libkineto/src/RocmActivityProfiler.cpp
@@ -17,6 +17,9 @@
 #include "ActivityBuffers.h"
 #include "Config.h"
 #include "Logger.h"
+// RoctracerActivity.h must stay in this .cpp only — RoctracerActivity_inl.h
+// has inline functions referencing thread_local anonymous-namespace maps
+#include "RoctracerActivity.h"
 #include "ThreadUtil.h"
 
 using namespace std::chrono;

--- a/libkineto/src/RocmActivityProfiler.h
+++ b/libkineto/src/RocmActivityProfiler.h
@@ -14,7 +14,6 @@
 
 #include <roctracer.h>
 #include "GenericActivityProfiler.h"
-#include "RoctracerActivity.h"
 #include "RoctracerActivityApi.h"
 #include "RoctracerLogger.h"
 
@@ -43,19 +42,14 @@ class RocmActivityProfiler : public GenericActivityProfiler {
 
  private:
   // Process generic RocTracer activity
-  void handleRoctracerActivity(
-      const roctracerBase* record,
-      ActivityLogger* logger);
-  void handleCorrelationActivity(
-      uint64_t correlationId,
-      uint64_t externalId,
-      RoctracerLogger::CorrelationDomain externalKind);
+  void handleRoctracerActivity(const roctracerBase* record, ActivityLogger* logger);
+  void handleCorrelationActivity(uint64_t correlationId,
+                                 uint64_t externalId,
+                                 RoctracerLogger::CorrelationDomain externalKind);
   // Process specific GPU activity types
   template <class T>
   void handleRuntimeActivity(const T* activity, ActivityLogger* logger);
-  void handleGpuActivity(
-      const roctracerAsyncRow* record,
-      ActivityLogger* logger);
+  void handleGpuActivity(const roctracerAsyncRow* record, ActivityLogger* logger);
 
   // Calls to ROCtracer is encapsulated behind this interface
   RoctracerActivityApi& roctracer_;


### PR DESCRIPTION
Summary:
Bug fix for https://github.com/pytorch/pytorch/actions/runs/22315914481/job/64566125466

The error is that the grid keyword is not found in the kineto json output. For ROCm, the json output gets constructed [here](https://www.internalfb.com/code/fbsource/[5867decda83f]/fbcode/kineto/libkineto/src/RoctracerActivity_inl.h?lines=124%2C133)

When `correlationToGrid.count(gpuActivity.id) > 0` is false, the grid attribute is not returned. `correlationToGrid` is defined as a thread_local map (and the functions the read/write from it are inlined) -- I think what's happening is that a recent change moved the RoctracerActivity.h include from RocmActivityProfiler.cpp to RocmActivityProfiler.h. Since RocmActivityProfiler.h is also included in the ActivityProfilerController, both TUs have a private copy of the inline functions which seems to mess things up.

Claude's explanation: P2205224940

Differential Revision: D94391145


