### PR TITLE
Stop ConfigLoader polling thread before folly singleton destruction (T265237207)

### DIFF
--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -87,6 +87,11 @@ class ConfigLoader {
 
   std::string getConfString();
 
+  // Stop the background polling thread. Safe to call multiple times.
+  // Exposed for embedders that need to join the thread before other
+  // singletons are destroyed.
+  void stopThread();
+
  private:
   ConfigLoader();
   ~ConfigLoader();
@@ -94,7 +99,6 @@ class ConfigLoader {
   IDaemonConfigLoader* daemonConfigLoader();
 
   void startThread();
-  void stopThread();
   void updateConfigThread();
   void updateBaseConfig();
 


### PR DESCRIPTION
Summary:
`folly::SingletonVault::fireShutdownTimer` aborts `repro_afg_tools --lowering_type local` (and similar binaries) about 5 minutes after main returns. Investigation shows kineto's `ConfigLoader` polling thread keeps calling the destroyed `folly::Singleton<DynoConfigClient>` during this window because `ConfigLoader` is a Meyers' (function-local-static) singleton — its destructor (which calls `stopThread()` to join the polling thread) only runs at C++ static-destruction time, AFTER folly's `std::atexit`-driven `destroyInstancesFinal()`.

Fix: register a process-lifetime `folly::CancellationCallback` on `SingletonVault::singleton()->getDestructionCancellationToken()` from `kineto/libkineto/fb/init.cpp`. The vault fires its cancellation token at the very top of `destroyInstances()` (folly/Singleton.cpp:375), before any singleton's destructor runs. The callback calls the existing private `stopThread()` (now exposed publicly in ConfigLoader.h with a doc comment explaining the use case) which joins the polling thread synchronously. Wrapped in `folly::Indestructible` so its own destructor never races static destruction — same pattern used in:
- data_preproc/client/SessionManagementHandler.cpp:198 (FunctionScheduler shutdown)
- ods3/instrumentation/cpp2/{prod,dev}/InstrumentReader.cpp:21 (final flush)
- hphp/facebook/extensions/ods3/PeriodicCollector.cpp:21 (flushAndShutdown)

13+ existing call sites of `getDestructionCancellationToken` in fbcode confirm this is the standard pattern for Meyers'-singleton background threads that touch folly singletons.

This is a kineto-only change — `fb/` is the Meta-only sibling of `src/` and already depends on folly. Adding the callback there preserves the OSS layering decision from D23550982 ("Refactor for OSS 8/n: Move FB-specific code out of ConfigLoader") that explicitly removed folly from `src/ConfigLoader`. No OSS code change.

CAVEAT: This fix removes the kineto polling-thread piece of T265237207 — the kineto polling thread is provably joined before any folly singleton destruction. However, after this fix `repro_afg_tools` STILL aborts via `fireShutdownTimer` because of a SECOND, independent hang in `facebook::servicerouter::cpp2::EventBasePoolHolder` destructor (next singleton in destruction order after `falcon::FalconRolloutExecutor`). That ServiceRouter bug is a separate root cause and is NOT in scope for this diff — it'll be tracked as a follow-up. The kineto noise during shutdown was a real bug regardless.

Reviewed By: scotts, mzzchy

Differential Revision: D101296012


