### PR TITLE
Remove bad linux guard from test files

### DIFF
--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -18,10 +18,11 @@
 #include <cstdint>
 #include <cstdio>
 
+#include <unistd.h>
+
 #ifdef __linux__
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #endif
 
 #include "include/Config.h"
@@ -76,13 +77,11 @@ const TraceSpan& defaultTraceSpan() {
   return span;
 }
 
-#ifdef __linux__
 void createTempTraceFile(char* filename) {
   const int fd = mkstemps(filename, 5);
   ASSERT_GE(fd, 0) << "mkstemps failed for " << filename;
   close(fd);
 }
-#endif
 } // namespace
 
 // Provides ability to easily create a few test CPU-side ops

--- a/libkineto/test/CuptiRangeProfilerTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerTest.cpp
@@ -10,11 +10,12 @@
 #include <array>
 #include <set>
 
+#include <unistd.h>
+
 #ifdef __linux__
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #endif
 
 #include <fmt/format.h>
@@ -57,13 +58,11 @@ static ICuptiRBProfilerSessionFactory& getFactory() {
   return factory_;
 }
 
-#ifdef __linux__
 void createTempTraceFile(char* filename) {
   const int fd = mkstemps(filename, 5);
   ASSERT_GE(fd, 0) << "mkstemps failed for " << filename;
   close(fd);
 }
-#endif
 
 // Create mock CUPTI profiler events and simuulate context
 // creation and kernel launches

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -16,11 +16,12 @@
 #include <chrono>
 #include <cstdlib>
 
+#include <unistd.h>
+
 #ifdef __linux__
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #endif
 
 #include "include/Config.h"
@@ -82,13 +83,11 @@ const TraceSpan& defaultTraceSpan() {
   return span;
 }
 
-#ifdef __linux__
 void createTempTraceFile(char* filename) {
   const int fd = mkstemps(filename, 5);
   ASSERT_GE(fd, 0) << "mkstemps failed for " << filename;
   close(fd);
 }
-#endif
 } // namespace
 
 // Provides ability to easily create a test CPU-side ops


### PR DESCRIPTION
Summary:
I missed these linux guards -- this is wrong, the original test used `mkstemps` unguarded.

Not sure how this ran in windows builds previously tbh.

Differential Revision: D102347840


