### PR TITLE
Emit USDT logger messages on profiler start/stop (#1325)

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -412,6 +412,7 @@ void ActivityProfilerController::toggleCollectionDynamic(const bool enable) {
 
 void ActivityProfilerController::startTrace() {
   UST_LOGGER_MARK_COMPLETED(kWarmUpStage);
+  USDT_EMIT_START_TRACE();
   profiler_->startTrace(std::chrono::system_clock::now());
 }
 bool ActivityProfilerController::isActive() {
@@ -451,6 +452,7 @@ void ActivityProfilerController::popUserCorrelationId() {
 std::unique_ptr<ActivityTraceInterface> ActivityProfilerController::
     stopTrace() {
   profiler_->stopTrace(std::chrono::system_clock::now());
+  USDT_EMIT_STOP_TRACE();
   UST_LOGGER_MARK_COMPLETED(kCollectionStage);
   auto logger = std::make_unique<MemoryTraceLogger>(profiler_->config());
   profiler_->processTrace(*logger);

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -29,6 +29,7 @@
 #define UST_LOGGER_MARK_COMPLETED(stage)
 #define USDT_LOGGER_EMIT_MESSAGE(usdt_type)
 #define USDT_EMIT_START_TRACE()
+#define USDT_EMIT_STOP_TRACE()
 
 #else // !USE_GOOGLE_LOG
 #include <stdio.h>
@@ -254,6 +255,7 @@ struct __to_constant__ {
 #define UST_LOGGER_MARK_COMPLETED(stage) LOG(libkineto::LoggerOutputType::STAGE) << "Completed Stage: " << stage
 
 #define USDT_LOGGER_EMIT_MESSAGE(usdt_type) LOG(libkineto::LoggerOutputType::USDT) << usdt_type
-#define USDT_EMIT_START_TRACE() USDT_LOGGER_EMIT_MESSAGE("StartTrace")
+#define USDT_EMIT_START_TRACE() USDT_LOGGER_EMIT_MESSAGE("profiler_start")
+#define USDT_EMIT_STOP_TRACE() USDT_LOGGER_EMIT_MESSAGE("profiler_stop")
 
 #endif // USE_GOOGLE_LOG


### PR DESCRIPTION
Summary:

Add `USDT_LOGGER_EMIT_MESSAGE` calls in `ActivityProfilerController` to
emit "profiler_start" and "profiler_stop" messages through the Logger
observer system. This allows USDT-based LoggerCollector implementations
to receive notifications when GPU profiling begins and ends.

Reviewed By: scotts

Differential Revision: D97795063


