### PR TITLE
XPUPTI: Fix ts=0 trace events on Windows

### DIFF
--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
@@ -63,13 +63,13 @@ XpuptiActivityProfilerSession::~XpuptiActivityProfilerSession() {
 // =========== Session Public Methods ============= //
 void XpuptiActivityProfilerSession::start() {
   profilerStartTs_ =
-      libkineto::timeSinceEpoch(std::chrono::high_resolution_clock::now());
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
 }
 
 void XpuptiActivityProfilerSession::stop() {
   xpti_.disablePtiActivities(activity_types_);
   profilerEndTs_ =
-      libkineto::timeSinceEpoch(std::chrono::high_resolution_clock::now());
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
 }
 
 void XpuptiActivityProfilerSession::toggleCollectionDynamic(const bool enable) {


### PR DESCRIPTION
On Windows, `high_resolution_clock` is aliased to `steady_clock` whose epoch is system boot time, not Unix time.
`ChromeTraceBaseTime` uses `system_clock` (Unix epoch) to compute relative timestamps. The mismatch causes `transToRelativeTime()` to clamp XPU session span timestamps to zero, producing three events with `ts=0` in Chrome Trace JSON. Perfetto UI interprets this as a ~15-day timeline, making traces unusable.

On Linux this is a no-op because `high_resolution_clock` is aliased to `system_clock`.