### PR TITLE
Stop ConfigLoader polling thread before folly singleton destruction (T265237207) (#1371)

### DIFF
--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -87,6 +87,11 @@ class ConfigLoader {
 
   std::string getConfString();
 
+  // Stop the background polling thread. Safe to call multiple times.
+  // Exposed for embedders that need to join the thread before other
+  // singletons are destroyed.
+  void stopThread();
+
  private:
   ConfigLoader();
   ~ConfigLoader();
@@ -94,7 +99,6 @@ class ConfigLoader {
   IDaemonConfigLoader* daemonConfigLoader();
 
   void startThread();
-  void stopThread();
   void updateConfigThread();
   void updateBaseConfig();
 


### PR DESCRIPTION
Summary:

Make ConfigLoader::stopThread() public

Move stopThread() from private to public in ConfigLoader.h. This lets embedders that manage their own singleton lifetimes join the config-polling thread before dependent singletons are destroyed, preventing use-after-destroy during process shutdown.

Safe to call multiple times (idempotent). No behavior change for existing callers — the method already existed, this just widens access.

Reviewed By: scotts, mzzchy

Differential Revision: D101296012


