### PR TITLE
Add USDT log type to logger framework

### DIFF
--- a/libkineto/include/ILoggerObserver.h
+++ b/libkineto/include/ILoggerObserver.h
@@ -33,7 +33,7 @@ constexpr char kEmptyTrace[] = "No Valid Trace Events (CPU/GPU) found. Outputtin
 
 namespace libkineto {
 
-enum LoggerOutputType { VERBOSE = 0, INFO = 1, WARNING = 2, STAGE = 3, ERROR = 4, ENUM_COUNT = 5 };
+enum LoggerOutputType { VERBOSE = 0, INFO = 1, WARNING = 2, STAGE = 3, ERROR = 4, USDT = 5, ENUM_COUNT = 6 };
 
 const char* toString(LoggerOutputType t);
 LoggerOutputType toLoggerOutputType(const std::string& str);

--- a/libkineto/src/ILoggerObserver.cpp
+++ b/libkineto/src/ILoggerObserver.cpp
@@ -30,6 +30,7 @@ static constexpr std::array<LoggerTypeName, LoggerTypeCount + 1> LoggerMap{
      {"WARNING", LoggerOutputType::WARNING},
      {"STAGE", LoggerOutputType::STAGE},
      {"ERROR", LoggerOutputType::ERROR},
+     {"USDT", LoggerOutputType::USDT},
      {"???", LoggerOutputType::ENUM_COUNT}}};
 
 static constexpr bool matchingOrder(int idx = 0) {

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -27,6 +27,8 @@
 #define LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND()
 #define LOGGER_OBSERVER_ADD_METADATA(key, value)
 #define UST_LOGGER_MARK_COMPLETED(stage)
+#define USDT_LOGGER_EMIT_MESSAGE(usdt_type)
+#define USDT_EMIT_START_TRACE()
 
 #else // !USE_GOOGLE_LOG
 #include <stdio.h>
@@ -250,5 +252,8 @@ struct __to_constant__ {
 
 // UST Logger Semantics to describe when a stage is complete.
 #define UST_LOGGER_MARK_COMPLETED(stage) LOG(libkineto::LoggerOutputType::STAGE) << "Completed Stage: " << stage
+
+#define USDT_LOGGER_EMIT_MESSAGE(usdt_type) LOG(libkineto::LoggerOutputType::USDT) << usdt_type
+#define USDT_EMIT_START_TRACE() USDT_LOGGER_EMIT_MESSAGE("StartTrace")
 
 #endif // USE_GOOGLE_LOG


### PR DESCRIPTION
Summary: Add a new USDT LoggerOutputType enum value and a USDT_LOGGER_EMIT_MESSAGE macro to the Kineto logger infrastructure. This prepares the logging framework for emitting USDT probes by introducing a dedicated log channel that USDT-aware logger observers can listen on.

Differential Revision: D95334353


