### PR TITLE
Start flows on hipGraphLaunch

### DIFF
--- a/libkineto/src/RocprofActivity_inl.h
+++ b/libkineto/src/RocprofActivity_inl.h
@@ -149,7 +149,8 @@ inline bool RuntimeActivity<T>::flowStart() const {
       raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMalloc || raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipFree ||
       raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpy ||
       raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyAsync ||
-      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyWithStream;
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMemcpyWithStream ||
+      raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipGraphLaunch;
   return should_correlate;
 }
 


### PR DESCRIPTION
Currently, hipGraphLaunch is not linked to the corresponding kernel calls, e.g. when viewing in Perfetto. This patch modified the flow start condition to address this.

Example:
<img width="985" height="761" alt="image" src="https://github.com/user-attachments/assets/1bfddb0f-f6f3-4aec-93d9-2bb7da1837d5" />
