### PR TITLE
Stop allocating CUPTI buffers after exceeding max buffer count (#1362)

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -151,6 +151,14 @@ void CuptiActivityApi::bufferRequested(
     LOG(WARNING) << "Exceeded max GPU buffer count ("
                  << allocatedGpuTraceBuffers_.size()
                  << " >= " << maxGpuBufferCount_ << ") - terminating tracing";
+    // Return null buffer to CUPTI. Per the CUPTI documentation for
+    // CUpti_BuffersCallbackRequestFunc: "If set to NULL then no buffer is
+    // returned." CUPTI will drop activity records, which are counted by
+    // cuptiActivityGetNumDroppedRecords.
+    *buffer = nullptr;
+    *size = 0;
+    *maxNumRecords = 0;
+    return;
   }
 
   auto buf = std::make_unique<CuptiActivityBuffer>(kBufSize);
@@ -166,6 +174,9 @@ std::unique_ptr<CuptiActivityBufferMap> CuptiActivityApi::activityBuffers() {
   {
     std::lock_guard<std::mutex> guard(mutex_);
     if (allocatedGpuTraceBuffers_.empty()) {
+      if (readyGpuTraceBuffers_) {
+        return std::move(readyGpuTraceBuffers_);
+      }
       return nullptr;
     }
   }


### PR DESCRIPTION
Summary:

Fixes a runaway-memory allocation bug. When the allocated buffer count exceeds `maxGpuBufferCount_`, the code set `stopCollection=true` but continued to allocate a new 4MB buffer on every callback invocation. Since CUPTI keeps calling bufferRequested from its internal thread and the profiler runloop only checks `stopCollection` every ~1s (`kControllerIntervalMsecs`), this caused unbounded memory growth.

Fix: `return *buffer = nullptr` when the limit is hit. Per the CUPTI documentation for `CUpti_BuffersCallbackRequestFunc`, "If set to NULL then no buffer is returned." CUPTI will drop subsequent activity records, which are counted via `cuptiActivityGetNumDroppedRecords`.

XLA follows a similar pattern when it wants to indicate a problem with buffer allocation: https://github.com/openxla/xla/blob/a8d210262bee397cfaec30fe6f24b165da7cb21d/xla/backends/profiler/gpu/cupti_tracer.cc#L1679-L1684

Reviewed By: ryanzhang22

Differential Revision: D100731798
