### PR TITLE
Add a scope guard for logging to help us capture all exit paths (#1383)

### DIFF
--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -143,6 +143,7 @@ const std::unordered_set<std::string>& getLoggerMedataAllowList() {
 } // namespace
 
 void GenericActivityProfiler::processTraceInternal(ActivityLogger& logger) {
+  UST_LOGGER_STAGE_SCOPE(kPostProcessingStage);
   LOG(INFO) << "Processing " << traceBuffers_->cpu.size() << " CPU buffers";
   VLOG(0) << "Profile time range: " << captureWindowStartTime_ << " - "
           << captureWindowEndTime_;
@@ -974,7 +975,6 @@ time_point<system_clock> GenericActivityProfiler::performRunLoopStep(
       // for quickly handling trace request via synchronous API
       std::lock_guard<std::recursive_mutex> guard(mutex_);
       processTraceInternal(*logger_);
-      UST_LOGGER_MARK_COMPLETED(kPostProcessingStage);
       resetInternal();
       VLOG(0) << "ProcessTrace -> WaitForRequest";
       break;

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -166,6 +166,13 @@ void Logger::addLoggerObserverAddMetadata(
   }
 }
 
+USTLoggerStageGuard::~USTLoggerStageGuard() {
+  try {
+    UST_LOGGER_MARK_COMPLETED(stage_);
+  } catch (...) {
+  }
+}
+
 } // namespace KINETO_NAMESPACE
 
 #endif // USE_GOOGLE_LOG

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -27,6 +27,7 @@
 #define LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND()
 #define LOGGER_OBSERVER_ADD_METADATA(key, value)
 #define UST_LOGGER_MARK_COMPLETED(stage)
+#define UST_LOGGER_STAGE_SCOPE(stage)
 #define USDT_LOGGER_EMIT_MESSAGE(usdt_type)
 #define USDT_EMIT_START_TRACE()
 #define USDT_EMIT_STOP_TRACE()
@@ -155,6 +156,23 @@ class VoidLogger {
   void operator&(std::ostream&) {}
 };
 
+// RAII helper used to ensure a UST stage row is emitted on every exit from a scope.
+// Bucketed LOG(ERROR) / LOG(WARNING) calls within the scope are picked up by the
+// emitted row as usual.
+class USTLoggerStageGuard {
+ public:
+  explicit USTLoggerStageGuard(const std::string& stage) : stage_(stage) {}
+  ~USTLoggerStageGuard();
+
+  USTLoggerStageGuard(const USTLoggerStageGuard&) = delete;
+  USTLoggerStageGuard& operator=(const USTLoggerStageGuard&) = delete;
+  USTLoggerStageGuard(USTLoggerStageGuard&&) = delete;
+  USTLoggerStageGuard& operator=(USTLoggerStageGuard&&) = delete;
+
+ private:
+  std::string stage_;
+};
+
 } // namespace KINETO_NAMESPACE
 
 #ifdef LOG // Undefine in case these are already defined (quite likely)
@@ -262,6 +280,9 @@ struct __to_constant__ {
                                                                               : libkineto::VoidLogger() & \
           libkineto::Logger(libkineto::LoggerOutputType::STAGE, __LINE__, __FILE__).stream()              \
               << "Completed Stage: " << stage
+
+// RAII helper that fires UST_LOGGER_MARK_COMPLETED(stage) on scope exit.
+#define UST_LOGGER_STAGE_SCOPE(stage) libkineto::USTLoggerStageGuard LOCAL_VARNAME(ust_stage_guard)(stage)
 
 #define USDT_LOGGER_EMIT_MESSAGE(usdt_type)                                                              \
   !(libkineto::LoggerOutputType::USDT >= libkineto::Logger::severityLevel()) ? (void)0                   \

--- a/libkineto/src/SyncActivityProfilerHandler.cpp
+++ b/libkineto/src/SyncActivityProfilerHandler.cpp
@@ -62,7 +62,6 @@ std::unique_ptr<ActivityTraceInterface> SyncActivityProfilerHandler::
   profiler_.processTrace(*logger);
   // Will follow up with another patch for logging URLs when ActivityTrace
   // is moved.
-  UST_LOGGER_MARK_COMPLETED(kPostProcessingStage);
 
   // Logger Metadata contains a map of LOGs collected in Kineto
   //   logger_level -> List of log lines


### PR DESCRIPTION
Summary:

Currently, we mark all areas where we want to indicate stage completion with `UST_LOGGER_MARK_COMPLETED`. This macro routes us to the UST logger `write` method which keep a running list of all LOG(ERROR) messages. If no ERROR messages have been logged, we'll mark the stage as a success. Otherwise, we will include the error message in the Scuba write.

With this setup it's pretty easy for us to miss an exit path, especially in the post-processing path where we have a bunch of early exit branches. This change introduces a `USTLoggerStageGuard` to help automatically manage stage exit without needing to explicitly remember to mark `UST_LOGGER_MARK_COMPLETED`.

Reviewed By: scotts

Differential Revision: D102829439


