### PR TITLE
rocprofv3 fix

### DIFF
--- a/libkineto/rocprofiler_hide.lds
+++ b/libkineto/rocprofiler_hide.lds
@@ -1,0 +1,4 @@
+{
+  global: *;
+  local: rocprofiler_*;
+};


### PR DESCRIPTION
Summary:
## Summary
tl;dr. D92225068 broke rocprofv3 when running ISA-level profiling (i.e. ATT): P2250348439.

D92225068 added rocprofiler-sdk-lazy as a dependency for kineto's AMD GPU support. The lazy library generates assembly trampolines (stubs) for all 77 rocprofiler_* SDK functions. These stubs get statically linked into the final Python interpreter binary and appear in its dynamic symbol table.

When rocprofv3 --att LD_PRELOADs the real librocprofiler-sdk.so, the interpreter's lazy stubs shadow the real SDK functions (ELF symbol resolution: executable > LD_PRELOAD). During _dl_init, the SDK's ATT configuration calls rocprofiler_configure_dispatch_thread_trace_service through the lazy stub → dlopen/dlsym on a partially-initialized SDK → null ostream dereference → SIGSEGV.

Fix (2 parts):

Linker version script (rocprofiler_hide.lds): Hides all rocprofiler_* symbols from the dynamic symbol table so they can't shadow the LD_PRELOAD'd real SDK:

{ global: *; local: rocprofiler_*; };

Reviewed By: merengue171

Differential Revision: D98325321


