### PR TITLE
Move activity_type enum <> string map to .h file (#1317)

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -55,12 +55,54 @@ enum class ActivityType {
   OPTIONAL_ACTIVITY_TYPE_START = GLOW_RUNTIME,
 };
 
-const char* toString(ActivityType t);
-ActivityType toActivityType(const std::string& str);
-
 // Return an array of all activity types except COUNT
 constexpr int activityTypeCount = (int)ActivityType::ENUM_COUNT;
 constexpr int defaultActivityTypeCount = (int)ActivityType::OPTIONAL_ACTIVITY_TYPE_START;
+
+// These definitions are not part of the public Kineto API. They are inlined
+// here because some build configurations include this header
+// without linking libkineto, and toString() must resolve at compile time.
+struct _ActivityTypeName {
+  const char* name;
+  ActivityType type;
+};
+
+inline constexpr std::array<_ActivityTypeName, activityTypeCount + 1> _activityTypeNames{{
+    {"cpu_op", ActivityType::CPU_OP},
+    {"user_annotation", ActivityType::USER_ANNOTATION},
+    {"gpu_user_annotation", ActivityType::GPU_USER_ANNOTATION},
+    {"gpu_memcpy", ActivityType::GPU_MEMCPY},
+    {"gpu_memset", ActivityType::GPU_MEMSET},
+    {"kernel", ActivityType::CONCURRENT_KERNEL},
+    {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
+    {"cuda_runtime", ActivityType::CUDA_RUNTIME},
+    {"cuda_driver", ActivityType::CUDA_DRIVER},
+    {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
+    {"python_function", ActivityType::PYTHON_FUNCTION},
+    {"overhead", ActivityType::OVERHEAD},
+    {"mtia_runtime", ActivityType::MTIA_RUNTIME},
+    {"mtia_ccp_events", ActivityType::MTIA_CCP_EVENTS},
+    {"mtia_insight", ActivityType::MTIA_INSIGHT},
+    {"cuda_sync", ActivityType::CUDA_SYNC},
+    {"cuda_event", ActivityType::CUDA_EVENT},
+    {"mtia_counters", ActivityType::MTIA_COUNTERS},
+    {"glow_runtime", ActivityType::GLOW_RUNTIME},
+    {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
+    {"hpu_op", ActivityType::HPU_OP},
+    {"xpu_runtime", ActivityType::XPU_RUNTIME},
+    {"xpu_driver", ActivityType::XPU_DRIVER},
+    {"collective_comm", ActivityType::COLLECTIVE_COMM},
+    {"privateuse1_runtime", ActivityType::PRIVATEUSE1_RUNTIME},
+    {"privateuse1_driver", ActivityType::PRIVATEUSE1_DRIVER},
+    {"ENUM_COUNT", ActivityType::ENUM_COUNT},
+}};
+
+inline const char* toString(ActivityType t) {
+  return _activityTypeNames[static_cast<int>(t)].name;
+}
+
+ActivityType toActivityType(const std::string& str);
+
 std::array<ActivityType, activityTypeCount> activityTypes();
 std::array<ActivityType, defaultActivityTypeCount> defaultActivityTypes();
 

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -12,54 +12,17 @@
 
 namespace libkineto {
 
-struct ActivityTypeName {
-  const char* name;
-  ActivityType type;
-};
-
-static constexpr std::array<ActivityTypeName, activityTypeCount + 1> map{
-    {{"cpu_op", ActivityType::CPU_OP},
-     {"user_annotation", ActivityType::USER_ANNOTATION},
-     {"gpu_user_annotation", ActivityType::GPU_USER_ANNOTATION},
-     {"gpu_memcpy", ActivityType::GPU_MEMCPY},
-     {"gpu_memset", ActivityType::GPU_MEMSET},
-     {"kernel", ActivityType::CONCURRENT_KERNEL},
-     {"external_correlation", ActivityType::EXTERNAL_CORRELATION},
-     {"cuda_runtime", ActivityType::CUDA_RUNTIME},
-     {"cuda_driver", ActivityType::CUDA_DRIVER},
-     {"cpu_instant_event", ActivityType::CPU_INSTANT_EVENT},
-     {"python_function", ActivityType::PYTHON_FUNCTION},
-     {"overhead", ActivityType::OVERHEAD},
-     {"mtia_runtime", ActivityType::MTIA_RUNTIME},
-     {"mtia_ccp_events", ActivityType::MTIA_CCP_EVENTS},
-     {"mtia_insight", ActivityType::MTIA_INSIGHT},
-     {"cuda_sync", ActivityType::CUDA_SYNC},
-     {"cuda_event", ActivityType::CUDA_EVENT},
-     {"mtia_counters", ActivityType::MTIA_COUNTERS},
-     {"glow_runtime", ActivityType::GLOW_RUNTIME},
-     {"cuda_profiler_range", ActivityType::CUDA_PROFILER_RANGE},
-     {"hpu_op", ActivityType::HPU_OP},
-     {"xpu_runtime", ActivityType::XPU_RUNTIME},
-     {"xpu_driver", ActivityType::XPU_DRIVER},
-     {"collective_comm", ActivityType::COLLECTIVE_COMM},
-     {"privateuse1_runtime", ActivityType::PRIVATEUSE1_RUNTIME},
-     {"privateuse1_driver", ActivityType::PRIVATEUSE1_DRIVER},
-     {"ENUM_COUNT", ActivityType::ENUM_COUNT}}};
-
 static constexpr bool matchingOrder(int idx = 0) {
-  return map[idx].type == ActivityType::ENUM_COUNT ||
-      ((idx == static_cast<int>(map[idx].type)) && matchingOrder(idx + 1));
+  return _activityTypeNames[idx].type == ActivityType::ENUM_COUNT ||
+      ((idx == static_cast<int>(_activityTypeNames[idx].type)) &&
+       matchingOrder(idx + 1));
 }
 static_assert(matchingOrder(), "ActivityTypeName map is out of order");
 
-const char* toString(ActivityType t) {
-  return map[static_cast<int>(t)].name;
-}
-
 ActivityType toActivityType(const std::string& str) {
   for (int i = 0; i < activityTypeCount; i++) {
-    if (str == map[i].name) {
-      return map[i].type;
+    if (str == _activityTypeNames[i].name) {
+      return _activityTypeNames[i].type;
     }
   }
   throw std::invalid_argument(fmt::format("Invalid activity type: {}", str));
@@ -68,7 +31,7 @@ ActivityType toActivityType(const std::string& str) {
 std::array<ActivityType, activityTypeCount> activityTypes() {
   std::array<ActivityType, activityTypeCount> res;
   for (int i = 0; i < activityTypeCount; i++) {
-    res[i] = map[i].type;
+    res[i] = _activityTypeNames[i].type;
   }
   return res;
 }
@@ -76,7 +39,7 @@ std::array<ActivityType, activityTypeCount> activityTypes() {
 std::array<ActivityType, defaultActivityTypeCount> defaultActivityTypes() {
   std::array<ActivityType, defaultActivityTypeCount> res;
   for (int i = 0; i < defaultActivityTypeCount; i++) {
-    res[i] = map[i].type;
+    res[i] = _activityTypeNames[i].type;
   }
   return res;
 }


### PR DESCRIPTION
Summary:

A previous version of https://github.com/pytorch/pytorch/pull/177532 tried to add a pybind binding for activity_type which called `libkineto::toString(ActivityType)`. Some build configurations include the Kineto headers but do not link the compiled libkineto library, which caused an undefined symbol error at load time when `toString()` is called.

To get around this -- move the activity type enum <> string mapping and `toString()` to the header.

Reviewed By: scotts

Differential Revision: D97318652
