### PR TITLE
Expose isGpuCollectionStopped() through Kineto's public API

### DIFF
--- a/libkineto/include/ActivityProfilerInterface.h
+++ b/libkineto/include/ActivityProfilerInterface.h
@@ -34,6 +34,9 @@ class ActivityProfilerInterface {
   virtual bool isActive() {
     return false;
   }
+  virtual bool isStopped() const {
+    return false;
+  }
 
   // *** Asynchronous API ***
   // Instead of starting and stopping the trace manually, provide a start time

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -149,6 +149,10 @@ bool ActivityProfilerController::isActive() {
   return profiler_->isActive();
 }
 
+bool ActivityProfilerController::isStopped() const {
+  return profiler_->isStopped();
+}
+
 void ActivityProfilerController::transferCpuTrace(
     std::unique_ptr<libkineto::CpuTraceBuffer> cpuTrace) {
   profiler_->transferCpuTrace(std::move(cpuTrace));

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -61,6 +61,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   std::unique_ptr<ActivityTraceInterface> stopTrace();
 
   bool isActive();
+  bool isStopped() const;
 
   void transferCpuTrace(std::unique_ptr<libkineto::CpuTraceBuffer> cpuTrace);
 

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -92,6 +92,10 @@ bool ActivityProfilerProxy::isActive() {
   return controller_->isActive();
 }
 
+bool ActivityProfilerProxy::isStopped() const {
+  return controller_->isStopped();
+}
+
 void ActivityProfilerProxy::pushCorrelationId(uint64_t id) {
   controller_->pushCorrelationId(id);
 }

--- a/libkineto/src/ActivityProfilerProxy.h
+++ b/libkineto/src/ActivityProfilerProxy.h
@@ -45,6 +45,7 @@ class ActivityProfilerProxy : public ActivityProfilerInterface {
   }
 
   bool isActive() override;
+  bool isStopped() const override;
 
   void recordThreadInfo() override;
 

--- a/libkineto/src/GenericActivityProfiler.h
+++ b/libkineto/src/GenericActivityProfiler.h
@@ -116,6 +116,9 @@ class GenericActivityProfiler {
   bool isActive() const {
     return currentRunloopState_ != RunloopState::WaitForRequest;
   }
+  bool isStopped() const {
+    return isGpuCollectionStopped();
+  }
   bool isCollectingMemorySnapshot() const {
     return currentRunloopState_ == RunloopState::CollectMemorySnapshot;
   }


### PR DESCRIPTION
Summary:
When the sync profiling path is active and we've reached our limit of CUPTI activity buffers, `CuptiActivityApi::bufferRequested()` sets `stopCollection = true`. The async path already checks this via `isGpuCollectionStopped()` in `performRunLoopStep()`, but the sync path has no way to query it — the method is protected on `GenericActivityProfiler` and not exposed through the public `ActivityProfilerInterface`.

This diff plumbs this status up through to the public interface.

A follow-up change in PyTorch will use this API in the Python profiler's `step()` method to detect that the profiling had to stop early and force an early `stop_trace`. 

We've already fixed it so that when there's too many activity buffers, CUPTI should stop requesting buffers (D100731798 / https://github.com/pytorch/kineto/pull/1362). But we still don't have a way to tell the Python layer that profiling should stop in synchronous tracing.

Differential Revision: D101044411


