### PR TITLE
Add host_name to OSS Kineto trace metadata via gethostname() (#1323)

### DIFF
--- a/libkineto/include/EnvMetadata.h
+++ b/libkineto/include/EnvMetadata.h
@@ -9,10 +9,18 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <array>
 #include <cstdint>
 #include <cstdlib>
 #include <string>
 #include <unordered_map>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#pragma comment(lib, "ws2_32.lib")
+#else
+#include <unistd.h>
+#endif
 
 namespace libkineto {
 
@@ -29,7 +37,7 @@ inline const std::unordered_map<EnvVar, const char*> K_ENV_VAR_MAP = {
 };
 
 // Returns a map of (env_var_name, env_value) for all environment variables
-// that are currently set. Only includes entries where the env var exists.
+// that are currently set. Also captures the hostname of the current machine.
 inline std::unordered_map<std::string, std::string> getEnvMetadata() {
   std::unordered_map<std::string, std::string> result;
   for (const auto& [key, name] : K_ENV_VAR_MAP) {
@@ -37,6 +45,18 @@ inline std::unordered_map<std::string, std::string> getEnvMetadata() {
       result[name] = fmt::format("\"{}\"", val);
     }
   }
+
+  // Capture hostname for per-rank host identification in distributed training.
+  // $HOSTNAME is not guaranteed in non-interactive or containerized environments,
+  // so we use gethostname() which reads the kernel hostname directly.
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) == 0) {
+    hostname.back() = '\0';
+    if (hostname[0] != '\0') {
+      result["host_name"] = fmt::format("\"{}\"", hostname.data());
+    }
+  }
+
   return result;
 }
 

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -1089,6 +1089,13 @@ TEST(CuptiActivityProfiler, MetadataJsonFormatingTest) {
       jsonData["PT_PROFILER_JOB_NAME"].get<std::string>(), "test_training_job");
   EXPECT_EQ(jsonData["PT_PROFILER_JOB_VERSION"].get<std::string>(), "2");
   EXPECT_EQ(jsonData["PT_PROFILER_JOB_ATTEMPT_INDEX"].get<std::string>(), "5");
+
+  // Verify hostname is non-empty when present (gethostname may not be
+  // available in all environments, but when it succeeds the value must
+  // not be empty).
+  if (jsonData.contains("host_name")) {
+    EXPECT_FALSE(jsonData["host_name"].get<std::string>().empty());
+  }
 #endif
 
   // Clean up environment variables


### PR DESCRIPTION
Summary:

Kineto's OSS Chrome trace logger captures profiler metadata (job name, version, attempt index) from environment variables but does not record the hostname of the machine producing the trace. In distributed training, this makes it impossible to map per-rank traces back to specific hosts for topology-aware performance analysis.

This change adds a `gethostname()` call to `getEnvMetadata()` in `EnvMetadata.h`, writing the result under the key `"host_name"`. Downstream trace consumers can now identify which host produced each rank's trace.

Why `gethostname()` and not an environment variable:
- `$HOSTNAME` is a shell-level variable, not guaranteed to be set in non-interactive or containerized environments
- Job-scheduler env vars (e.g. `PT_PROFILER_*`) are set at the job level, so a hypothetical `PT_PROFILER_HOSTNAME` would be identical across all ranks in a job
- `gethostname()` reads the kernel hostname, which container runtimes typically set per-container, giving true per-rank host identity

`addEnvVarsToMetadata()` in `output_json.cpp` gives precedence to caller-supplied metadata, so trace loggers that already provide `host_name` through other means will have their value preserved.

`gethostname()` is POSIX (Linux/macOS/Android via `unistd.h`) and available on Windows via `winsock2.h`.

Reviewed By: hjli-creator

Differential Revision: D97387341
