### PR TITLE
Add graphId and graphNodeId to kernel metadata

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -477,7 +477,7 @@ void CuptiActivityProfiler::handleCuptiActivity(
           reinterpret_cast<const CUpti_ActivityAPI*>(record), logger);
       break;
     case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL: {
-      auto kernel = reinterpret_cast<const CUpti_ActivityKernel4*>(record);
+      auto kernel = reinterpret_cast<const CUpti_ActivityKernelType*>(record);
       // Register all kernels launches so we could correlate them with other
       // events.
       KernelRegistry::singleton()->recordKernel(

--- a/libkineto/src/DeviceProperties.cpp
+++ b/libkineto/src/DeviceProperties.cpp
@@ -143,18 +143,18 @@ int smCount(uint32_t deviceId) {
 }
 
 #ifdef HAS_CUPTI
-float blocksPerSm(const CUpti_ActivityKernel4& kernel) {
+float blocksPerSm(const CUpti_ActivityKernelType& kernel) {
   return (kernel.gridX * kernel.gridY * kernel.gridZ) /
       (float)smCount(kernel.deviceId);
 }
 
-float warpsPerSm(const CUpti_ActivityKernel4& kernel) {
+float warpsPerSm(const CUpti_ActivityKernelType& kernel) {
   constexpr int threads_per_warp = 32;
   return blocksPerSm(kernel) * (kernel.blockX * kernel.blockY * kernel.blockZ) /
       threads_per_warp;
 }
 
-float kernelOccupancy(const CUpti_ActivityKernel4& kernel) {
+float kernelOccupancy(const CUpti_ActivityKernelType& kernel) {
   float blocks_per_sm = -1.0;
   int sm_count = smCount(kernel.deviceId);
   if (sm_count) {

--- a/libkineto/src/DeviceProperties.h
+++ b/libkineto/src/DeviceProperties.h
@@ -24,11 +24,19 @@ int smCount(uint32_t deviceId);
 
 // TODO: Implement the below for HAS_ROCTRACER
 #ifdef HAS_CUPTI
-float blocksPerSm(const CUpti_ActivityKernel4& kernel);
-float warpsPerSm(const CUpti_ActivityKernel4& kernel);
+
+// Use CUpti_ActivityKernel9 in CUDA 12.0+ for extended kernel fields
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+using CUpti_ActivityKernelType = CUpti_ActivityKernel9;
+#else
+using CUpti_ActivityKernelType = CUpti_ActivityKernel4;
+#endif
+
+float blocksPerSm(const CUpti_ActivityKernelType& kernel);
+float warpsPerSm(const CUpti_ActivityKernelType& kernel);
 
 // Return estimated achieved occupancy for a kernel
-float kernelOccupancy(const CUpti_ActivityKernel4& kernel);
+float kernelOccupancy(const CUpti_ActivityKernelType& kernel);
 float kernelOccupancy(uint32_t deviceId,
                       uint16_t registersPerThread,
                       int32_t staticSharedMemory,

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -150,7 +150,7 @@ struct MockCuptiActivityBuffer {
       int64_t end_ns,
       int64_t correlation) {
     auto& act =
-        createActivity<CUpti_ActivityKernel4>(start_ns, end_ns, correlation);
+        createActivity<CUpti_ActivityKernelType>(start_ns, end_ns, correlation);
     act.kind = CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL;
     act.deviceId = 0;
     act.contextId = 0;
@@ -196,7 +196,7 @@ struct MockCuptiActivityBuffer {
       int64_t end_ns,
       int64_t correlation) {
     auto& act =
-        createActivity<CUpti_ActivityKernel4>(start_ns, end_ns, correlation);
+        createActivity<CUpti_ActivityKernelType>(start_ns, end_ns, correlation);
     act.name = "collective_gpu";
     act.kind = CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL;
     act.queued = 0;


### PR DESCRIPTION
Summary:
As titled

graphId and graphNodeId are present in CUpti_ActivityKernel5 and above (but not in CUpti_ActivityKernel4, which we currently use).

CUpti_ActivityKernel10 is the latest but is only present in 13.0+ -- CUpti_ActivityKernel9 seems to be the latest that also covers 12.0+. It doesn't cover below 12.0 though, so we conditionally change the type we use depending on the CUDA version.

I guess technically we don't support <12.6, but not sure we want to intentionally break it? Open to thoughts here.

Differential Revision: D94413488


