### PR TITLE
Use HAS_CUPTI_RANGE_PROFILER to avoid range profiler init

### DIFF
--- a/libkineto/src/CuptiRangeProfiler.h
+++ b/libkineto/src/CuptiRangeProfiler.h
@@ -24,6 +24,12 @@
 
 namespace KINETO_NAMESPACE {
 
+#if defined(HAS_CUPTI_RANGE_PROFILER)
+constexpr bool kHasCuptiRangeProfiler = true;
+#else
+constexpr bool kHasCuptiRangeProfiler = false;
+#endif
+
 using CuptiProfilerPrePostCallback = std::function<void(void)>;
 
 /* Activity Profiler session encapsulates the CUPTI Range based Profiler

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -152,19 +152,15 @@ void libkineto_init(bool cpuOnly, [[maybe_unused]] bool logOnError) {
 #endif
 
 #ifdef HAS_CUPTI
-  bool initRangeProfiler = true;
-
   if (!cpuOnly && !libkineto::isDaemonEnvVarSet()) {
     bool success = setupCuptiInitCallback(logOnError);
     cpuOnly = !success;
-    initRangeProfiler = success;
-  }
-
-  // Initialize CUPTI Range Profiler API
-  // Note: the following is a no-op if Range Profiler is not supported
-  // currently it is only enabled in fbcode.
-  if (!cpuOnly && initRangeProfiler) {
-    rangeProfilerInit = std::make_unique<CuptiRangeProfilerInit>();
+    // Initialize CUPTI Range Profiler API
+    if constexpr (kHasCuptiRangeProfiler) {
+      if (success) {
+        rangeProfilerInit = std::make_unique<CuptiRangeProfilerInit>();
+      }
+    }
   }
 
   if (!cpuOnly && shouldPreloadCuptiInstrumentation()) {


### PR DESCRIPTION
Summary:
Range profiler initialization (CuptiRangeProfilerInit) was running whenever HAS_CUPTI was defined, even when HAS_CUPTI_RANGE_PROFILER was not defined (i.e., range profiler is not actually supported).

That is bad because
1. This would be causing unnecessary memory allocation for unique_ptr rangeProfilerInit.
2. It leads to registration of CuptiRangeProfilerConfig factory

Reviewed By: aaronenyeshi, scotts

Differential Revision: D94610428


