### PR TITLE
Integrate PyTorch's disabled tests mechanism into CI

### DIFF
--- a/.github/scripts/config_cpu.sh
+++ b/.github/scripts/config_cpu.sh
@@ -36,9 +36,9 @@ export BUILD_TEST=1
 # --- Deselected PyTorch profiler tests ---
 # Each entry is a pytest node ID passed as a --deselect argument.
 #
-# TODO: Dynamically add/remove tests to the exclusion list based on their
-# status on trunk instead of maintaining a hardcoded list of known failures.
-# This will prevent the list from becoming stale as tests get fixed upstream.
+# Dynamic skipping of known-broken/flaky upstream tests is handled via
+# DISABLED_TESTS_FILE in pytorch_build_test.sh. The hardcoded list below
+# supplements it for tests not yet tracked upstream.
 
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(

--- a/.github/scripts/config_cuda.sh
+++ b/.github/scripts/config_cuda.sh
@@ -27,9 +27,9 @@ export BUILD_TEST=1
 # --- Deselected PyTorch profiler tests ---
 # Each entry is a pytest node ID passed as a --deselect argument.
 #
-# TODO: Dynamically add/remove tests to the exclusion list based on their
-# status on trunk instead of maintaining a hardcoded list of known failures.
-# This will prevent the list from becoming stale as tests get fixed upstream.
+# Dynamic skipping of known-broken/flaky upstream tests is handled via
+# DISABLED_TESTS_FILE in pytorch_build_test.sh. The hardcoded list below
+# supplements it for tests not yet tracked upstream.
 
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(

--- a/.github/scripts/config_rocm.sh
+++ b/.github/scripts/config_rocm.sh
@@ -32,9 +32,9 @@ export BUILD_TEST=1
 # --- Deselected PyTorch profiler tests ---
 # Each entry is a pytest node ID passed as a --deselect argument.
 #
-# TODO: Dynamically add/remove tests to the exclusion list based on their
-# status on trunk instead of maintaining a hardcoded list of known failures.
-# This will prevent the list from becoming stale as tests get fixed upstream.
+# Dynamic skipping of known-broken/flaky upstream tests is handled via
+# DISABLED_TESTS_FILE in pytorch_build_test.sh. The hardcoded list below
+# supplements it for tests not yet tracked upstream.
 
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -39,6 +39,15 @@ fi
 python -m pip install --no-build-isolation -v -e .
 echo "====: Built PyTorch from source"
 
+# Download PyTorch's dynamic disabled tests list from S3. This is generated every
+# 15 minutes from DISABLED GitHub Issues in pytorch/pytorch, enabling automatic
+# skipping of known-broken/flaky tests without hardcoded deselections.
+# The function downloads, processes (converts format and filters re-enabled issues),
+# and caches the result to .pytorch-disabled-tests.json.
+python -c "from tools.stats.import_test_stats import get_disabled_tests; get_disabled_tests('.')"
+export DISABLED_TESTS_FILE=.pytorch-disabled-tests.json
+echo "====: Downloaded disabled tests list"
+
 # The deselected tests array is sourced from the architecture config above.
 DESELECT_ARGS=()
 for t in "${DESELECTED_TESTS[@]}"; do


### PR DESCRIPTION
Download PyTorch's dynamic disabled tests list from S3 before running profiler tests. This enables automatic skipping of known-broken/flaky upstream tests without manual DESELECTED_TESTS updates.

Note that we're not changing the current hardcoded list. Let's get this in, then start working on reducing that list.