### PR TITLE
Fix linting CI workflow

### DIFF
--- a/libkineto/src/ThreadUtil.cpp
+++ b/libkineto/src/ThreadUtil.cpp
@@ -80,8 +80,7 @@ int32_t processId(bool cache) {
   return _pid;
 }
 
-int32_t systemThreadId(
-    bool cache) {
+int32_t systemThreadId(bool cache) {
   int32_t sysTid = 0;
   if (!_sysTid) {
 #ifdef __APPLE__


### PR DESCRIPTION
Our CI linting workflow was not catching lint errors on PRs because it was only running `lintrunner` against *dirty* files. But no files were dirty because it was checking out the PR. This PR changes it so that we run against what's on main.

Note that `lintrunner --all-files` does not work for us because `third_party/dynolog` has filenames with non-Latin characters: https://github.com/civetweb/civetweb/tree/d7ba35bbb649209c66e582d5a0244ba988a15159/test/nonlatin. It can't handle those files. I filed https://github.com/suo/lintrunner/issues/101.