### PR TITLE
Add seq_num propagation to GPU kernel events in Kineto trace output

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -49,6 +49,7 @@ static constexpr const std::string_view kOutTensorsStart =
 static constexpr const std::string_view kRank = "Rank";
 static constexpr const std::string_view kP2pSrc = "Src Rank";
 static constexpr const std::string_view kP2pDst = "Dst Rank";
+static constexpr const std::string_view kSeqNum = "Seq";
 
 #ifdef __linux__
 static constexpr std::string_view kDefaultLogFileFmt =
@@ -553,6 +554,14 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
     }
     if (!srcRank.empty()) {
       arg_values.append(fmt::format(", \"{}\": {}", kP2pSrc, srcRank));
+    }
+    const auto& seqNum =
+        collectiveRecord->getMetadataValue(std::string(kSeqNum));
+    if (!seqNum.empty()) {
+      if (!arg_values.empty()) {
+        arg_values.append(",");
+      }
+      arg_values.append(fmt::format(" \"{}\": {}", kSeqNum, seqNum));
     }
 
     if (distInfo_.backend.empty() && processGroupDesc == "\"default_pg\"") {

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -52,6 +52,7 @@ static constexpr auto kGroupSize = "Group size";
 static constexpr const char* kProcessGroupName = "Process Group Name";
 static constexpr const char* kProcessGroupDesc = "Process Group Description";
 static constexpr const char* kGroupRanks = "Process Group Ranks";
+static constexpr auto kSeqNum = "Seq";
 static constexpr int32_t kTruncatLength = 30;
 
 #define CUDA_LAUNCH_KERNEL CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000
@@ -663,6 +664,7 @@ TEST_F(CuptiActivityProfilerTest, GpuNCCLCollectiveTest) {
   metadataMap.emplace(kGroupSize, "2");
   metadataMap.emplace(kProcessGroupName, fmt::format("\"{}\"", "12341234"));
   metadataMap.emplace(kProcessGroupDesc, fmt::format("\"{}\"", "test_purpose"));
+  metadataMap.emplace(kSeqNum, "42");
 
   std::vector<int64_t> inSplitSizes(50, 0);
   std::string inSplitSizesStr;
@@ -804,6 +806,8 @@ TEST_F(CuptiActivityProfilerTest, GpuNCCLCollectiveTest) {
   EXPECT_EQ(2, countSubstrings(jsonString, "test_purpose"));
   EXPECT_EQ(2, countSubstrings(jsonString, kGroupRanks));
   EXPECT_EQ(2, countSubstrings(jsonString, expectedGroupRanksStr));
+  EXPECT_EQ(2, countSubstrings(jsonString, kSeqNum));
+  EXPECT_EQ(2, countSubstrings(jsonString, "42"));
 #endif
 }
 


### PR DESCRIPTION
Summary:
Propagate the NCCL collective sequence number (Seq) from CPU-side
record_param_comms events to their linked GPU kernel events in the
chrome trace JSON output.

CPU events already carry the Seq field via generic metadata serialization.
This change copies it to CONCURRENT_KERNEL events so that GPU-level
collective operations can also be correlated across ranks.

Changes:
- output_json.cpp: Add kSeqNum constant and read Seq from the linked
  CPU collective record's metadata, appending it to GPU kernel event args

Differential Revision: D96145504


