### PR TITLE
Refactor CI to be more fine-grain

### DIFF
--- a/.github/workflows/linux_cpu_kineto.yml
+++ b/.github/workflows/linux_cpu_kineto.yml
@@ -1,0 +1,28 @@
+name: Linux CPU Kineto build and test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  pr-test:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      job-name: linux-cpu-kineto-build-and-test
+      runner: linux.12xlarge
+      timeout: 180
+      # Checkout the Kineto repo at the PR ref with submodules
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}
+      submodules: recursive
+      gpu-arch-type: cpu
+      script: |
+        set -eux
+        .github/scripts/setup.sh
+        .github/scripts/kineto_build_test.sh cpu

--- a/.github/workflows/linux_cpu_pytorch.yml
+++ b/.github/workflows/linux_cpu_pytorch.yml
@@ -1,15 +1,10 @@
-name: Linux XPU build and test
+name: Linux CPU PyTorch build and test
 
 on:
   push:
-    tags:
-      - ciflow/xpu/*
     branches:
       - main
-
-permissions:
-  id-token: write
-  contents: read
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
@@ -19,17 +14,15 @@ jobs:
   pr-test:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      job-name: linux-xpu-build-and-test
-      runner: linux.idc.xpu
+      job-name: linux-cpu-pytorch-build-and-test
+      runner: linux.12xlarge
       timeout: 180
       # Checkout the Kineto repo at the PR ref with submodules
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       submodules: recursive
-      gpu-arch-type: xpu
-      docker-image: pytorch/manylinux2_28-builder:xpu
+      gpu-arch-type: cpu
       script: |
         set -eux
         .github/scripts/setup.sh
-        .github/scripts/kineto_build_test.sh xpu
-        .github/scripts/pytorch_build_test.sh xpu
+        .github/scripts/pytorch_build_test.sh cpu

--- a/.github/workflows/linux_cuda_kineto.yml
+++ b/.github/workflows/linux_cuda_kineto.yml
@@ -1,4 +1,4 @@
-name: Linux CPU build and test
+name: Linux CUDA Kineto build and test
 
 on:
   push:
@@ -14,16 +14,17 @@ jobs:
   pr-test:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      job-name: linux-cpu-build-and-test
-      runner: linux.12xlarge
+      job-name: linux-cuda-kineto-build-and-test
+      # AWS A10G GPU instance
+      runner: linux.g5.4xlarge.nvidia.gpu
       timeout: 180
       # Checkout the Kineto repo at the PR ref with submodules
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       submodules: recursive
-      gpu-arch-type: cpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.6"
       script: |
         set -eux
         .github/scripts/setup.sh
-        .github/scripts/kineto_build_test.sh cpu
-        .github/scripts/pytorch_build_test.sh cpu
+        .github/scripts/kineto_build_test.sh cuda

--- a/.github/workflows/linux_cuda_pytorch.yml
+++ b/.github/workflows/linux_cuda_pytorch.yml
@@ -1,0 +1,30 @@
+name: Linux CUDA PyTorch build and test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  pr-test:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      job-name: linux-cuda-pytorch-build-and-test
+      # AWS A10G GPU instance
+      runner: linux.g5.4xlarge.nvidia.gpu
+      timeout: 180
+      # Checkout the Kineto repo at the PR ref with submodules
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}
+      submodules: recursive
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.6"
+      script: |
+        set -eux
+        .github/scripts/setup.sh
+        .github/scripts/pytorch_build_test.sh cuda

--- a/.github/workflows/linux_rocm_kineto.yml
+++ b/.github/workflows/linux_rocm_kineto.yml
@@ -2,9 +2,10 @@ name: Linux ROCm Kineto build and test
 
 on:
   push:
+    tags:
+      - ciflow/rocm/*
     branches:
       - main
-  pull_request:
 
 permissions:
   id-token: write

--- a/.github/workflows/linux_rocm_kineto.yml
+++ b/.github/workflows/linux_rocm_kineto.yml
@@ -1,0 +1,33 @@
+name: Linux ROCm Kineto build and test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  pr-test:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      job-name: linux-rocm-kineto-build-and-test
+      runner: linux.rocm.gpu.gfx942.1
+      timeout: 180
+      # Checkout the Kineto repo at the PR ref with submodules
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}
+      submodules: recursive
+      gpu-arch-type: rocm
+      gpu-arch-version: "7.2"
+      script: |
+        set -eux
+        .github/scripts/setup.sh
+        .github/scripts/kineto_build_test.sh rocm

--- a/.github/workflows/linux_rocm_pytorch.yml
+++ b/.github/workflows/linux_rocm_pytorch.yml
@@ -1,0 +1,34 @@
+name: Linux ROCm PyTorch build and test
+
+on:
+  push:
+    tags:
+      - ciflow/rocm/*
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  pr-test:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      job-name: linux-rocm-pytorch-build-and-test
+      runner: linux.rocm.gpu.gfx942.1
+      timeout: 180
+      # Checkout the Kineto repo at the PR ref with submodules
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}
+      submodules: recursive
+      gpu-arch-type: rocm
+      gpu-arch-version: "7.2"
+      script: |
+        set -eux
+        .github/scripts/setup.sh
+        .github/scripts/pytorch_build_test.sh rocm

--- a/.github/workflows/linux_xpu_kineto.yml
+++ b/.github/workflows/linux_xpu_kineto.yml
@@ -2,9 +2,10 @@ name: Linux XPU Kineto build and test
 
 on:
   push:
+    tags:
+      - ciflow/xpu/*
     branches:
       - main
-  pull_request:
 
 permissions:
   id-token: write

--- a/.github/workflows/linux_xpu_kineto.yml
+++ b/.github/workflows/linux_xpu_kineto.yml
@@ -1,11 +1,10 @@
-name: Linux ROCm build and test
+name: Linux XPU Kineto build and test
 
 on:
   push:
-    tags:
-      - ciflow/rocm/*
     branches:
       - main
+  pull_request:
 
 permissions:
   id-token: write
@@ -19,17 +18,16 @@ jobs:
   pr-test:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      job-name: linux-rocm-build-and-test
-      runner: linux.rocm.gpu.gfx942.1
+      job-name: linux-xpu-kineto-build-and-test
+      runner: linux.idc.xpu
       timeout: 180
       # Checkout the Kineto repo at the PR ref with submodules
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       submodules: recursive
-      gpu-arch-type: rocm
-      gpu-arch-version: "7.2"
+      gpu-arch-type: xpu
+      docker-image: pytorch/manylinux2_28-builder:xpu
       script: |
         set -eux
         .github/scripts/setup.sh
-        .github/scripts/kineto_build_test.sh rocm
-        .github/scripts/pytorch_build_test.sh rocm
+        .github/scripts/kineto_build_test.sh xpu

--- a/.github/workflows/linux_xpu_pytorch.yml
+++ b/.github/workflows/linux_xpu_pytorch.yml
@@ -1,10 +1,15 @@
-name: Linux CUDA build and test
+name: Linux XPU PyTorch build and test
 
 on:
   push:
+    tags:
+      - ciflow/xpu/*
     branches:
       - main
-  pull_request:
+
+permissions:
+  id-token: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
@@ -14,18 +19,16 @@ jobs:
   pr-test:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      job-name: linux-cuda-build-and-test
-      # AWS A10G GPU instance
-      runner: linux.g5.4xlarge.nvidia.gpu
+      job-name: linux-xpu-pytorch-build-and-test
+      runner: linux.idc.xpu
       timeout: 180
       # Checkout the Kineto repo at the PR ref with submodules
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       submodules: recursive
-      gpu-arch-type: cuda
-      gpu-arch-version: "12.6"
+      gpu-arch-type: xpu
+      docker-image: pytorch/manylinux2_28-builder:xpu
       script: |
         set -eux
         .github/scripts/setup.sh
-        .github/scripts/kineto_build_test.sh cuda
-        .github/scripts/pytorch_build_test.sh cuda
+        .github/scripts/pytorch_build_test.sh xpu


### PR DESCRIPTION
Our CI on main combines Kineto build and test with PyTorch build and test. Kineto build and test takes minutes; PyTorch build and test takes over an hour sometimes.

This PR splits those out so that we:

1. Get quicker signals from Kineto build and test.
2. Make it easier to reason about PyTorch build and test since it no longer contains Kineto build and test at all. There's no need to build Kineto because PyTorch build will handle it.

I tried to make it so that we could run all architectures on all PRs, but the actual CI systems those jobs run on need the label. So we still have to do ciflow/rocm and ciflow/xpu.