### PR TITLE
approximate clock fast path for arm (#1333)

### DIFF
--- a/libkineto/src/ApproximateClock.h
+++ b/libkineto/src/ApproximateClock.h
@@ -32,6 +32,8 @@
 #else
 #undef KINETO_RDTSC
 #endif
+#elif defined(__aarch64__) && !defined(__CUDACC__) && !defined(__HIPCC__)
+#define KINETO_ARMTSC
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -62,6 +64,14 @@ inline time_t getTime([[maybe_unused]] bool allow_monotonic = false) {
 #endif
 }
 
+#if defined(KINETO_ARMTSC)
+inline uint64_t getArmApproximateTime() {
+  uint64_t val;
+  __asm__ __volatile__("mrs %0, cntvct_el0" : "=r"(val));
+  return val;
+}
+#endif
+
 // We often do not need to capture true wall times. If a fast mechanism such
 // as TSC is available we can use that instead and convert back to epoch time
 // during post processing. This greatly reduce the clock's contribution to
@@ -73,6 +83,8 @@ inline time_t getTime([[maybe_unused]] bool allow_monotonic = false) {
 inline auto getApproximateTime() {
 #if defined(KINETO_RDTSC)
   return static_cast<uint64_t>(__rdtsc());
+#elif defined(KINETO_ARMTSC)
+  return getArmApproximateTime();
 #else
   return getTime();
 #endif

--- a/libkineto/test/ApproximateClockTest.cpp
+++ b/libkineto/test/ApproximateClockTest.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "src/ApproximateClock.h"
+
+#include <chrono>
+
+#include <gtest/gtest.h>
+
+using namespace libkineto;
+
+TEST(ApproximateClockTest, ReturnsNonZero) {
+  approx_time_t t = getApproximateTime();
+  EXPECT_NE(t, 0);
+}
+
+TEST(ApproximateClockTest, IsMonotonic) {
+  constexpr int kIterations = 1000;
+  approx_time_t prev = getApproximateTime();
+  for (int i = 0; i < kIterations; ++i) {
+    approx_time_t curr = getApproximateTime();
+    ASSERT_GE(curr, prev) << "Clock went backwards at iteration " << i;
+    prev = curr;
+  }
+}
+
+TEST(ApproximateClockTest, AdvancesOverTime) {
+  approx_time_t t0 = getApproximateTime();
+
+  // We use this pattern several times in these tests. We keep checking
+  // approximate time until we find its value has increased, with a 10 ms
+  // timeout. If we hit the timeout, the test fails. On platforms such as
+  // x86, the first iteration should succeed as approximate time is tied
+  // to the clock cycle. On some other platforms, such as aarch64, it may take
+  // several clock cycles before approximate time actually increases.
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(10);
+  approx_time_t t1;
+  do {
+    t1 = getApproximateTime();
+  } while (t1 == t0 && std::chrono::steady_clock::now() < deadline);
+  EXPECT_GT(t1, t0);
+}
+
+TEST(ApproximateClockTest, MeasurePairCapturesBothClocks) {
+  auto pair = ApproximateClockToUnixTimeConverter::measurePair();
+  // Wall time should be a plausible epoch timestamp (after 2020, before 2100).
+  constexpr libkineto::time_t kYear2020 = 1577836800LL * 1'000'000'000;
+  constexpr libkineto::time_t kYear2100 = 4102444800LL * 1'000'000'000;
+  EXPECT_GT(pair.t_, kYear2020);
+  EXPECT_LT(pair.t_, kYear2100);
+  EXPECT_NE(pair.approx_t_, 0) << "Approximate time should be non-zero";
+}
+
+TEST(ApproximateClockTest, ConverterProducesPlausibleEpochTime) {
+  ApproximateClockToUnixTimeConverter converter;
+  auto convert = converter.makeConverter();
+
+  approx_time_t approx_now = getApproximateTime();
+  auto converted_ns = convert(approx_now);
+
+  constexpr libkineto::time_t kYear2020 = 1577836800LL * 1'000'000'000;
+  constexpr libkineto::time_t kYear2100 = 4102444800LL * 1'000'000'000;
+  EXPECT_GT(converted_ns, kYear2020);
+  EXPECT_LT(converted_ns, kYear2100);
+}
+
+TEST(ApproximateClockTest, ConverterPreservesOrdering) {
+  ApproximateClockToUnixTimeConverter converter;
+  auto convert = converter.makeConverter();
+
+  approx_time_t t0 = getApproximateTime();
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(10);
+  approx_time_t t1;
+  do {
+    t1 = getApproximateTime();
+  } while (t1 == t0 && std::chrono::steady_clock::now() < deadline);
+
+  auto wall0 = convert(t0);
+  auto wall1 = convert(t1);
+  EXPECT_GT(wall1, wall0) << "Converted times must preserve ordering";
+}
+
+TEST(ApproximateClockTest, GetTimeIsPositiveAndAdvances) {
+  libkineto::time_t t0 = getTime();
+  EXPECT_GT(t0, 0);
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(10);
+  libkineto::time_t t1;
+  do {
+    t1 = getTime();
+  } while (t1 == t0 && std::chrono::steady_clock::now() < deadline);
+  EXPECT_GT(t1, t0);
+}
+
+TEST(ApproximateClockTest, DefaultTimeConverterIsIdentity) {
+  auto& converter = get_time_converter();
+  constexpr approx_time_t kTestValue = 123456789;
+  EXPECT_EQ(converter(kTestValue), static_cast<libkineto::time_t>(kTestValue));
+}

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -26,6 +26,14 @@ endif()
 
 include_directories(${LIBKINETO_DIR})
 link_libraries(fmt::fmt-header-only)
+# ApproximateClockTest
+add_executable(ApproximateClockTest ApproximateClockTest.cpp)
+target_link_libraries(ApproximateClockTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(ApproximateClockTest)
+
 # ConfigTest
 add_executable(ConfigTest ConfigTest.cpp)
 target_link_libraries(ConfigTest PRIVATE


### PR DESCRIPTION
Summary:

Implements fast-path for ARM approximate clock.

There's a similar PR out for PyTorch, as these files are copy-pasted from there: https://github.com/pytorch/pytorch/pull/178639

Reviewed By: jiannanWang

Differential Revision: D98514697
