### PR TITLE
tb_plugin: fix 'occured' -> 'occurred' in run.py comment

### DIFF
--- a/tb_plugin/torch_tb_profiler/run.py
+++ b/tb_plugin/torch_tb_profiler/run.py
@@ -282,7 +282,7 @@ class RunProfile:
 
             return curves, peaks
 
-        # NOTE: this should have been occured in frontend
+        # NOTE: this should have have occurred in frontend
         def patch_curves_for_step_plot(curves: Dict[str, List]):
             # For example, if a curve is [(0, 0), (1, 1), (2,2)], the line plot
             # is a stright line. Interpolating it as [(0, 0), (1, 0), (1, 1),


### PR DESCRIPTION
Comment in `tb_plugin/torch_tb_profiler/run.py` line 285 reads `should have been occured in frontend`. Fixed grammar to `should have occurred in frontend`. Comment-only change.