### PR TITLE
Add NCCL collective sequence number (seq_num) to Kineto profiler traces

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -49,6 +49,7 @@ static constexpr const std::string_view kOutTensorsStart =
 static constexpr const std::string_view kRank = "Rank";
 static constexpr const std::string_view kP2pSrc = "Src Rank";
 static constexpr const std::string_view kP2pDst = "Dst Rank";
+static constexpr const std::string_view kSeqNum = "Seq";
 
 #ifdef __linux__
 static constexpr std::string_view kDefaultLogFileFmt =
@@ -553,6 +554,14 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
     }
     if (!srcRank.empty()) {
       arg_values.append(fmt::format(", \"{}\": {}", kP2pSrc, srcRank));
+    }
+    const auto& seqNum =
+        collectiveRecord->getMetadataValue(std::string(kSeqNum));
+    if (!seqNum.empty()) {
+      if (!arg_values.empty()) {
+        arg_values.append(",");
+      }
+      arg_values.append(fmt::format(" \"{}\": {}", kSeqNum, seqNum));
     }
 
     if (distInfo_.backend.empty() && processGroupDesc == "\"default_pg\"") {


### PR DESCRIPTION
Summary:
Thread the per-process-group sequence number from ProcessGroupNCCL through
ParamCommsDebugInfo into the Kineto trace JSON output.

This enables cross-rank correlation of collective operations: all ranks
participating in the same collective instance share the same seq_num
within a process group. Without this, there is no way to match collective
events across ranks in production trace data (gpu_comms_events Scuba table).

Changes:
- ParamCommsUtils.hpp: Add sequenceNumber_/isP2P_ fields and setter to
  ParamCommsDebugInfo. Update RECORD_PARAM_COMMS and RECORD_PARAM_COMMS_DATA
  macros to populate them from the existing seq tuple.
- util.h: Add kSeqNum constant ("Seq")
- util.cpp: Emit seq_num in saveNcclMeta() when available
- default_event_args.py (HTA): Add nccl::seq mapping so HTA parses the
  new field into a seq_num column

Differential Revision: D94566477


