### PR TITLE
Fix data race on CuptiActivityApi::externalCorrelationEnabled_

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -61,7 +61,8 @@ CuptiActivityApi& CuptiActivityApi::singleton() {
 }
 
 void CuptiActivityApi::pushCorrelationID(int id, CorrelationFlowType type) {
-  if (!singleton().externalCorrelationEnabled_) {
+  if (!singleton().externalCorrelationEnabled_.load(
+          std::memory_order_relaxed)) {
     return;
   }
   VLOG(2) << "pushCorrelationID(" << id << ")";
@@ -77,7 +78,8 @@ void CuptiActivityApi::pushCorrelationID(int id, CorrelationFlowType type) {
 }
 
 void CuptiActivityApi::popCorrelationID(CorrelationFlowType type) {
-  if (!singleton().externalCorrelationEnabled_) {
+  if (!singleton().externalCorrelationEnabled_.load(
+          std::memory_order_relaxed)) {
     return;
   }
   switch (type) {
@@ -334,7 +336,7 @@ void CuptiActivityApi::enableCuptiActivities(
   CUPTI_CALL(cuptiActivityRegisterCallbacks(
       bufferRequestedTrampoline, bufferCompletedTrampoline));
 
-  externalCorrelationEnabled_ = false;
+  externalCorrelationEnabled_.store(false, std::memory_order_relaxed);
   for (const auto& activity : selected_activities) {
     if (activity == ActivityType::GPU_MEMCPY) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY));
@@ -347,7 +349,7 @@ void CuptiActivityApi::enableCuptiActivities(
     }
     if (activity == ActivityType::EXTERNAL_CORRELATION) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION));
-      externalCorrelationEnabled_ = true;
+      externalCorrelationEnabled_.store(true, std::memory_order_relaxed);
     }
     if (activity == ActivityType::CUDA_SYNC) {
 #if CUDA_VERSION >= 13000
@@ -413,7 +415,7 @@ void CuptiActivityApi::disableCuptiActivities(
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_OVERHEAD));
     }
   }
-  externalCorrelationEnabled_ = false;
+  externalCorrelationEnabled_.store(false, std::memory_order_relaxed);
 }
 
 void CuptiActivityApi::teardownContext() {

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -76,7 +76,7 @@ class CuptiActivityApi {
   std::mutex mutex_;
   std::atomic<uint32_t> tracingEnabled_{0};
   std::atomic<uint32_t> tearingDown_{0};
-  bool externalCorrelationEnabled_{false};
+  std::atomic<bool> externalCorrelationEnabled_{false};
 
   int processActivitiesForBuffer(uint8_t* buf,
                                  size_t validSize,


### PR DESCRIPTION
Summary:
Fixes a field that was a plain `bool` but was written to and read from multiple threads. As a plain `bool`, this is a data race and undefined behavior under the C++ memory model. While unlikely to cause issues on x86 in practice, a compiler is free to optimize away the unsynchronized read, and TSan will flag it.

We make it a `std::atomic<bool>` with relaxed ordering. That is sufficient because there is no ordering dependency between this flag and other shared state — a stale read simply means one extra or one fewer correlation ID push/pop, which is harmless. Relaxed ordering avoids adding memory fence overhead on the hot path.

Differential Revision: D100995634


