### PR TITLE
Move Stream Sync events to a new row in JSON trace export (#1356)

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -814,6 +814,37 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
 
   int64_t device = op.deviceId();
   int64_t resource = op.resourceId();
+
+  // Move Stream Sync events to a dedicated row so they don't overlap with
+  // kernel events on the same stream in the trace viewer.
+  if (op.type() == ActivityType::CUDA_SYNC && op.name() == "Stream Sync") {
+    int64_t syncTid = resource + kSyncStreamTidOffset;
+    int64_t key = (device << 32) | syncTid;
+    if (syncStreamMetadataEmitted_.insert(key).second) {
+      int64_t metaTime = transToRelativeTime(ts);
+      // clang-format off
+      fmt::print(traceOf_, R"JSON(
+  {{
+    "name": "thread_name", "ph": "M", "ts": {}.{:03}, "pid": {}, "tid": {},
+    "args": {{
+      "name": "stream {} (sync)"
+    }}
+  }},
+  {{
+    "name": "thread_sort_index", "ph": "M", "ts": {}.{:03}, "pid": {}, "tid": {},
+    "args": {{
+      "sort_index": {}
+    }}
+  }},)JSON",
+          metaTime/1000, metaTime%1000, device, syncTid,
+          resource,
+          metaTime/1000, metaTime%1000, device, syncTid,
+          resource);
+      // clang-format on
+    }
+    resource = syncTid;
+  }
+
   // TODO: Remove this once legacy tools are updated.
   std::string op_name = op.name() == "kernel" ? "Kernel" : op.name();
   sanitizeStrForJSON(op_name);
@@ -875,11 +906,17 @@ void ChromeTraceLogger::handleLink(
   }
 
   int64_t ts = transToRelativeTime(e.timestamp());
+  int64_t tid = e.resourceId();
+  // Use the virtual tid for Stream Sync events to match the row
+  // they were placed on in handleActivity().
+  if (e.type() == ActivityType::CUDA_SYNC && e.name() == "Stream Sync") {
+    tid = tid + kSyncStreamTidOffset;
+  }
   writeFlowEvent(
       /*type=*/type,
       /*id=*/id,
       /*pid=*/e.deviceId(),
-      /*tid=*/sanitizeTid(e.resourceId()),
+      /*tid=*/sanitizeTid(tid),
       /*ts=*/ts,
       /*cat=*/name,
       /*name=*/name);

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
@@ -203,6 +204,14 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
   // pg_name, value is pgConfig that will be used to populate pg_config in
   // distributedInfo of trace
   std::unordered_map<std::string, pgConfig> pgMap_ = {};
+
+  // Offset added to stream ID for CUDA_SYNC events to place them on a
+  // separate row from kernel events in the Chrome Trace JSON output.
+  static constexpr int64_t kSyncStreamTidOffset = 1000000;
+
+  // Tracks which (device, virtualTid) pairs have had thread_name metadata
+  // emitted, to avoid duplicates.
+  std::unordered_set<int64_t> syncStreamMetadataEmitted_;
 };
 
 // std::chrono header start

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -653,6 +653,40 @@ TEST_F(CuptiActivityProfilerTest, SyncTrace) {
   struct stat buf{};
   fstat(fd, &buf);
   EXPECT_GT(buf.st_size, 100);
+
+  // Verify Stream Sync events are on a separate row from kernel events
+  // in the JSON trace output (tid offset by kSyncStreamTidOffset).
+  {
+    std::ifstream traceFile(filename);
+    std::string traceStr(
+        (std::istreambuf_iterator<char>(traceFile)),
+        std::istreambuf_iterator<char>());
+    auto traceJson = nlohmann::json::parse(traceStr);
+    int64_t kernelTid = -1;
+    int64_t streamSyncTid = -1;
+    bool foundSyncRowMeta = false;
+    for (const auto& event : traceJson["traceEvents"]) {
+      if (event.value("name", "") == "Kernel") {
+        kernelTid = event.value("tid", (int64_t)-1);
+      }
+      if (event.value("name", "") == "Stream Sync") {
+        streamSyncTid = event.value("tid", (int64_t)-1);
+      }
+      if (event.value("name", "") == "thread_name") {
+        auto args = event.value("args", nlohmann::json::object());
+        std::string threadName = args.value("name", "");
+        if (threadName.find("sync") != std::string::npos) {
+          foundSyncRowMeta = true;
+        }
+      }
+    }
+    EXPECT_NE(kernelTid, -1) << "Expected kernel events in trace";
+    EXPECT_NE(streamSyncTid, -1) << "Expected Stream Sync event in trace";
+    EXPECT_NE(kernelTid, streamSyncTid)
+        << "Stream Sync should be on a different tid than kernels";
+    EXPECT_TRUE(foundSyncRowMeta)
+        << "Expected thread_name metadata for sync row";
+  }
 #endif
 }
 


### PR DESCRIPTION
Summary:

Stream Sync events (from cudaStreamSynchronize) are placed on the same GPU
stream row as kernel events in Chrome Trace JSON output. Since Stream Sync
uses CPU-side timestamps that overlap with still-running kernels, Perfetto
drops the overlapping events, making Stream Sync invisible in the trace
viewer.

Fix: In the JSON export path only, emit Stream Sync events on a virtual tid
(streamId + 1000000) with a "stream N (sync)" label. The same sort_index as
the original stream places the sync row right below it in Perfetto. The
in-memory event data and protobuf export are unchanged.

Reviewed By: ryanzhang22

Differential Revision: D100110463


