### PR TITLE
Fix Lingering INT32 Overflow (#1324)

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -13,6 +13,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <set>
 #include <string>
@@ -213,7 +214,7 @@ class Config : public AbstractConfig {
     return activitiesRunIterations_;
   }
 
-  [[nodiscard]] int activitiesMaxGpuBufferSize() const {
+  [[nodiscard]] int64_t activitiesMaxGpuBufferSize() const {
     return activitiesMaxGpuBufferSize_;
   }
 
@@ -453,7 +454,7 @@ class Config : public AbstractConfig {
   // Log activities to memory buffer
   bool activitiesLogToMemory_{false};
 
-  int activitiesMaxGpuBufferSize_;
+  int64_t activitiesMaxGpuBufferSize_;
   std::chrono::seconds activitiesWarmupDuration_;
   int activitiesWarmupIterations_;
   bool activitiesCudaSyncWaitEvents_;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -39,7 +39,7 @@ constexpr std::chrono::milliseconds Config::kControllerIntervalMsecs;
 constexpr milliseconds kDefaultSamplePeriodMsecs(1000);
 constexpr milliseconds kDefaultMultiplexPeriodMsecs(1000);
 constexpr milliseconds kDefaultActivitiesProfileDurationMSecs(500);
-constexpr int kDefaultActivitiesMaxGpuBufferSize(128 * 1024 * 1024);
+constexpr int64_t kDefaultActivitiesMaxGpuBufferSize(128 * 1024 * 1024);
 constexpr seconds kDefaultActivitiesWarmupDurationSecs(5);
 constexpr seconds kDefaultReportPeriodSecs(1);
 constexpr int kDefaultSamplesPerReport(1);
@@ -433,7 +433,8 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     }
     activitiesOnDemandTimestamp_ = timestamp();
   } else if (!name.compare(kActivitiesMaxGpuBufferSizeKey)) {
-    activitiesMaxGpuBufferSize_ = toInt32(val) * 1024 * 1024;
+    activitiesMaxGpuBufferSize_ =
+        static_cast<int64_t>(toInt32(val)) * 1024 * 1024;
   } else if (!name.compare(kActivitiesWarmupDurationSecsKey)) {
     activitiesWarmupDuration_ = seconds(toInt32(val));
   } else if (!name.compare(kActivitiesWarmupIterationsKey)) {
@@ -615,7 +616,7 @@ void Config::printActivityProfilerConfig(std::ostream& s) const {
   fmt::print(
       s,
       "  Max GPU buffer size: {:.0f}MB\n",
-      activitiesMaxGpuBufferSize() / 1024.0 / 1024.0);
+      static_cast<double>(activitiesMaxGpuBufferSize()) / 1024.0 / 1024.0);
 
   std::vector<std::string> activities;
   activities.reserve(selectedActivityTypes_.size());

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -108,7 +108,7 @@ static bool nextActivityRecord(
   return record != nullptr;
 }
 
-void CuptiActivityApi::setMaxBufferSize(int size) {
+void CuptiActivityApi::setMaxBufferSize(int64_t size) {
   maxGpuBufferCount_ = 1 + size / kBufSize;
 }
 
@@ -147,7 +147,7 @@ void CuptiActivityApi::bufferRequested(
     size_t* maxNumRecords) {
   std::lock_guard<std::mutex> guard(mutex_);
   LOG(VERBOSE) << "CUPTI buffer requested";
-  if (static_cast<int>(allocatedGpuTraceBuffers_.size()) >=
+  if (static_cast<int64_t>(allocatedGpuTraceBuffers_.size()) >=
       maxGpuBufferCount_) {
     stopCollection = true;
     LOG(WARNING) << "Exceeded max GPU buffer count ("

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -57,7 +57,7 @@ class CuptiActivityApi {
   virtual const std::pair<int, size_t> processActivities(CuptiActivityBufferMap&,
                                                          const std::function<void(const CUpti_Activity*)>& handler);
 
-  void setMaxBufferSize(int size);
+  void setMaxBufferSize(int64_t size);
   void setDeviceBufferSize(size_t size);
   void setDeviceBufferPoolLimit(size_t limit);
 
@@ -70,7 +70,7 @@ class CuptiActivityApi {
   static void preConfigureCUPTI();
 
  private:
-  int maxGpuBufferCount_{0};
+  int64_t maxGpuBufferCount_{0};
   CuptiActivityBufferMap allocatedGpuTraceBuffers_;
   std::unique_ptr<CuptiActivityBufferMap> readyGpuTraceBuffers_;
   std::mutex mutex_;

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -105,7 +105,7 @@ void CuptiActivityProfiler::logGpuVersions() {
   addVersionMetadata("cuda_driver_version", std::to_string(cudaDriverVersion));
 }
 
-void CuptiActivityProfiler::setMaxGpuBufferSize(int size) {
+void CuptiActivityProfiler::setMaxGpuBufferSize(int64_t size) {
   cupti_.setMaxBufferSize(size);
 }
 

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -24,7 +24,7 @@ class CuptiActivityProfiler : public GenericActivityProfiler {
 
  protected:
   void logGpuVersions() override;
-  void setMaxGpuBufferSize(int size) override;
+  void setMaxGpuBufferSize(int64_t size) override;
   void enableGpuTracing() override;
   void disableGpuTracing() override;
   void clearGpuActivities() override;

--- a/libkineto/src/GenericActivityProfiler.h
+++ b/libkineto/src/GenericActivityProfiler.h
@@ -243,7 +243,7 @@ class GenericActivityProfiler {
   // these virtual member functions. We provide empty defaults because
   // GenericActivityProfiler can also be in cpuOnly mode.
   virtual void logGpuVersions() {}
-  virtual void setMaxGpuBufferSize([[maybe_unused]] int size) {}
+  virtual void setMaxGpuBufferSize([[maybe_unused]] int64_t size) {}
   virtual void enableGpuTracing() {}
   virtual void disableGpuTracing() {}
   virtual void clearGpuActivities() {}

--- a/libkineto/src/RocmActivityProfiler.cpp
+++ b/libkineto/src/RocmActivityProfiler.cpp
@@ -100,7 +100,7 @@ void RocmActivityProfiler::logGpuVersions() {
 #endif
 }
 
-void RocmActivityProfiler::setMaxGpuBufferSize(int size) {
+void RocmActivityProfiler::setMaxGpuBufferSize(int64_t size) {
   roc_.setMaxBufferSize(size);
 }
 

--- a/libkineto/src/RocmActivityProfiler.h
+++ b/libkineto/src/RocmActivityProfiler.h
@@ -39,7 +39,7 @@ class RocmActivityProfiler : public GenericActivityProfiler {
 
  protected:
   void logGpuVersions() override;
-  void setMaxGpuBufferSize(int size) override;
+  void setMaxGpuBufferSize(int64_t size) override;
   void enableGpuTracing() override;
   void disableGpuTracing() override;
   void clearGpuActivities() override;

--- a/libkineto/src/RocprofActivityApi.cpp
+++ b/libkineto/src/RocprofActivityApi.cpp
@@ -57,7 +57,7 @@ void RocprofActivityApi::setMaxEvents(uint32_t maxEvents) {
   d->setMaxEvents(maxEvents);
 }
 
-void RocprofActivityApi::setMaxBufferSize([[maybe_unused]] int size) {
+void RocprofActivityApi::setMaxBufferSize([[maybe_unused]] int64_t size) {
   // FIXME: implement?
   // maxGpuBufferCount_ = 1 + size / kBufSize;
 }

--- a/libkineto/src/RocprofActivityApi.h
+++ b/libkineto/src/RocprofActivityApi.h
@@ -51,7 +51,7 @@ class RocprofActivityApi {
       std::function<void(const rocprofBase*)> handler,
       std::function<void(uint64_t, uint64_t, RocLogger::CorrelationDomain)> correlationHandler);
 
-  void setMaxBufferSize(int size);
+  void setMaxBufferSize(int64_t size);
 
   std::atomic_bool stopCollection{false};
 

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -54,7 +54,7 @@ void RoctracerActivityApi::popCorrelationID(CorrelationFlowType type) {
 #endif
 }
 
-void RoctracerActivityApi::setMaxBufferSize(int size) {
+void RoctracerActivityApi::setMaxBufferSize(int64_t size) {
   // FIXME: implement?
   // maxGpuBufferCount_ = 1 + size / kBufSize;
 }

--- a/libkineto/src/RoctracerActivityApi.h
+++ b/libkineto/src/RoctracerActivityApi.h
@@ -51,7 +51,7 @@ class RoctracerActivityApi {
       std::function<void(const rocprofBase*)> handler,
       std::function<void(uint64_t, uint64_t, RocLogger::CorrelationDomain)> correlationHandler);
 
-  void setMaxBufferSize(int size);
+  void setMaxBufferSize(int64_t size);
 
   std::atomic_bool stopCollection{false};
 

--- a/libkineto/src/plugin/aiupti/AiuptiActivityApi.cpp
+++ b/libkineto/src/plugin/aiupti/AiuptiActivityApi.cpp
@@ -68,7 +68,7 @@ static bool nextActivityRecord(
   return record != nullptr;
 }
 
-void AiuptiActivityApi::setMaxBufferSize(int size) {
+void AiuptiActivityApi::setMaxBufferSize(int64_t size) {
   maxAiuBufferCount_ = 1 + size / kBufSize;
 }
 

--- a/libkineto/src/plugin/aiupti/AiuptiActivityApi.h
+++ b/libkineto/src/plugin/aiupti/AiuptiActivityApi.h
@@ -36,7 +36,7 @@ class AiuptiActivityApi {
   virtual const std::pair<int, int> processActivities(AiuptiActivityBufferDeque&,
                                                       std::function<void(const Pti_Activity*)> handler);
 
-  void setMaxBufferSize(int size);
+  void setMaxBufferSize(int64_t size);
   // void setDeviceBufferSize(size_t size);
   // void setDeviceBufferPoolLimit(size_t limit);
 
@@ -44,7 +44,7 @@ class AiuptiActivityApi {
   int64_t flushOverhead{0};
 
  private:
-  int maxAiuBufferCount_{0};
+  int64_t maxAiuBufferCount_{0};
   AiuptiActivityBufferDeque allocatedAiuTraceBuffers_;
   std::unique_ptr<AiuptiActivityBufferDeque> readyAiuTraceBuffers_;
   std::mutex mutex_;


### PR DESCRIPTION
Summary:

Upcast several values that hold byte numbers from INT32 to INT64 to prevent numerical overflow. Overflow issues became noticeable after D95426862 added additional type guards.

Reviewed By: scotts

Differential Revision: D97592032


