### PR TITLE
Make sure we clear the logger observer before starting a new session (#1387)

### DIFF
--- a/libkineto/include/ILoggerObserver.h
+++ b/libkineto/include/ILoggerObserver.h
@@ -54,6 +54,11 @@ class ILoggerObserver {
   virtual void addDestination(const std::string& dest) = 0;
   virtual void setTriggerOnDemand() {}
   virtual void addMetadata(const std::string& key, const std::string& value) = 0;
+  // Metadata that is constant for the process lifetime (e.g. GPU/driver
+  // versions). Unlike addMetadata, this is NOT cleared by reset(), so it
+  // survives across traces and must not be used for per-trace values.
+  virtual void addPersistentMetadata([[maybe_unused]] const std::string& key,
+                                     [[maybe_unused]] const std::string& value) {}
 };
 
 } // namespace libkineto

--- a/libkineto/src/AsyncActivityProfilerHandler.cpp
+++ b/libkineto/src/AsyncActivityProfilerHandler.cpp
@@ -266,6 +266,7 @@ void AsyncActivityProfilerHandler::activateConfig(
     std::chrono::time_point<std::chrono::system_clock> now) {
   logger_ = ActivityProfilerController::makeLogger(*asyncRequestConfig_);
   profiler_.setLogger(logger_.get());
+  LOGGER_OBSERVER_RESET();
   LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND();
   profiler_.configure(*asyncRequestConfig_, now);
   asyncRequestConfig_ = nullptr;

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -97,10 +97,11 @@ void CuptiActivityProfiler::logGpuVersions() {
             << "; Runtime: " << cudaRuntimeVersion
             << "; Driver: " << cudaDriverVersion;
 
-  LOGGER_OBSERVER_ADD_METADATA("cupti_version", std::to_string(cuptiVersion));
-  LOGGER_OBSERVER_ADD_METADATA(
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
+      "cupti_version", std::to_string(cuptiVersion));
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
       "cuda_runtime_version", std::to_string(cudaRuntimeVersion));
-  LOGGER_OBSERVER_ADD_METADATA(
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
       "cuda_driver_version", std::to_string(cudaDriverVersion));
   addVersionMetadata("cupti_version", std::to_string(cuptiVersion));
   addVersionMetadata(

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -157,12 +157,28 @@ void Logger::setLoggerObserverOnDemand() {
   }
 }
 
+void Logger::resetLoggerObservers() {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->reset();
+  }
+}
+
 void Logger::addLoggerObserverAddMetadata(
     const std::string& key,
     const std::string& value) {
   std::lock_guard<std::mutex> guard(loggerObserversMutex());
   for (auto observer : loggerObservers()) {
     observer->addMetadata(key, value);
+  }
+}
+
+void Logger::addLoggerObserverPersistentMetadata(
+    const std::string& key,
+    const std::string& value) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->addPersistentMetadata(key, value);
   }
 }
 

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -26,6 +26,8 @@
 #define LOGGER_OBSERVER_ADD_DESTINATION(dest)
 #define LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND()
 #define LOGGER_OBSERVER_ADD_METADATA(key, value)
+#define LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(key, value)
+#define LOGGER_OBSERVER_RESET()
 #define UST_LOGGER_MARK_COMPLETED(stage)
 #define UST_LOGGER_STAGE_SCOPE(stage)
 #define USDT_LOGGER_EMIT_MESSAGE(usdt_type)
@@ -130,7 +132,11 @@ class Logger {
 
   static void setLoggerObserverOnDemand();
 
+  static void resetLoggerObservers();
+
   static void addLoggerObserverAddMetadata(const std::string& key, const std::string& value);
+
+  static void addLoggerObserverPersistentMetadata(const std::string& key, const std::string& value);
 
  private:
   std::stringstream buf_;
@@ -266,8 +272,15 @@ struct __to_constant__ {
 // Record this was triggered by On-Demand.
 #define LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND() libkineto::Logger::setLoggerObserverOnDemand()
 
+// Reset all logger observers to a clean per-trace state.
+#define LOGGER_OBSERVER_RESET() libkineto::Logger::resetLoggerObservers()
+
 // Record this was triggered by On-Demand.
 #define LOGGER_OBSERVER_ADD_METADATA(key, value) libkineto::Logger::addLoggerObserverAddMetadata(key, value)
+
+// Metadata that is constant for the process lifetime and survives reset().
+#define LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(key, value) \
+  libkineto::Logger::addLoggerObserverPersistentMetadata(key, value)
 
 // UST Logger Semantics to describe when a stage is complete.
 // Use libkineto::Logger directly instead of the LOG/LOG_IS_ON macros, which

--- a/libkineto/src/LoggerCollector.h
+++ b/libkineto/src/LoggerCollector.h
@@ -41,6 +41,7 @@ class LoggerCollector : public ILoggerObserver {
   }
 
   void reset() override {
+    buckets_.clear();
     trace_duration_ms = 0;
     event_count = 0;
     destinations.clear();

--- a/libkineto/src/RocmActivityProfiler.cpp
+++ b/libkineto/src/RocmActivityProfiler.cpp
@@ -49,10 +49,11 @@ void RocmActivityProfiler::logGpuVersions() {
             << "; Runtime: " << hipRuntimeVersion
             << "; Driver: " << hipDriverVersion;
 
-  LOGGER_OBSERVER_ADD_METADATA("rocprofiler-sdk_version", rocprofVersion);
-  LOGGER_OBSERVER_ADD_METADATA(
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
+      "rocprofiler-sdk_version", rocprofVersion);
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
       "hip_runtime_version", std::to_string(hipRuntimeVersion));
-  LOGGER_OBSERVER_ADD_METADATA(
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
       "hip_driver_version", std::to_string(hipDriverVersion));
   addVersionMetadata("rocprofiler-sdk_version", rocprofVersion);
   addVersionMetadata("hip_runtime_version", std::to_string(hipRuntimeVersion));

--- a/libkineto/src/SyncActivityProfilerHandler.cpp
+++ b/libkineto/src/SyncActivityProfilerHandler.cpp
@@ -44,6 +44,7 @@ void SyncActivityProfilerHandler::prepareTrace(const Config& config) {
     profiler_.reset();
   }
 
+  LOGGER_OBSERVER_RESET();
   profiler_.configure(config, now);
 }
 


### PR DESCRIPTION
Summary:

Currently, we don't reset the UST logger between sync (auto-trace)/async (on-demand) runs, so the data from one run can pollute the other. In particular, if we have an async then sync run, the sync run's UST logs will have artifacts from the async run.

Before sync/async's `configure` method, we add a `resetLoggerObservers` call. We add it here because `configure` is when we know the request was accepted.

Some of the logger's metadata is only set once and is persisted across runs (i.e. cuda version) and clearing it would reset it for future profiling sessions. So we introduce an option to add "persistent" metadata which is not cleared upon `.reset()`.

Reviewed By: sanrise, scotts

Differential Revision: D103278391


