### PR TITLE
Ensure that async doesn't loop while sync is active (#1327)

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -263,7 +263,10 @@ void ActivityProfilerController::profilerLoop() {
       next_wakeup_time += Config::kControllerIntervalMsecs;
     }
 
-    if (profiler_->isActive() && !profiler_->isCollectingMemorySnapshot()) {
+    // Use syncTraceActive_ so we don't step into the loop while sync trace is
+    // running
+    if (profiler_->isActive() && !profiler_->isCollectingMemorySnapshot() &&
+        !syncTraceActive_) {
       next_wakeup_time = profiler_->performRunLoopStep(now, next_wakeup_time);
       VLOG(1) << "Profiler loop: "
               << duration_cast<milliseconds>(system_clock::now() - now).count()
@@ -389,6 +392,7 @@ void ActivityProfilerController::prepareTrace(const Config& config) {
   // requests from other sources (signal, daemon).
   // Cancel any ongoing request and refuse new ones.
   auto now = system_clock::now();
+  syncTraceActive_ = true;
   if (profiler_->isActive()) {
     LOG(WARNING) << "Cancelling current trace request in order to start "
                  << "higher priority synchronous request";
@@ -462,6 +466,7 @@ std::unique_ptr<ActivityTraceInterface> ActivityProfilerController::
   logger->setLoggerMetadata(std::move(loggerMD));
 
   profiler_->reset();
+  syncTraceActive_ = false;
   return std::make_unique<ActivityTrace>(std::move(logger), loggerFactory());
 }
 

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -103,6 +103,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   std::vector<std::shared_ptr<LoggerCollector>> loggerCollectors_;
   std::thread* profilerThreads_[ThreadType::THREAD_MAX_COUNT] = {nullptr};
   std::atomic_bool stopRunloop_{false};
+  std::atomic_bool syncTraceActive_{false};
   std::atomic<std::int64_t> iterationCount_{-1};
   ConfigLoader& configLoader_;
 };


### PR DESCRIPTION
Summary:

When an OD trace finishes, there's nothing preventing `performRunLoopStep` from continuing to step. This can cause bad behavior if an auto-trace session starts and keeps driving state transitions that also cause `performRunLoopStep` to transition as well.

We have a bigger refactor coming to separate out these two trace modes which is a cleaner way to address this, however we need a short term solution too. For now we will block the async loop if we know that sync is active. It's easier for us to track the sync state because it's driven by the main profiler loop instead of background threads.

As always -- the big issue is that `isActive()` can represent either the sync and async paths, and we can't tell which one is active from this single boolean.

Reviewed By: sanrise, divyanshk

Differential Revision: D98011780
