### PR TITLE
Fix fork-time deadlock between ConfigLoader and threadSafeForkPrepare

### DIFF
--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -166,13 +166,17 @@ void ConfigLoader::startThread() {
   }
 }
 
+void ConfigLoader::signalStop() {
+  stopFlag_ = true;
+  {
+    std::lock_guard<std::mutex> lock(updateThreadMutex_);
+    updateThreadCondVar_.notify_one();
+  }
+}
+
 void ConfigLoader::stopThread() {
+  signalStop();
   if (updateThread_) {
-    stopFlag_ = true;
-    {
-      std::lock_guard<std::mutex> lock(updateThreadMutex_);
-      updateThreadCondVar_.notify_one();
-    }
     if (updateThread_->joinable()) {
       updateThread_->join();
     }

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -87,8 +87,13 @@ class ConfigLoader {
 
   std::string getConfString();
 
-  // Stop the background polling thread. Safe to call multiple times.
-  // Exposed for embedders that need to join the thread before other
+  // Signal the background polling thread to stop without joining it.
+  // Use this when joining is unsafe (e.g., the thread may be blocked on a
+  // lock held by the caller). The thread will exit on its next loop iteration.
+  void signalStop();
+
+  // Stop the background polling thread and join it. Safe to call multiple
+  // times. Exposed for embedders that need to join the thread before other
   // singletons are destroyed.
   void stopThread();
 


### PR DESCRIPTION
Summary:
Fix a deadlock when `torch._thread_safe_fork` (used by `torch.compile`'s
`SubprocPool`) triggers `threadSafeForkPrepare()` while kineto's ConfigLoader
background thread is active.

The deadlock occurs because:
1. `threadSafeForkPrepare()` acquires exclusive `guardLock`, then calls
   `SingletonVault::destroyInstances()`
2. The `kShutdownConfigLoaderOnSingletonVaultDestroy` callback fires and calls
   `ConfigLoader::stopThread()`, which tries to `join()` the ConfigLoader thread
3. The ConfigLoader thread is blocked trying to acquire a shared
   `ThreadSafeForkGuard` in `DynoConfigLoader::readBaseConfig()` — but cannot
   because `guardLock` is held exclusively by the forking thread

This is a classic AB-BA deadlock: Thread A holds guardLock and waits for
Thread B to join; Thread B waits for guardLock (shared) and cannot exit.

The fix splits `stopThread()` into a non-blocking `signalStop()` (sets
`stopFlag_` + notifies condvar) and the existing `stopThread()` (signal + join).
The singleton vault callback now uses `signalStop()`. The ConfigLoader thread
exits cooperatively on its next loop iteration after `guardLock` is released.
The actual join is deferred to `~ConfigLoader()` at static-destruction time.

Differential Revision: D102071920


