### PR TITLE
Fix stream wait events referencing future correlation IDs (#1339)

### DIFF
--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -51,11 +51,12 @@ struct WaitEventInfo {
   uint32_t correlationId;
 };
 
-// Map (ctx, eventId) -> (stream, corr Id) that recorded the CUDA event
-std::unordered_map<CtxEventPair, WaitEventInfo, CtxEventPairHash>&
+// Map (ctx, eventId) -> list of WaitEventInfo for all recorded events.
+std::unordered_map<CtxEventPair, std::vector<WaitEventInfo>, CtxEventPairHash>&
 waitEventMap() {
-  static std::unordered_map<CtxEventPair, WaitEventInfo, CtxEventPairHash>
-      waitEventMap_;
+  static std::
+      unordered_map<CtxEventPair, std::vector<WaitEventInfo>, CtxEventPairHash>
+          waitEventMap_;
   return waitEventMap_;
 }
 
@@ -168,6 +169,7 @@ void CuptiActivityProfiler::popCorrelationIdImpl(CorrelationFlowType type) {
 void CuptiActivityProfiler::onResetTraceData() {
   cupti_.teardownContext();
   KernelRegistry::singleton()->clear();
+  waitEventMap().clear();
 }
 
 void CuptiActivityProfiler::onFinalizeTrace(
@@ -313,11 +315,25 @@ void CuptiActivityProfiler::handleOverheadActivity(
 
 static std::optional<WaitEventInfo> getWaitEventInfo(
     uint32_t ctx,
-    uint32_t eventId) {
+    uint32_t eventId,
+    uint32_t queryCorrelationId) {
   auto key = CtxEventPair{ctx, eventId};
   auto it = waitEventMap().find(key);
   if (it != waitEventMap().end()) {
-    return it->second;
+    // Records are sorted by correlationId. Find the most recent record
+    // that precedes the query (i.e., the last record with
+    // correlationId < queryCorrelationId).
+    const std::vector<WaitEventInfo>& vec = it->second;
+    std::vector<WaitEventInfo>::const_iterator pos = std::upper_bound(
+        vec.begin(),
+        vec.end(),
+        queryCorrelationId,
+        [](uint32_t val, const WaitEventInfo& info) {
+          return val < info.correlationId;
+        });
+    if (pos != vec.begin()) {
+      return *std::prev(pos);
+    }
   }
   return std::nullopt;
 }
@@ -331,10 +347,18 @@ void CuptiActivityProfiler::handleCudaEventActivity(
           << " streamId=" << activity->streamId
           << " contextId=" << activity->contextId;
 
-  // Update the stream, corrID the cudaEvent was last recorded on
+  // Record the stream and correlationId, sorted for binary search in
+  // getWaitEventInfo().
   auto key = CtxEventPair{activity->contextId, activity->eventId};
-  waitEventMap()[key] =
-      WaitEventInfo{activity->streamId, activity->correlationId};
+  std::vector<WaitEventInfo>& vec = waitEventMap()[key];
+  std::vector<WaitEventInfo>::iterator pos = std::lower_bound(
+      vec.begin(),
+      vec.end(),
+      activity->correlationId,
+      [](const WaitEventInfo& info, uint32_t val) {
+        return info.correlationId < val;
+      });
+  vec.insert(pos, WaitEventInfo{activity->streamId, activity->correlationId});
 
   // Create and log the CUDA event activity
   const ITraceActivity* linked =
@@ -381,8 +405,8 @@ void CuptiActivityProfiler::handleCudaSyncActivity(
     int32_t src_stream = -1;
     int32_t src_corrid = -1;
     if (isEventSync(activity->type)) {
-      auto maybe_wait_event_info =
-          getWaitEventInfo(activity->contextId, activity->cudaEventId);
+      auto maybe_wait_event_info = getWaitEventInfo(
+          activity->contextId, activity->cudaEventId, activity->correlationId);
       if (maybe_wait_event_info) {
         src_stream = maybe_wait_event_info->stream;
         src_corrid = maybe_wait_event_info->correlationId;

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -1314,3 +1314,154 @@ TEST_F(CuptiActivityProfilerTest, JsonGPUIDSortTest) {
   }
 #endif
 }
+
+TEST_F(CuptiActivityProfilerTest, StreamWaitEventFutureCorrelation) {
+  // When a CUDA event is re-recorded (same eventId, new correlationId), CUPTI
+  // may deliver the later record before the wait. Verify the wait links to the
+  // most recent record that precedes it, not the future re-record.
+  std::vector<std::string> log_modules({"CuptiActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 500;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+  profiler.recordThreadInfo();
+
+  auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+      start_time_ns, start_time_ns + duration_ns);
+  cpuOps->addOp("op1", start_time_ns + 10, start_time_ns + 30, 1);
+  profiler.transferCpuTrace(std::move(cpuOps));
+
+  // Chronological order: record(corrId=100), wait(corrId=101),
+  // re-record(corrId=200). Delivery order: record(100), re-record(200),
+  // wait(101).
+  auto gpuOps = std::make_unique<MockCuptiActivityBuffer>();
+  gpuOps->addRuntimeActivity(
+      CUDA_LAUNCH_KERNEL, start_time_ns + 13, start_time_ns + 18, 1);
+  gpuOps->addKernelActivity(start_time_ns + 50, start_time_ns + 70, 1);
+  gpuOps->addCudaEventActivity(100, 42, 1, 0);
+  gpuOps->addCudaEventActivity(200, 42, 1, 0);
+  gpuOps->addSyncActivity(
+      start_time_ns + 200,
+      start_time_ns + 202,
+      101,
+      CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT,
+      1,
+      42);
+  cuptiActivities_.activityBuffer = std::move(gpuOps);
+
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+
+  bool foundWaitEvent = false;
+  for (auto& activity : *trace.activities()) {
+    if (activity->name() == "Stream Wait Event") {
+      foundWaitEvent = true;
+      auto metadata = activity->metadataJson();
+      auto json = nlohmann::json::parse("{" + metadata + "}");
+      EXPECT_EQ(json["wait_on_cuda_event_record_corr_id"], 100)
+          << "Should reference corrId 100 (the record before the wait), got: "
+          << metadata;
+      EXPECT_EQ(json["wait_on_cuda_event_id"], 42)
+          << "Should reference eventId 42, got: " << metadata;
+    }
+  }
+  EXPECT_TRUE(foundWaitEvent) << "Stream Wait Event activity not found";
+}
+
+TEST_F(CuptiActivityProfilerTest, WaitEventMapClearedOnReset) {
+  // Verify waitEventMap is cleared between profiling sessions so that a wait
+  // event in session 2 does not pick up a stale record from session 1.
+  std::vector<std::string> log_modules({"CuptiActivityProfiler.cpp"});
+  SET_LOG_VERBOSITY_LEVEL(2, log_modules);
+
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 500;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+
+  // Session 1: record eventId=42 with corrId=100, then reset.
+  {
+    CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
+    profiler.configure(*cfg_, start_time);
+    profiler.startTrace(start_time);
+    profiler.stopTrace(start_time + nanoseconds(duration_ns));
+    libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+    profiler.recordThreadInfo();
+
+    auto cpuOps = std::make_unique<MockCpuActivityBuffer>(
+        start_time_ns, start_time_ns + duration_ns);
+    cpuOps->addOp("op1", start_time_ns + 10, start_time_ns + 30, 1);
+    profiler.transferCpuTrace(std::move(cpuOps));
+
+    auto gpuOps = std::make_unique<MockCuptiActivityBuffer>();
+    gpuOps->addRuntimeActivity(
+        CUDA_LAUNCH_KERNEL, start_time_ns + 13, start_time_ns + 18, 1);
+    gpuOps->addKernelActivity(start_time_ns + 50, start_time_ns + 70, 1);
+    gpuOps->addCudaEventActivity(100, 42, 1, 0);
+    cuptiActivities_.activityBuffer = std::move(gpuOps);
+
+    auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+    profiler.processTrace(*logger);
+    profiler.reset();
+  }
+
+  // Session 2: no cudaEventRecord for eventId=42, but a wait references it.
+  {
+    CuptiActivityProfiler profiler2(cuptiActivities_, /*cpu only*/ false);
+    int64_t start_time_ns2 = start_time_ns + 10000;
+    auto start_time2 = time_point<system_clock>(nanoseconds(start_time_ns2));
+
+    auto cfg2 = std::make_unique<Config>();
+    cfg2->validate(std::chrono::system_clock::now());
+
+    profiler2.configure(*cfg2, start_time2);
+    profiler2.startTrace(start_time2);
+    profiler2.stopTrace(start_time2 + nanoseconds(duration_ns));
+    libkineto::get_time_converter() = [](approx_time_t t) { return t; };
+    profiler2.recordThreadInfo();
+
+    auto cpuOps2 = std::make_unique<MockCpuActivityBuffer>(
+        start_time_ns2, start_time_ns2 + duration_ns);
+    cpuOps2->addOp("op1", start_time_ns2 + 10, start_time_ns2 + 30, 1);
+    profiler2.transferCpuTrace(std::move(cpuOps2));
+
+    auto gpuOps2 = std::make_unique<MockCuptiActivityBuffer>();
+    gpuOps2->addRuntimeActivity(
+        CUDA_LAUNCH_KERNEL, start_time_ns2 + 13, start_time_ns2 + 18, 1);
+    gpuOps2->addKernelActivity(start_time_ns2 + 50, start_time_ns2 + 70, 1);
+    gpuOps2->addSyncActivity(
+        start_time_ns2 + 200,
+        start_time_ns2 + 202,
+        501,
+        CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT,
+        1,
+        42);
+    cuptiActivities_.activityBuffer = std::move(gpuOps2);
+
+    auto logger2 = std::make_unique<MemoryTraceLogger>(*cfg2);
+    profiler2.processTrace(*logger2);
+    profiler2.reset();
+
+    ActivityTrace trace2(std::move(logger2), loggerFactory);
+
+    for (auto& activity : *trace2.activities()) {
+      if (activity->name() == "Stream Wait Event") {
+        auto metadata = activity->metadataJson();
+        auto json = nlohmann::json::parse("{" + metadata + "}");
+        EXPECT_EQ(json["wait_on_cuda_event_record_corr_id"], -1)
+            << "Expected default corrId -1 (no record in session 2), got: "
+            << metadata;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary:
### Problem

`waitEventMap()` stored only the most recent `cudaEventRecord` for each `(context, eventId)` pair. This caused two bugs:

Bug 1 Future correlation ID: A CUDA event can be recorded multiple times (re-used). CUPTI may deliver the activity records out of buffer order. If a later `cudaEventRecord` (higher correlationId) was delivered before the `cudaStreamWaitEvent` was processed, it would overwrite the map entry. The wait event would then be linked to a future `cudaEventRecord`.

Bug 2 Stale entries across sessions: The static `waitEventMap()` was never cleared between profiling sessions. If a CUDA event ID was reused in a subsequent session, the wait event would pick up a correlation ID from the previous session.

###  Fix

Bug 1: Change `waitEventMap()` from `unordered_map<CtxEventPair, WaitEventInfo>` to `unordered_map<CtxEventPair, vector<WaitEventInfo>>`, storing all records for each `(context, eventId)`. Pass `correlationId` of the wait event into `getWaitEventInfo` and use `std::upper_bound` to find the most recent `cudaEventRecord` that occurred strictly before the wait (largest `correlationId ≤ queryCorrelationId`).

**Note**: since now we record all WaitEventInfo in the vector, it may accumulate during the profiling session. I'm not sure if that would be a problem for taking up the memory.

 Bug 2: Clear waitEventMap() in onResetTraceData().

 The sorted insert (`std::lower_bound`) at record time keeps the vector ordered, making the lookup O(log n) instead of O(n).

###  Tests
- `StreamWaitEventFutureCorrelation`: simulates out-of-order CUPTI delivery where a re-record (`corrId=200`) arrives before the wait (`corrId=101`). Verify the wait links to `corrId=100`, not `corrId=200`.
-  `WaitEventMapClearedOnReset`: runs two back-to-back profiling sessions with the same event ID. Verify the second session does not pick up the correlation ID from the first.


Reviewed By: ryanzhang22

Differential Revision: D99131994

Pulled By: jiannanWang


