### PR TITLE
Add additionalLoggerCollector mechanism to ActivityProfilerController (#1290)

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -45,19 +45,21 @@ using namespace std::chrono;
 namespace KINETO_NAMESPACE {
 
 #if !USE_GOOGLE_LOG
-static std::shared_ptr<LoggerCollector>& loggerCollectorFactory() {
-  static std::shared_ptr<LoggerCollector> factory = nullptr;
-  return factory;
+namespace {
+std::vector<std::shared_ptr<LoggerCollector>>& loggerCollectors() {
+  static std::vector<std::shared_ptr<LoggerCollector>> collectors;
+  return collectors;
 }
+} // namespace
 
-void ActivityProfilerController::setLoggerCollectorFactory(
+void ActivityProfilerController::addLoggerCollectorFactory(
     const std::function<std::shared_ptr<LoggerCollector>()>& factory) {
-  loggerCollectorFactory() = factory();
+  loggerCollectors().push_back(factory());
 }
 
-std::shared_ptr<LoggerCollector> ActivityProfilerController::
-    getLoggerCollector() {
-  return loggerCollectorFactory();
+std::vector<std::shared_ptr<LoggerCollector>> ActivityProfilerController::
+    getLoggerCollectors() {
+  return loggerCollectors();
 }
 #endif // !USE_GOOGLE_LOG
 
@@ -69,13 +71,12 @@ ActivityProfilerController::ActivityProfilerController(
   ChromeTraceBaseTime::singleton().init();
 
 #if !USE_GOOGLE_LOG
-  // Initialize LoggerCollector before ActivityProfiler to log
+  // Initialize LoggerCollectors before ActivityProfiler to log
   // CUPTI and CUDA driver versions.
-  if (loggerCollectorFactory()) {
-    // Keep a reference to the logger collector factory to handle safe
-    // static de-initialization.
-    loggerCollectorFactory_ = loggerCollectorFactory();
-    Logger::addLoggerObserver(loggerCollectorFactory_.get());
+  // Keep a reference to handle safe static de-initialization.
+  loggerCollectors_ = loggerCollectors();
+  for (auto& collector : loggerCollectors_) {
+    Logger::addLoggerObserver(collector.get());
   }
 #endif // !USE_GOOGLE_LOG
 
@@ -109,8 +110,8 @@ ActivityProfilerController::~ActivityProfilerController() {
   }
 
 #if !USE_GOOGLE_LOG
-  if (loggerCollectorFactory()) {
-    Logger::removeLoggerObserver(loggerCollectorFactory_.get());
+  for (auto& collector : loggerCollectors_) {
+    Logger::removeLoggerObserver(collector.get());
   }
 #endif // !USE_GOOGLE_LOG
 }

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
@@ -43,8 +44,8 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   ~ActivityProfilerController();
 
 #if !USE_GOOGLE_LOG
-  static std::shared_ptr<LoggerCollector> getLoggerCollector();
-  static void setLoggerCollectorFactory(const std::function<std::shared_ptr<LoggerCollector>()>& factory);
+  static void addLoggerCollectorFactory(const std::function<std::shared_ptr<LoggerCollector>()>& factory);
+  static std::vector<std::shared_ptr<LoggerCollector>> getLoggerCollectors();
 #endif // !USE_GOOGLE_LOG
 
   static void addLoggerFactory(const std::string& protocol, ActivityLoggerFactory::FactoryFunc factory);
@@ -99,7 +100,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
 
   std::unique_ptr<GenericActivityProfiler> profiler_;
   std::unique_ptr<ActivityLogger> logger_;
-  std::shared_ptr<LoggerCollector> loggerCollectorFactory_;
+  std::vector<std::shared_ptr<LoggerCollector>> loggerCollectors_;
   std::thread* profilerThreads_[ThreadType::THREAD_MAX_COUNT] = {nullptr};
   std::atomic_bool stopRunloop_{false};
   std::atomic<std::int64_t> iterationCount_{-1};

--- a/libkineto/test/LoggerObserverTest.cpp
+++ b/libkineto/test/LoggerObserverTest.cpp
@@ -15,6 +15,7 @@
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "LoggerCollector.h"
 #include "include/libkineto.h"
+#include "src/ActivityProfilerController.h"
 #include "src/Logger.h"
 
 using namespace KINETO_NAMESPACE;
@@ -101,6 +102,68 @@ TEST(LoggerObserverTest, FourCollectorObserver) {
   Logger::removeLoggerObserver(lc2.get());
   Logger::removeLoggerObserver(lc3.get());
   Logger::removeLoggerObserver(lc4.get());
+}
+
+TEST(LoggerObserverTest, AddAndGetLoggerCollector) {
+  auto baseline = ActivityProfilerController::getLoggerCollectors().size();
+
+  // Register a logger collector via the static API.
+  ActivityProfilerController::addLoggerCollectorFactory(
+      []() { return std::make_shared<LoggerCollector>(); });
+
+  auto collectors = ActivityProfilerController::getLoggerCollectors();
+  EXPECT_EQ(collectors.size(), baseline + 1);
+
+  // The returned collector should be a valid LoggerCollector that can
+  // receive log messages when manually registered as an observer.
+  auto& collector = collectors[baseline];
+  Logger::addLoggerObserver(collector.get());
+
+  LOG(INFO) << InfoTestStr;
+  LOG(WARNING) << WarningTestStr;
+  LOG(ERROR) << ErrorTestStr;
+
+  auto metadata = collector->extractCollectorMetadata();
+  EXPECT_TRUE(
+      metadata[LoggerOutputType::INFO][0].find(InfoTestStr) !=
+      std::string::npos);
+  EXPECT_TRUE(
+      metadata[LoggerOutputType::WARNING][0].find(WarningTestStr) !=
+      std::string::npos);
+  EXPECT_TRUE(
+      metadata[LoggerOutputType::ERROR][0].find(ErrorTestStr) !=
+      std::string::npos);
+
+  Logger::removeLoggerObserver(collector.get());
+}
+
+TEST(LoggerObserverTest, MultipleLoggerCollectors) {
+  auto baseline = ActivityProfilerController::getLoggerCollectors().size();
+
+  // Register two more collectors.
+  ActivityProfilerController::addLoggerCollectorFactory(
+      []() { return std::make_shared<LoggerCollector>(); });
+  ActivityProfilerController::addLoggerCollectorFactory(
+      []() { return std::make_shared<LoggerCollector>(); });
+
+  auto collectors = ActivityProfilerController::getLoggerCollectors();
+  EXPECT_EQ(collectors.size(), baseline + 2);
+
+  // Both collectors should independently receive log messages.
+  auto& c1 = collectors[baseline];
+  auto& c2 = collectors[baseline + 1];
+  Logger::addLoggerObserver(c1.get());
+  Logger::addLoggerObserver(c2.get());
+
+  LOG(INFO) << InfoTestStr;
+
+  auto md1 = c1->extractCollectorMetadata();
+  auto md2 = c2->extractCollectorMetadata();
+  EXPECT_EQ(md1[LoggerOutputType::INFO].size(), 1);
+  EXPECT_EQ(md2[LoggerOutputType::INFO].size(), 1);
+
+  Logger::removeLoggerObserver(c1.get());
+  Logger::removeLoggerObserver(c2.get());
 }
 
 #endif // !USE_GOOGLE_LOG


### PR DESCRIPTION
Summary:

Extend the ActivityProfilerController to support registering multiple additional LoggerCollector instances alongside the existing single factory. This enables plugging in supplementary logger observers (like a USDT probe logger) without replacing the primary UST logger collector. The additional collectors are registered/unregistered during controller construction/destruction.

Differential Revision: D95829535


