### PR TITLE
Fix GPU trace collection on ROCm by ensuring early rocprofiler-sdk tool registration

### DIFF
--- a/libkineto/src/RocprofLogger.cpp
+++ b/libkineto/src/RocprofLogger.cpp
@@ -762,8 +762,28 @@ void RocprofLogger::setMaxEvents(uint32_t maxBufferSize) {
   maxBufferSize_ = maxBufferSize;
 }
 
+void RocprofLogger::ensureRegistered() {
+  int status = 0;
+  rocprofiler_is_initialized(&status);
+  VLOG(0) << "rocprofiler_is_initialized returned " << status;
+  if (status == 0) {
+    VLOG(0) << "Forcing rocprofiler-sdk tool registration";
+    auto result = rocprofiler_force_configure(&rocprofiler_configure);
+    if (result == ROCPROFILER_STATUS_SUCCESS) {
+      VLOG(0) << "rocprofiler-sdk tool registration completed successfully";
+      singleton().registered_ = true;
+    } else {
+      LOG(WARNING) << "rocprofiler_force_configure failed with status "
+                   << result;
+    }
+  } else if (status == 1) {
+    singleton().registered_ = true;
+  }
+}
+
 void RocprofLogger::startLogging() {
   if (!registered_) {
+    ensureRegistered();
   }
 
   externalCorrelationEnabled_ = true;

--- a/libkineto/src/RocprofLogger.h
+++ b/libkineto/src/RocprofLogger.h
@@ -37,6 +37,7 @@ class RocprofLogger {
   static void pushCorrelationID(uint64_t id, RocLogger::CorrelationDomain type);
   static void popCorrelationID(RocLogger::CorrelationDomain type);
 
+  static void ensureRegistered();
   void startLogging();
   void stopLogging();
   void clearLogs();

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -23,6 +23,9 @@
 #include "CuptiRangeProfiler.h"
 #include "EventProfilerController.h"
 #endif
+#ifdef HAS_ROCTRACER
+#include "RocprofLogger.h"
+#endif
 #ifdef HAS_XPUPTI
 #include "plugin/xpupti/XpuptiActivityApi.h"
 #include "plugin/xpupti/XpuptiActivityProfiler.h"
@@ -167,6 +170,12 @@ void libkineto_init(bool cpuOnly, [[maybe_unused]] bool logOnError) {
     CuptiActivityApi::forceLoadCupti();
   }
 #endif // HAS_CUPTI
+
+#ifdef HAS_ROCTRACER
+  if (!cpuOnly) {
+    RocprofLogger::ensureRegistered();
+  }
+#endif
 
   ConfigLoader& config_loader = libkineto::api().configLoader();
   libkineto::api().registerProfiler(


### PR DESCRIPTION
Summary:
On ROCm/AMD systems, PyTorch profiler traces were missing GPU kernel events
(0 GPU records). The root cause is a race condition in rocprofiler-sdk tool
registration: if any HIP/GPU activity occurs before Kineto registers as a
profiling tool, rocprofiler-sdk skips the registration callback and no GPU
kernel events are captured.

The fix adds `RocprofLogger::ensureRegistered()` which explicitly calls
`rocprofiler_force_configure()` to guarantee tool registration happens
early, regardless of HIP initialization order. This is called:
1. From `libkineto_init()` — before any profiler setup
2. From `startLogging()` — as a fallback if init didn't run

This follows the same pattern used by XLA's ROCm profiler integration.

Additionally, `rocprofiler_hide.lds` hides all `rocprofiler_*` symbols on
AMD builds, which prevents the passive symbol-discovery registration
mechanism. The explicit `force_configure` call bypasses this limitation.

Differential Revision: D99105057


