### PR TITLE
Add MTIA_COUNTERS ActivityType and counter event output support (#1303)

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -35,21 +35,22 @@ enum class ActivityType {
   MTIA_INSIGHT = 14, // MTIA Insight Events
   CUDA_SYNC = 15, // synchronization events between runtime and kernels
   CUDA_EVENT = 16, // CUDA event activities (cudaEventRecord, etc.)
+  MTIA_COUNTERS = 17, // MTIA hardware counter events (HBM, cache, DPE, SFU)
 
   // Optional Activity types
-  GLOW_RUNTIME = 17, // host side glow runtime events
-  CUDA_PROFILER_RANGE = 18, // CUPTI Profiler range for performance metrics
-  HPU_OP = 19, // HPU host side runtime event
-  XPU_RUNTIME = 20, // host side xpu runtime events
-  XPU_DRIVER = 21, // host side xpu driver events
-  COLLECTIVE_COMM = 22, // collective communication
+  GLOW_RUNTIME = 18, // host side glow runtime events
+  CUDA_PROFILER_RANGE = 19, // CUPTI Profiler range for performance metrics
+  HPU_OP = 20, // HPU host side runtime event
+  XPU_RUNTIME = 21, // host side xpu runtime events
+  XPU_DRIVER = 22, // host side xpu driver events
+  COLLECTIVE_COMM = 23, // collective communication
 
   // PRIVATEUSE1 Activity types are used for custom backends.
   // The corresponding device type is `DeviceType::PrivateUse1` in PyTorch.
-  PRIVATEUSE1_RUNTIME = 23, // host side privateUse1 runtime events
-  PRIVATEUSE1_DRIVER = 24, // host side privateUse1 driver events
+  PRIVATEUSE1_RUNTIME = 24, // host side privateUse1 runtime events
+  PRIVATEUSE1_DRIVER = 25, // host side privateUse1 driver events
 
-  ENUM_COUNT = 25, // This is to add buffer and not used for any profiling logic. Add
+  ENUM_COUNT = 26, // This is to add buffer and not used for any profiling logic. Add
   // your new type before it.
   OPTIONAL_ACTIVITY_TYPE_START = GLOW_RUNTIME,
 };

--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -103,6 +103,17 @@ class GenericTraceActivity : public ITraceActivity {
     metadataMap_.emplace(key, std::make_pair(value, true));
   }
 
+  // Store a typed counter value. Preferred over addMetadata for counter
+  // activities — preserves full double precision and avoids the JSON
+  // serialize/deserialize round-trip in output backends.
+  void addCounterValue(const std::string& name, double value) {
+    counterValues_.emplace_back(name, value);
+  }
+
+  const std::vector<std::pair<std::string, double>>& counterValues() const override {
+    return counterValues_;
+  }
+
   const std::string getMetadataValue(const std::string& key) const override {
     if (auto it = metadataMap_.find(key); it != metadataMap_.end()) {
       return it->second.first;
@@ -150,6 +161,8 @@ class GenericTraceActivity : public ITraceActivity {
   const TraceSpan* traceSpan_;
   // Metadata map: { key: (value, quoted)}
   std::unordered_map<std::string, std::pair<std::string, bool>> metadataMap_;
+  // Typed counter values: (name, double) to avoid round-tripping though string
+  std::vector<std::pair<std::string, double>> counterValues_;
 };
 
 } // namespace libkineto

--- a/libkineto/include/ITraceActivity.h
+++ b/libkineto/include/ITraceActivity.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "ActivityType.h"
 
@@ -52,6 +54,12 @@ struct ITraceActivity {
   // @lint-ignore CLANGTIDY: clang-diagnostic-unused-parameter
   [[nodiscard]] virtual const std::string getMetadataValue([[maybe_unused]] const std::string& key) const {
     return "";
+  }
+  // Return typed counter values (name, value) for activities with
+  // floating-point metadata that should not be round-tripped through strings.
+  [[nodiscard]] virtual const std::vector<std::pair<std::string, double>>& counterValues() const {
+    static const std::vector<std::pair<std::string, double>> kEmpty;
+    return kEmpty;
   }
 
   static int64_t nsToUs(int64_t ns) {

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -35,6 +35,7 @@ static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{
      {"mtia_insight", ActivityType::MTIA_INSIGHT},
      {"cuda_sync", ActivityType::CUDA_SYNC},
      {"cuda_event", ActivityType::CUDA_EVENT},
+     {"mtia_counters", ActivityType::MTIA_COUNTERS},
      {"glow_runtime", ActivityType::GLOW_RUNTIME},
      {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
      {"hpu_op", ActivityType::HPU_OP},

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -14,6 +14,7 @@
 #include <ctime>
 #include <fstream>
 #include <iterator>
+#include <sstream>
 #include "Config.h"
 #include "EnvMetadata.h"
 #include "TraceSpan.h"
@@ -395,6 +396,43 @@ void ChromeTraceLogger::handleGenericInstantEvent(
       op.metadataJson());
 }
 
+void ChromeTraceLogger::handleCounterEvent(
+    const libkineto::ITraceActivity& op) {
+  if (!traceOf_) {
+    return;
+  }
+
+  std::stringstream args;
+  bool first = true;
+  for (const auto& [name, value] : op.counterValues()) {
+    if (!first) {
+      args << ", ";
+    }
+    args << fmt::format("\"{}\": {}", name, value);
+    first = false;
+  }
+
+  uint64_t ts = transToRelativeTime(op.timestamp());
+  fmt::print(
+      traceOf_,
+      R"JSON(
+  {{
+    "ph": "C", "cat": "{}", "name": "{}",
+    "pid": {}, "tid": {},
+    "ts": {}.{:03},
+    "args": {{
+      {}
+    }}
+  }},)JSON",
+      toString(op.type()),
+      op.name(),
+      op.deviceId(),
+      sanitizeTid(static_cast<int32_t>(op.resourceId())),
+      ts / 1000,
+      ts % 1000,
+      args.str());
+}
+
 void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
   if (!traceOf_) {
     return;
@@ -402,6 +440,11 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
 
   if (op.type() == ActivityType::CPU_INSTANT_EVENT) {
     handleGenericInstantEvent(op);
+    return;
+  }
+
+  if (op.type() == ActivityType::MTIA_COUNTERS) {
+    handleCounterEvent(op);
     return;
   }
 

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -97,6 +97,8 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
 
   void handleGenericInstantEvent(const ITraceActivity& op);
 
+  void handleCounterEvent(const ITraceActivity& op);
+
   void handleGenericLink(const ITraceActivity& activity);
 
   void metadataToJSON(const std::unordered_map<std::string, std::string>& metadata);

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -105,7 +105,8 @@ TEST(ParseTest, ActivityTypes) {
            ActivityType::CUDA_EVENT,
            ActivityType::MTIA_RUNTIME,
            ActivityType::MTIA_INSIGHT,
-           ActivityType::MTIA_CCP_EVENTS}));
+           ActivityType::MTIA_CCP_EVENTS,
+           ActivityType::MTIA_COUNTERS}));
 
   Config cfg2;
   EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES=gpu_memcpy,gpu_MeMsEt,kernel"));


### PR DESCRIPTION
Summary:

Add a new MTIA_COUNTERS activity type for hardware counter events
(HBM bandwidth, cache bandwidth, DPE/SFU compute). Add counter event
emission support in both Chrome trace (ph: C) and Perfetto (TYPE_COUNTER)
output formats.

Key changes:
- Add MTIA_COUNTERS = 25 to ActivityType enum and its string mapping
- Add handleCounterEvent() to ChromeTraceLogger emitting "ph": "C" events
- Add handleCounterEvent() to PerfettoTraceBuilder emitting TYPE_COUNTER
  events with proper CounterDescriptor counter tracks
- Dispatch MTIA_COUNTERS activities to the counter event handler in both
  output layers

Differential Revision: D95963886
