### PR TITLE
Remove INFO logs from kineto trace metadata to fix invalid JSON (#1336)

### DIFF
--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -748,7 +748,10 @@ GenericActivityProfiler::getLoggerMetadata() {
   // Save logs from LoggerCollector objects into Trace metadata.
   auto LoggerMDMap = loggerCollectorMetadata_->extractCollectorMetadata();
   for (auto& md : LoggerMDMap) {
-    loggerMD[toString(md.first)] = md.second;
+    // Only WARNING and ERROR are included in trace metadata.
+    if (md.first == WARNING || md.first == ERROR) {
+      loggerMD[toString(md.first)] = md.second;
+    }
   }
 #endif // !USE_GOOGLE_LOG
   return loggerMD;

--- a/libkineto/test/LoggerObserverTest.cpp
+++ b/libkineto/test/LoggerObserverTest.cpp
@@ -166,6 +166,23 @@ TEST(LoggerObserverTest, MultipleLoggerCollectors) {
   Logger::removeLoggerObserver(c2.get());
 }
 
+TEST(LoggerObserverTest, GetLoggerMetadataOnlyIncludesWarningAndError) {
+  GenericActivityProfiler profiler(/*cpuOnly=*/true);
+  profiler.configure(Config{}, {});
+
+  LOG(INFO) << InfoTestStr;
+  LOG(WARNING) << WarningTestStr;
+  LOG(ERROR) << ErrorTestStr;
+
+  const auto loggerMD = profiler.getLoggerMetadata();
+  EXPECT_EQ(loggerMD.size(), 2);
+  EXPECT_EQ(loggerMD.count("INFO"), 0);
+  EXPECT_EQ(loggerMD.count("WARNING"), 1);
+  EXPECT_EQ(loggerMD.count("ERROR"), 1);
+
+  profiler.reset();
+}
+
 #endif // !USE_GOOGLE_LOG
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:

## Problem
Kineto’s LoggerCollector can capture INFO logs that include unescaped double quotes from activity metadata (example: cudaEvent "event_id": 64, ...). Those quotes can break the JSON, causing json trace parsers to fail.

## Fix

Rather than filtering INFO logs at the LoggerCollector level (which is a generic collection class), this PR filters them in GenericActivityProfiler::getLoggerMetadata(), the point where logs are written into the trace. Only WARNING and ERROR entries make it into the metadata map written to the JSON trace.

This makes the intent clearer: the filtering is a trace-writing concern, not a general logging concern. LoggerCollector remains generic and continues to collect all log levels (INFO, WARNING, ERROR) as before.

Note: This bug only affects dyno traces, not PyTorch profiler traces. The LoggerCollector metadata is written to the trace file through ChromeTraceLogger::finalizeTrace(), used by kineto's on-demand controller path. The Python torch.profiler API uses its own export path that does not include logger metadata.

## Verification

 Generated traces using `buck2 run @//mode/opt //kineto/libkineto/fb/integration_tests:pytorch_resnet_integration_test -- --enable_profiling --trace_handler=local --num_iters 110`:

 BEFORE (original kineto) — trace contains INFO section with 10 entries:
  "INFO": [
    "INFO:2026-03-30 16:01:31 2519601:2519601 GenericActivityProfiler.cpp:526] Enabling GPU tracing with max buffer size 128MB)",
    "INFO:2026-03-30 16:01:31 2519601:2519601 GenericActivityProfiler.cpp:450] [Profiler = CuptiRangeProfiler] Evaluating whether to run child profiler.",
    "INFO:2026-03-30 16:01:31 2519601:2519601 GenericActivityProfiler.cpp:463] [Profiler = CuptiRangeProfiler] Not running child profiler.",
    "INFO:2026-03-30 16:01:31 2519601:2519601 GenericActivityProfiler.cpp:563] Tracing starting in 6s",
    "INFO:2026-03-30 16:01:31 2519601:2519601 GenericActivityProfiler.cpp:568] Tracing will end in 7s",
    "INFO:2026-03-30 16:01:31 2519601:2519601 GenericActivityProfiler.cpp:146] Processing 1 CPU buffers",
    "INFO:2026-03-30 16:01:31 2519601:2519601 CuptiActivityProfiler.cpp:196] Processed 239252 GPU records (9221680 bytes)",
    "INFO:2026-03-30 16:01:31 2519601:2519601 GenericActivityProfiler.cpp:218] Record counts: Out-of-range = 11888, Blocklisted runtime = 74589, Invalid ext correlations = 0, CPU GPU out-of-order = 0, Unexpected CUDA events = 0, GPU stopped early? = 0",
    "INFO:2026-03-30 16:01:31 2519601:2519601 GenericActivityProfiler.cpp:654] CPU Traces Recorded:",
    "INFO:2026-03-30 16:01:31 2519601:2519601 GenericActivityProfiler.cpp:657] PyTorch Profiler: 1 span(s) recorded"
  ],

 AFTER (patched kineto) — no INFO section in trace.

Reviewed By: scotts

Differential Revision: D98257725
