### PR TITLE
Fix integer overflow in activitiesMaxGpuBufferSize for values >= 2048 MB

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -213,7 +213,7 @@ class Config : public AbstractConfig {
     return activitiesRunIterations_;
   }
 
-  [[nodiscard]] int activitiesMaxGpuBufferSize() const {
+  [[nodiscard]] int64_t activitiesMaxGpuBufferSize() const {
     return activitiesMaxGpuBufferSize_;
   }
 
@@ -453,7 +453,7 @@ class Config : public AbstractConfig {
   // Log activities to memory buffer
   bool activitiesLogToMemory_{false};
 
-  int activitiesMaxGpuBufferSize_;
+  int64_t activitiesMaxGpuBufferSize_;
   std::chrono::seconds activitiesWarmupDuration_;
   int activitiesWarmupIterations_;
   bool activitiesCudaSyncWaitEvents_;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -39,7 +39,7 @@ constexpr std::chrono::milliseconds Config::kControllerIntervalMsecs;
 constexpr milliseconds kDefaultSamplePeriodMsecs(1000);
 constexpr milliseconds kDefaultMultiplexPeriodMsecs(1000);
 constexpr milliseconds kDefaultActivitiesProfileDurationMSecs(500);
-constexpr int kDefaultActivitiesMaxGpuBufferSize(128 * 1024 * 1024);
+constexpr int64_t kDefaultActivitiesMaxGpuBufferSize(128 * 1024 * 1024);
 constexpr seconds kDefaultActivitiesWarmupDurationSecs(5);
 constexpr seconds kDefaultReportPeriodSecs(1);
 constexpr int kDefaultSamplesPerReport(1);
@@ -433,7 +433,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     }
     activitiesOnDemandTimestamp_ = timestamp();
   } else if (!name.compare(kActivitiesMaxGpuBufferSizeKey)) {
-    activitiesMaxGpuBufferSize_ = toInt32(val) * 1024 * 1024;
+    activitiesMaxGpuBufferSize_ =
+        static_cast<int64_t>(toInt32(val)) * 1024 * 1024;
   } else if (!name.compare(kActivitiesWarmupDurationSecsKey)) {
     activitiesWarmupDuration_ = seconds(toInt32(val));
   } else if (!name.compare(kActivitiesWarmupIterationsKey)) {

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -108,7 +108,7 @@ static bool nextActivityRecord(
   return record != nullptr;
 }
 
-void CuptiActivityApi::setMaxBufferSize(int size) {
+void CuptiActivityApi::setMaxBufferSize(int64_t size) {
   maxGpuBufferCount_ = 1 + size / kBufSize;
 }
 

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -57,7 +57,7 @@ class CuptiActivityApi {
   virtual const std::pair<int, size_t> processActivities(CuptiActivityBufferMap&,
                                                          const std::function<void(const CUpti_Activity*)>& handler);
 
-  void setMaxBufferSize(int size);
+  void setMaxBufferSize(int64_t size);
   void setDeviceBufferSize(size_t size);
   void setDeviceBufferPoolLimit(size_t limit);
 

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -105,7 +105,7 @@ void CuptiActivityProfiler::logGpuVersions() {
   addVersionMetadata("cuda_driver_version", std::to_string(cudaDriverVersion));
 }
 
-void CuptiActivityProfiler::setMaxGpuBufferSize(int size) {
+void CuptiActivityProfiler::setMaxGpuBufferSize(int64_t size) {
   cupti_.setMaxBufferSize(size);
 }
 

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -24,7 +24,7 @@ class CuptiActivityProfiler : public GenericActivityProfiler {
 
  protected:
   void logGpuVersions() override;
-  void setMaxGpuBufferSize(int size) override;
+  void setMaxGpuBufferSize(int64_t size) override;
   void enableGpuTracing() override;
   void disableGpuTracing() override;
   void clearGpuActivities() override;

--- a/libkineto/src/GenericActivityProfiler.h
+++ b/libkineto/src/GenericActivityProfiler.h
@@ -243,7 +243,7 @@ class GenericActivityProfiler {
   // these virtual member functions. We provide empty defaults because
   // GenericActivityProfiler can also be in cpuOnly mode.
   virtual void logGpuVersions() {}
-  virtual void setMaxGpuBufferSize([[maybe_unused]] int size) {}
+  virtual void setMaxGpuBufferSize([[maybe_unused]] int64_t size) {}
   virtual void enableGpuTracing() {}
   virtual void disableGpuTracing() {}
   virtual void clearGpuActivities() {}

--- a/libkineto/src/RocmActivityProfiler.cpp
+++ b/libkineto/src/RocmActivityProfiler.cpp
@@ -100,7 +100,7 @@ void RocmActivityProfiler::logGpuVersions() {
 #endif
 }
 
-void RocmActivityProfiler::setMaxGpuBufferSize(int size) {
+void RocmActivityProfiler::setMaxGpuBufferSize(int64_t size) {
   roc_.setMaxBufferSize(size);
 }
 

--- a/libkineto/src/RocmActivityProfiler.h
+++ b/libkineto/src/RocmActivityProfiler.h
@@ -39,7 +39,7 @@ class RocmActivityProfiler : public GenericActivityProfiler {
 
  protected:
   void logGpuVersions() override;
-  void setMaxGpuBufferSize(int size) override;
+  void setMaxGpuBufferSize(int64_t size) override;
   void enableGpuTracing() override;
   void disableGpuTracing() override;
   void clearGpuActivities() override;

--- a/libkineto/src/RocprofActivityApi.cpp
+++ b/libkineto/src/RocprofActivityApi.cpp
@@ -57,7 +57,7 @@ void RocprofActivityApi::setMaxEvents(uint32_t maxEvents) {
   d->setMaxEvents(maxEvents);
 }
 
-void RocprofActivityApi::setMaxBufferSize([[maybe_unused]] int size) {
+void RocprofActivityApi::setMaxBufferSize([[maybe_unused]] int64_t size) {
   // FIXME: implement?
   // maxGpuBufferCount_ = 1 + size / kBufSize;
 }

--- a/libkineto/src/RocprofActivityApi.h
+++ b/libkineto/src/RocprofActivityApi.h
@@ -51,7 +51,7 @@ class RocprofActivityApi {
       std::function<void(const rocprofBase*)> handler,
       std::function<void(uint64_t, uint64_t, RocLogger::CorrelationDomain)> correlationHandler);
 
-  void setMaxBufferSize(int size);
+  void setMaxBufferSize(int64_t size);
 
   std::atomic_bool stopCollection{false};
 

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -54,7 +54,7 @@ void RoctracerActivityApi::popCorrelationID(CorrelationFlowType type) {
 #endif
 }
 
-void RoctracerActivityApi::setMaxBufferSize(int size) {
+void RoctracerActivityApi::setMaxBufferSize(int64_t size) {
   // FIXME: implement?
   // maxGpuBufferCount_ = 1 + size / kBufSize;
 }

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -51,7 +51,7 @@ class RoctracerActivityApi {
       std::function<void(const rocprofBase*)> handler,
       std::function<void(uint64_t, uint64_t, RocLogger::CorrelationDomain)> correlationHandler);
 
-  void setMaxBufferSize(int size);
+  void setMaxBufferSize(int64_t size);
 
   std::atomic_bool stopCollection{false};
 

--- a/libkineto/src/plugin/aiupti/AiuptiActivityApi.cpp
+++ b/libkineto/src/plugin/aiupti/AiuptiActivityApi.cpp
@@ -68,7 +68,7 @@ static bool nextActivityRecord(
   return record != nullptr;
 }
 
-void AiuptiActivityApi::setMaxBufferSize(int size) {
+void AiuptiActivityApi::setMaxBufferSize(int64_t size) {
   maxAiuBufferCount_ = 1 + size / kBufSize;
 }
 

--- a/libkineto/src/plugin/aiupti/AiuptiActivityApi.h
+++ b/libkineto/src/plugin/aiupti/AiuptiActivityApi.h
@@ -36,7 +36,7 @@ class AiuptiActivityApi {
   virtual const std::pair<int, int> processActivities(AiuptiActivityBufferDeque&,
                                                       std::function<void(const Pti_Activity*)> handler);
 
-  void setMaxBufferSize(int size);
+  void setMaxBufferSize(int64_t size);
   // void setDeviceBufferSize(size_t size);
   // void setDeviceBufferPoolLimit(size_t limit);
 


### PR DESCRIPTION
Summary:
Fix integer overflow that occurs when `ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB` is set to 2048 MB or higher, which was causing GPU trace collection to fail silently with negative buffer sizes.

Change `activitiesMaxGpuBufferSize_` and related APIs from `int` to `int64_t` throughout the codebase to prevent overflow when multiplying megabytes by 1024*1024. The overflow occurred because `2048 * 1024 * 1024 = 2^31`, which exceeds the signed 32-bit integer maximum, resulting in a negative value that immediately terminated GPU profiling during warmup.

---
AI generated Summary & Test Plan from DEV117610005

Differential Revision: D97185175


