### PR TITLE
Disable test_schedule_function_count which is segfaulting

### DIFF
--- a/.github/scripts/config_cuda.sh
+++ b/.github/scripts/config_cuda.sh
@@ -46,6 +46,9 @@ DESELECTED_TESTS=(
   # https://github.com/pytorch/kineto/issues/1308
   test/profiler/test_profiler.py::TestProfiler::test_record_function_fast
 
+  # https://github.com/pytorch/kineto/issues/1319
+  test/profiler/test_profiler.py::TestProfiler::test_schedule_function_count
+
   test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize
   test/profiler/test_profiler.py::TestExperimentalUtils::test_profiler_debug_autotuner
   test/profiler/test_torch_tidy.py::TestTorchTidyProfiler::test_tensorimpl_invalidation_scalar_args


### PR DESCRIPTION
Summary: As titled. Seeing consistent failures since yesterday, and I'm unable to repro locally. Looks similar to https://github.com/pytorch/kineto/issues/1308

Differential Revision: D97524728


