### PR TITLE
Add XPU to external correlation IDs excluded types

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -796,6 +796,8 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
         libkineto::ActivityType::CONCURRENT_KERNEL,
         libkineto::ActivityType::CUDA_RUNTIME,
         libkineto::ActivityType::CUDA_DRIVER,
+        libkineto::ActivityType::XPU_RUNTIME,
+        libkineto::ActivityType::XPU_DRIVER,
         libkineto::ActivityType::PRIVATEUSE1_RUNTIME,
         libkineto::ActivityType::PRIVATEUSE1_DRIVER};
     if (excludedTypes.find(op.type()) == excludedTypes.end()) {


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/3479

Add `XPU_RUNTIME` and `XPU_DRIVER` to `excludedTypes` to handle orphan XPU events similarly as other devices.


This fix: `test_disable_external_correlation` in issue mentioned above by correctly handling events xpu-specific events like: `urEnqueueKernelLaunch`