### PR TITLE
Fix toggle test

### DIFF
--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -593,11 +593,12 @@ void GenericActivityProfiler::toggleCollectionDynamic(const bool enable) {
     return;
   }
   toggleState_.store(enable);
+  if (!enable) {
+    disableGpuTracing();
+  }
   synchronizeGpuDevice();
   if (enable) {
     enableGpuTracing();
-  } else {
-    disableGpuTracing();
   }
 }
 

--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -593,6 +593,14 @@ void GenericActivityProfiler::toggleCollectionDynamic(const bool enable) {
     return;
   }
   toggleState_.store(enable);
+
+  // The ordering of conditions and synchronization is deliberate. We
+  // intentionally synchronize:
+  //
+  //   - AFTER we disable
+  //   - BEFORE we enable
+  //
+  // Both to prevent the synchronization event from showing up in traces.
   if (!enable) {
     disableGpuTracing();
   }


### PR DESCRIPTION
Fix `test_dynamic_toggle` failure caused by toggle's own CUDA events leaking into trace.

PR #1362 (D100731798) fixed a bug in `activityBuffers()` where `readyGpuTraceBuffers_` was ignored when `allocatedGpuTraceBuffers_` was empty. A side effect is that CUPTI buffers flushed during `toggleCollectionDynamic(false)` are now correctly returned during trace processing. This surfaced a latent issue: `synchronizeGpuDevice()` calls `cudaDeviceSynchronize()` while CUPTI is still enabled, so CUPTI captures that call as a "cudaDeviceSynchronize" runtime activity. The event contains "cuda" in its name and fails the PyTorch `test_dynamic_toggle` assertion that no GPU events appear after the toggle.

Fix by disabling CUPTI activity collection before the device sync when toggling off. The sync still serves its purpose — draining in-flight GPU work and flushing pre-existing CUPTI buffers — but the sync call itself is no longer instrumented.