### PR TITLE
Update ROCPROFILER_CALLBACK_* references to ROCPROFILER_BUFFER_*

### DIFF
--- a/libkineto/src/RocLogger.h
+++ b/libkineto/src/RocLogger.h
@@ -82,6 +82,10 @@ struct rocprofBase {
   uint64_t id; // correlation_id
   uint64_t begin;
   uint64_t end;
+  // Tracing domain/kind. Actual type depends on the code path:
+  // - rocprofiler-sdk callbacks: rocprofiler_callback_tracing_kind_t
+  // - rocprofiler-sdk buffer tracing (rocprofAsyncRow): rocprofiler_buffer_tracing_kind_t
+  // - roctracer fallback: activity_domain_t
   uint32_t domain;
   rocprof_activity_types type;
 };

--- a/libkineto/src/RocprofActivity.h
+++ b/libkineto/src/RocprofActivity.h
@@ -83,10 +83,10 @@ struct GpuActivity : public RocprofActivity<rocprofAsyncRow> {
   explicit GpuActivity(const rocprofAsyncRow* activity, const ITraceActivity* linked)
       : RocprofActivity(activity, linked) {
     switch (activity_.domain) {
-      case ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY:
+      case ROCPROFILER_BUFFER_TRACING_MEMORY_COPY:
         type_ = ActivityType::GPU_MEMCPY;
         break;
-      case ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH:
+      case ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH:
       default:
         type_ = ActivityType::CONCURRENT_KERNEL;
         break;

--- a/libkineto/src/RocprofActivityApi.cpp
+++ b/libkineto/src/RocprofActivityApi.cpp
@@ -125,11 +125,11 @@ int RocprofActivityApi::processActivities(
       filtered = true;
     } else {
       switch (reinterpret_cast<rocprofAsyncRow*>(item)->domain) {
-        case ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY:
+        case ROCPROFILER_BUFFER_TRACING_MEMORY_COPY:
           if (!isLogged(ActivityType::GPU_MEMCPY))
             filtered = true;
           break;
-        case ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH:
+        case ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH:
         default:
           if (!isLogged(ActivityType::CONCURRENT_KERNEL))
             filtered = true;

--- a/libkineto/src/RocprofActivity_inl.h
+++ b/libkineto/src/RocprofActivity_inl.h
@@ -28,9 +28,9 @@ thread_local std::unordered_map<int, size_t> correlationToSize;
 } // namespace
 
 inline const char* getGpuActivityKindString(uint32_t domain, uint32_t op) {
-  if (domain == ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH)
+  if (domain == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH)
     return "Dispatch Kernel";
-  else if (domain == ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY) {
+  else if (domain == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY) {
     switch (op) {
       case ROCPROFILER_MEMORY_COPY_HOST_TO_HOST:
         return "HtoH";
@@ -115,8 +115,8 @@ inline const std::string GpuActivity::metadataJson() const {
       gpuActivity.device, gpuActivity.queue,
       gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op),
       size, bandwidth_gib);
-  } 
-  
+  }
+
   // if compute kernel, add grid and block
   else if (correlationToGrid.count(gpuActivity.id) > 0) {
     return fmt::format(R"JSON(

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -203,7 +203,7 @@ struct MockRocLogger {
 #else
     rocprofAsyncRow* row = new rocprofAsyncRow(
         correlation,
-        ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
+        ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
         0,
         0,
         0,
@@ -233,7 +233,7 @@ struct MockRocLogger {
 #else
     rocprofAsyncRow* row = new rocprofAsyncRow(
         correlation,
-        ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY,
+        ROCPROFILER_BUFFER_TRACING_MEMORY_COPY,
         0,
         ROCPROFILER_MEMORY_COPY_HOST_TO_DEVICE,
         0,
@@ -263,7 +263,7 @@ struct MockRocLogger {
 #else
     rocprofAsyncRow* row = new rocprofAsyncRow(
         correlation,
-        ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY,
+        ROCPROFILER_BUFFER_TRACING_MEMORY_COPY,
         0,
         ROCPROFILER_MEMORY_COPY_DEVICE_TO_HOST,
         0,


### PR DESCRIPTION
Summary:
While debugging the test_disable_external_correlation profiler test, I found a bug where ROCm profiles didn't seem to produce "gpu_memcpy" events, leading to a validation error (see [code ref](https://www.internalfb.com/code/fbsource/[475c7d69dbbe]/fbcode/caffe2/test/profiler/test_profiler.py?lines=2392%2C2419)). The payload here is doing .cuda() calls which should trigger the memcpy.

In the RocprofLogger.cpp file, we request Rocprofiler to return 'ROCPROFILER_BUFFER_TRACING_MEMORY_COPY' events thru [`rocprofiler_configure_buffer_tracing_service`](https://www.internalfb.com/code/fbsource/[475c7d69dbbe]/fbcode/kineto/libkineto/src/RocprofLogger.cpp?lines=427). However throughout the rest of the Rocprof logic we are expecting ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY calls. In the switch statements modified in this diff, this causes the mem copy calls to fall back to kernel type by default -- so gpu_memcpy events are missing from the gpu trace + we're unable to get the kind of mem copy.

Differential Revision: D96124233


