### PR TITLE
Upgrade Kineto to C++20

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -31,7 +31,7 @@ target_compile_definitions(json_output_benchmark PRIVATE
 )
 
 set_target_properties(json_output_benchmark PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
 )

--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -302,7 +302,7 @@ if(NOT WIN32 AND NOT APPLE AND NOT KINETO_BACKEND STREQUAL "xpu")
 endif()
 
 set_target_properties(kineto kineto_base kineto_api PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED YES
       CXX_EXTENSIONS NO)
 

--- a/libkineto/include/AbstractConfig.h
+++ b/libkineto/include/AbstractConfig.h
@@ -93,6 +93,10 @@ class AbstractConfig {
   [[nodiscard]] std::vector<std::string> splitAndTrim(const std::string& s, char delim) const;
   // Lowercase for case-insensitive comparisons
   std::string toLower(std::string& s) const;
+  // Does string end with suffix.
+  // New code should prefer std::string::ends_with directly (C++20). This
+  // wrapper is kept only for existing callers; do not add new ones.
+  [[nodiscard]] bool endsWith(const std::string& s, const std::string& suffix) const;
   // Conversions
   [[nodiscard]] int64_t toIntRange(const std::string& val, int64_t min, int64_t max) const;
   [[nodiscard]] int32_t toInt32(const std::string& val) const;

--- a/libkineto/include/AbstractConfig.h
+++ b/libkineto/include/AbstractConfig.h
@@ -93,8 +93,6 @@ class AbstractConfig {
   [[nodiscard]] std::vector<std::string> splitAndTrim(const std::string& s, char delim) const;
   // Lowercase for case-insensitive comparisons
   std::string toLower(std::string& s) const;
-  // Does string end with suffix
-  [[nodiscard]] bool endsWith(const std::string& s, const std::string& suffix) const;
   // Conversions
   [[nodiscard]] int64_t toIntRange(const std::string& val, int64_t min, int64_t max) const;
   [[nodiscard]] int32_t toInt32(const std::string& val) const;

--- a/libkineto/include/IActivityProfiler.h
+++ b/libkineto/include/IActivityProfiler.h
@@ -46,8 +46,6 @@ enum class TraceStatus {
  *   processes and gpu rows in the trace viewer.
  */
 struct DeviceInfo {
-  DeviceInfo(int64_t id, int64_t sortIndex, std::string name, std::string label)
-      : id(id), sortIndex(sortIndex), name(std::move(name)), label(std::move(label)) {}
   int64_t id; // process id
   int64_t sortIndex; // position in trace view
   const std::string name; // process name
@@ -58,8 +56,6 @@ struct DeviceInfo {
  *   Can be used to specify resource inside device
  */
 struct ResourceInfo {
-  ResourceInfo(int64_t deviceId, int64_t id, int64_t sortIndex, std::string name)
-      : id(id), sortIndex(sortIndex), deviceId(deviceId), name(std::move(name)) {}
   int64_t id; // resource id
   int64_t sortIndex; // position in trace view
   int64_t deviceId; // id of device which owns this resource (specified in

--- a/libkineto/src/AbstractConfig.cpp
+++ b/libkineto/src/AbstractConfig.cpp
@@ -80,13 +80,6 @@ string AbstractConfig::toLower(string& s) const {
   return res;
 }
 
-bool AbstractConfig::endsWith(const string& s, const string& suffix) const {
-  if (suffix.size() > s.size()) {
-    return false;
-  }
-  return s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
 vector<string> AbstractConfig::splitAndTrim(const string& s, char delim) const {
   auto res = split(s, delim);
   for (string& x : res) {

--- a/libkineto/src/AbstractConfig.cpp
+++ b/libkineto/src/AbstractConfig.cpp
@@ -80,6 +80,10 @@ string AbstractConfig::toLower(string& s) const {
   return res;
 }
 
+bool AbstractConfig::endsWith(const string& s, const string& suffix) const {
+  return s.ends_with(suffix);
+}
+
 vector<string> AbstractConfig::splitAndTrim(const string& s, char delim) const {
   auto res = split(s, delim);
   for (string& x : res) {

--- a/libkineto/src/ApproximateClock.cpp
+++ b/libkineto/src/ApproximateClock.cpp
@@ -56,7 +56,7 @@ std::function<time_t(approx_time_t)> ApproximateClockToUnixTimeConverter::
     scale_factors[i] =
         static_cast<double>(delta_ns) / static_cast<double>(delta_approx);
   }
-  std::sort(scale_factors.begin(), scale_factors.end());
+  std::ranges::sort(scale_factors);
   long double scale_factor = scale_factors[(replicates / 2) + 1];
 
   // We shift all times by `t0` for better numerics. Double precision only has

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -337,34 +337,35 @@ void CuptiActivityApi::enableCuptiActivities(
       bufferRequestedTrampoline, bufferCompletedTrampoline));
 
   externalCorrelationEnabled_.store(false, std::memory_order_relaxed);
+  using enum ActivityType;
   for (const auto& activity : selected_activities) {
-    if (activity == ActivityType::GPU_MEMCPY) {
+    if (activity == GPU_MEMCPY) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY));
     }
-    if (activity == ActivityType::GPU_MEMSET) {
+    if (activity == GPU_MEMSET) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMSET));
     }
-    if (activity == ActivityType::CONCURRENT_KERNEL) {
+    if (activity == CONCURRENT_KERNEL) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
     }
-    if (activity == ActivityType::EXTERNAL_CORRELATION) {
+    if (activity == EXTERNAL_CORRELATION) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION));
       externalCorrelationEnabled_.store(true, std::memory_order_relaxed);
     }
-    if (activity == ActivityType::CUDA_SYNC) {
+    if (activity == CUDA_SYNC) {
 #if CUDA_VERSION >= 13000
       CUPTI_CALL(cuptiActivityEnableCudaEventDeviceTimestamps(true));
 #endif
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
     }
-    if (activity == ActivityType::CUDA_RUNTIME) {
+    if (activity == CUDA_RUNTIME) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_RUNTIME));
 #if (CUDART_VERSION >= 12050)
       CUPTI_CALL(cuptiActivityEnableRuntimeApi(
           CUPTI_RUNTIME_TRACE_CBID_cudaGetDevice_v3020, 0));
 #endif
     }
-    if (activity == ActivityType::CUDA_DRIVER) {
+    if (activity == CUDA_DRIVER) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_DRIVER));
 #if (CUDART_VERSION >= 12050)
       CUPTI_CALL(cuptiActivityEnableDriverApi(
@@ -375,7 +376,7 @@ void CuptiActivityApi::enableCuptiActivities(
           CUPTI_DRIVER_TRACE_CBID_cuCtxGetCurrent, 0));
 #endif
     }
-    if (activity == ActivityType::OVERHEAD) {
+    if (activity == OVERHEAD) {
       CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_OVERHEAD));
     }
   }
@@ -388,30 +389,31 @@ void CuptiActivityApi::enableCuptiActivities(
 
 void CuptiActivityApi::disableCuptiActivities(
     const std::set<ActivityType>& selected_activities) {
+  using enum ActivityType;
   for (const auto& activity : selected_activities) {
-    if (activity == ActivityType::GPU_MEMCPY) {
+    if (activity == GPU_MEMCPY) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_MEMCPY));
     }
-    if (activity == ActivityType::GPU_MEMSET) {
+    if (activity == GPU_MEMSET) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_MEMSET));
     }
-    if (activity == ActivityType::CONCURRENT_KERNEL) {
+    if (activity == CONCURRENT_KERNEL) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
     }
-    if (activity == ActivityType::EXTERNAL_CORRELATION) {
+    if (activity == EXTERNAL_CORRELATION) {
       CUPTI_CALL(
           cuptiActivityDisable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION));
     }
-    if (activity == ActivityType::CUDA_SYNC) {
+    if (activity == CUDA_SYNC) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
     }
-    if (activity == ActivityType::CUDA_RUNTIME) {
+    if (activity == CUDA_RUNTIME) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_RUNTIME));
     }
-    if (activity == ActivityType::CUDA_DRIVER) {
+    if (activity == CUDA_DRIVER) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_DRIVER));
     }
-    if (activity == ActivityType::OVERHEAD) {
+    if (activity == OVERHEAD) {
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_OVERHEAD));
     }
   }

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -221,7 +221,7 @@ void CuptiActivityProfiler::processGpuActivities(ActivityLogger& logger) {
 // Populate ctxToDeviceId from a record with (contextId, deviceId) fields.
 template <class T>
 static inline void updateCtxToDeviceId(const T* act) {
-  if (ctxToDeviceId().count(act->contextId) == 0) {
+  if (!ctxToDeviceId().contains(act->contextId)) {
     ctxToDeviceId()[act->contextId] = act->deviceId;
   }
 }
@@ -229,10 +229,10 @@ static inline void updateCtxToDeviceId(const T* act) {
 // P2P memcpy carries separate source and destination (context, device) pairs.
 static inline void updateCtxToDeviceId(
     const CUpti_ActivityMemcpyPtoPType* act) {
-  if (ctxToDeviceId().count(act->srcContextId) == 0) {
+  if (!ctxToDeviceId().contains(act->srcContextId)) {
     ctxToDeviceId()[act->srcContextId] = act->srcDeviceId;
   }
-  if (ctxToDeviceId().count(act->dstContextId) == 0) {
+  if (!ctxToDeviceId().contains(act->dstContextId)) {
     ctxToDeviceId()[act->dstContextId] = act->dstDeviceId;
   }
 }
@@ -503,8 +503,7 @@ void CuptiActivityProfiler::logDeferredEvents() {
   // there was some GPU kernel/memcopy/memset observed on it in the trace
   // window.
   for (const auto& entry : logQueue_) {
-    if (seenDeviceStreams_.find({entry.device, entry.stream}) ==
-        seenDeviceStreams_.end()) {
+    if (!seenDeviceStreams_.contains({entry.device, entry.stream})) {
       VLOG(2) << "Skipping Stream Wait Event on unseen stream = "
               << entry.stream;
     } else {

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -210,7 +210,7 @@ bool CuptiCallbackApi::registerCallback(
   }
 
   // avoid duplicates
-  auto it = std::find(cblist->begin(), cblist->end(), cbfn);
+  auto it = std::ranges::find(*cblist, cbfn);
   if (it != cblist->end()) {
     LOG(WARNING) << "Adding duplicate callback -- domain = " << domain
                  << " callback id = " << cbid;
@@ -242,7 +242,7 @@ bool CuptiCallbackApi::deleteCallback(
   //  https://en.cppreference.com/w/cpp/container/list/erase
   //  "References and iterators to the erased elements are invalidated.
   //   Other references and iterators are not affected."
-  auto it = std::find(cblist->begin(), cblist->end(), cbfn);
+  auto it = std::ranges::find(*cblist, cbfn);
   if (it == cblist->end()) {
     LOG(WARNING) << "Could not find callback to remove -- domain = " << domain
                  << " callback id = " << cbid;

--- a/libkineto/src/CuptiCbidRegistry.cpp
+++ b/libkineto/src/CuptiCbidRegistry.cpp
@@ -262,7 +262,7 @@ bool CuptiCbidRegistry::isBlocklisted(CallbackDomain domain, uint32_t cbid) {
 
 bool CuptiCbidRegistry::isRegistered(CallbackDomain domain, uint32_t cbid) {
   const auto& map = getMapForDomain(domain);
-  if (map.find(cbid) != map.end()) {
+  if (map.contains(cbid)) {
     return true;
   }
   for (const auto& [rangeDomain, range] : cbidRanges_) {

--- a/libkineto/src/CuptiRangeProfiler.cpp
+++ b/libkineto/src/CuptiRangeProfiler.cpp
@@ -62,8 +62,8 @@ std::unordered_map<std::string, std::vector<std::string>> kDerivedMetrics = {
 };
 
 inline bool hasGPUActivitiesEnabled(const Config& config) {
-  return (config.selectedActivityTypes().count(
-             ActivityType::CONCURRENT_KERNEL)) > 0;
+  return config.selectedActivityTypes().contains(
+      ActivityType::CONCURRENT_KERNEL);
 }
 
 } // namespace
@@ -277,7 +277,7 @@ std::unique_ptr<IActivityProfilerSession> CuptiRangeProfiler::configure(
     const std::set<ActivityType>& /*activity_types*/,
     const Config& config) {
   const auto& activity_types_ = config.selectedActivityTypes();
-  if (activity_types_.find(kProfActivityType) == activity_types_.end()) {
+  if (!activity_types_.contains(kProfActivityType)) {
     return nullptr;
   }
 

--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -693,7 +693,11 @@ void GenericActivityProfiler::finalizeTrace(
   string process_name = processName(pid);
   if (!process_name.empty()) {
     logger.handleDeviceInfo(
-        {pid, pid, process_name, "CPU"}, captureWindowStartTime_);
+        {.id = pid,
+         .sortIndex = pid,
+         .name = process_name,
+         .label = "CPU"},
+        captureWindowStartTime_);
     if (!cpuOnly_ && use_default_device_info) {
       // Usually, GPU events use device id as pid (0-7).
       // In some cases, CPU sockets are numbered starting from 0.
@@ -706,10 +710,10 @@ void GenericActivityProfiler::finalizeTrace(
       // of the trace timelines.
       for (int gpu = 0; gpu <= kMaxGpuID; gpu++) {
         logger.handleDeviceInfo(
-            {gpu,
-             gpu + kExceedMaxPid,
-             process_name,
-             fmt::format("GPU {}", gpu)},
+            {.id = gpu,
+             .sortIndex = gpu + kExceedMaxPid,
+             .name = process_name,
+             .label = fmt::format("GPU {}", gpu)},
             captureWindowStartTime_);
       }
     }

--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -149,7 +149,7 @@ void GenericActivityProfiler::processTraceInternal(ActivityLogger& logger) {
 
   // Pass metadata within the trace to the logger observer.
   for (const auto& pair : metadata_) {
-    if (getLoggerMedataAllowList().count(pair.first) > 0) {
+    if (getLoggerMedataAllowList().contains(pair.first)) {
       LOGGER_OBSERVER_ADD_METADATA(pair.first, pair.second);
     }
   }
@@ -242,7 +242,7 @@ void GenericActivityProfiler::processCpuTrace(
   TraceSpan& cpu_span = span_pair.first;
   for (auto const& act : cpuTrace.activities) {
     VLOG(2) << act->correlationId() << ": OP " << act->activityName;
-    if (derivedConfig_->profileActivityTypes().count(act->type())) {
+    if (derivedConfig_->profileActivityTypes().contains(act->type())) {
       static_assert(
           std::is_same_v<
               std::remove_reference_t<decltype(act)>,
@@ -421,7 +421,7 @@ void GenericActivityProfiler::handleGpuActivity(
   act.log(*logger);
   setGpuActivityPresent(true);
   updateGpuNetSpan(act);
-  if (derivedConfig_->profileActivityTypes().count(
+  if (derivedConfig_->profileActivityTypes().contains(
           ActivityType::GPU_USER_ANNOTATION)) {
     const auto& it = userCorrelationMap_.find(act.correlationId());
     if (it != userCorrelationMap_.end()) {
@@ -542,8 +542,8 @@ void GenericActivityProfiler::configure(
   if (!profilers_.empty()) {
     configureChildProfilers();
   }
-  rangeProfilingActive_ = config_->selectedActivityTypes().count(
-                              ActivityType::CUDA_PROFILER_RANGE) > 0;
+  rangeProfilingActive_ = config_->selectedActivityTypes().contains(
+      ActivityType::CUDA_PROFILER_RANGE);
 
   if (libkineto::api().client()) {
     libkineto::api().client()->prepare(

--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -692,10 +692,7 @@ void GenericActivityProfiler::finalizeTrace(
   string process_name = processName(pid);
   if (!process_name.empty()) {
     logger.handleDeviceInfo(
-        {.id = pid,
-         .sortIndex = pid,
-         .name = process_name,
-         .label = "CPU"},
+        {.id = pid, .sortIndex = pid, .name = process_name, .label = "CPU"},
         captureWindowStartTime_);
     if (!cpuOnly_ && use_default_device_info) {
       // Usually, GPU events use device id as pid (0-7).

--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -162,8 +162,7 @@ void GenericActivityProfiler::processTraceInternal(ActivityLogger& logger) {
   }
   for (const auto& session : sessions_) {
     if (auto props = session->getDeviceProperties(); !props.empty()) {
-      if (std::find(
-              device_properties.begin(), device_properties.end(), props) ==
+      if (std::ranges::find(device_properties, props) ==
           device_properties.end()) {
         device_properties.push_back(props);
       }

--- a/libkineto/src/GenericActivityProfiler.h
+++ b/libkineto/src/GenericActivityProfiler.h
@@ -211,10 +211,11 @@ class GenericActivityProfiler {
   void recordThreadInfo(int32_t sysTid, int32_t tid, int32_t pid) {
     if (!resourceInfo_.contains({pid, tid})) {
       resourceInfo_.emplace(std::make_pair(pid, tid),
-                            ResourceInfo(pid,
-                                         sysTid,
-                                         sysTid, // sortindex
-                                         fmt::format("thread {} ({})", sysTid, getThreadName())));
+                            ResourceInfo{
+                                .id = sysTid,
+                                .sortIndex = sysTid,
+                                .deviceId = pid,
+                                .name = fmt::format("thread {} ({})", sysTid, getThreadName())});
     }
   }
 
@@ -335,7 +336,11 @@ class GenericActivityProfiler {
   inline void recordStream(int device, int id, const char* postfix) {
     if (!hasDeviceResource(device, id)) {
       resourceInfo_.emplace(std::make_pair(device, id),
-                            ResourceInfo(device, id, id, fmt::format("stream {} {}", id, postfix)));
+                            ResourceInfo{
+                                .id = id,
+                                .sortIndex = id,
+                                .deviceId = device,
+                                .name = fmt::format("stream {} {}", id, postfix)});
     }
   }
 
@@ -343,7 +348,12 @@ class GenericActivityProfiler {
   inline void recordDevice(int device) {
     constexpr int id = -1;
     if (!hasDeviceResource(device, id)) {
-      resourceInfo_.emplace(std::make_pair(device, id), ResourceInfo(device, id, id, fmt::format("Device {}", device)));
+      resourceInfo_.emplace(std::make_pair(device, id),
+                            ResourceInfo{
+                                .id = id,
+                                .sortIndex = id,
+                                .deviceId = device,
+                                .name = fmt::format("Device {}", device)});
     }
   }
 

--- a/libkineto/src/GenericActivityProfiler.h
+++ b/libkineto/src/GenericActivityProfiler.h
@@ -211,11 +211,10 @@ class GenericActivityProfiler {
   void recordThreadInfo(int32_t sysTid, int32_t tid, int32_t pid) {
     if (!resourceInfo_.contains({pid, tid})) {
       resourceInfo_.emplace(std::make_pair(pid, tid),
-                            ResourceInfo{
-                                .id = sysTid,
-                                .sortIndex = sysTid,
-                                .deviceId = pid,
-                                .name = fmt::format("thread {} ({})", sysTid, getThreadName())});
+                            ResourceInfo{.id = sysTid,
+                                         .sortIndex = sysTid,
+                                         .deviceId = pid,
+                                         .name = fmt::format("thread {} ({})", sysTid, getThreadName())});
     }
   }
 
@@ -335,12 +334,10 @@ class GenericActivityProfiler {
   // Create resource names for streams
   inline void recordStream(int device, int id, const char* postfix) {
     if (!hasDeviceResource(device, id)) {
-      resourceInfo_.emplace(std::make_pair(device, id),
-                            ResourceInfo{
-                                .id = id,
-                                .sortIndex = id,
-                                .deviceId = device,
-                                .name = fmt::format("stream {} {}", id, postfix)});
+      resourceInfo_.emplace(
+          std::make_pair(device, id),
+          ResourceInfo{
+              .id = id, .sortIndex = id, .deviceId = device, .name = fmt::format("stream {} {}", id, postfix)});
     }
   }
 
@@ -348,12 +345,9 @@ class GenericActivityProfiler {
   inline void recordDevice(int device) {
     constexpr int id = -1;
     if (!hasDeviceResource(device, id)) {
-      resourceInfo_.emplace(std::make_pair(device, id),
-                            ResourceInfo{
-                                .id = id,
-                                .sortIndex = id,
-                                .deviceId = device,
-                                .name = fmt::format("Device {}", device)});
+      resourceInfo_.emplace(
+          std::make_pair(device, id),
+          ResourceInfo{.id = id, .sortIndex = id, .deviceId = device, .name = fmt::format("Device {}", device)});
     }
   }
 

--- a/libkineto/src/GenericActivityProfiler.h
+++ b/libkineto/src/GenericActivityProfiler.h
@@ -209,7 +209,7 @@ class GenericActivityProfiler {
   // T107508020: We can deprecate the recordThreadInfo(void) once we optimized
   // profiler_kineto
   void recordThreadInfo(int32_t sysTid, int32_t tid, int32_t pid) {
-    if (resourceInfo_.find({pid, tid}) == resourceInfo_.end()) {
+    if (!resourceInfo_.contains({pid, tid})) {
       resourceInfo_.emplace(std::make_pair(pid, tid),
                             ResourceInfo(pid,
                                          sysTid,
@@ -328,7 +328,7 @@ class GenericActivityProfiler {
   void processCpuTrace(libkineto::CpuTraceBuffer& cpuTrace, ActivityLogger& logger);
 
   inline bool hasDeviceResource(int device, int id) {
-    return resourceInfo_.find({device, id}) != resourceInfo_.end();
+    return resourceInfo_.contains({device, id});
   }
 
   // Create resource names for streams

--- a/libkineto/src/output_csv.cpp
+++ b/libkineto/src/output_csv.cpp
@@ -53,7 +53,7 @@ void EventCSVLogger::handleSample(
     std::tm tm_result;
     get_local_time(&time, &tm_result);
     for (const Stat& s : sample.stats) {
-      if (eventNames_.find(s.name) == eventNames_.end()) {
+      if (!eventNames_.contains(s.name)) {
         continue;
       }
       *out_ << fmt::format("{:%Y-%m-%d %H:%M:%S}", tm_result) << ",";

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -798,7 +798,7 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
         libkineto::ActivityType::CUDA_DRIVER,
         libkineto::ActivityType::PRIVATEUSE1_RUNTIME,
         libkineto::ActivityType::PRIVATEUSE1_DRIVER};
-    if (excludedTypes.find(op.type()) == excludedTypes.end()) {
+    if (!excludedTypes.contains(op.type())) {
       external_id = op.correlationId();
     }
   }

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -60,9 +60,9 @@ constexpr std::string_view kDefaultLogFileFmt = "libkineto_activities_{}.json";
 void sanitizeStrForJSON(std::string& value) {
   // Replace all backslashes with forward slash because Windows paths causing
   // JSONDecodeError.
-  std::replace(value.begin(), value.end(), '\\', '/');
+  std::ranges::replace(value, '\\', '/');
   // Remove all new line characters
-  value.erase(std::remove(value.begin(), value.end(), '\n'), value.end());
+  std::erase(value, '\n');
 }
 
 std::string string2hex(const std::string& str) {
@@ -101,8 +101,8 @@ std::string fmtTs(int64_t time_ns) {
 }
 
 bool isWhitespace(std::string_view s) {
-  return std::all_of(
-      s.begin(), s.end(), [](unsigned char c) { return std::isspace(c); });
+  return std::ranges::all_of(
+      s, [](unsigned char c) { return std::isspace(c); });
 }
 
 } // namespace

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
@@ -114,11 +114,11 @@ std::vector<libkineto::ResourceInfo> XpuptiActivityProfilerSession::
     getResourceInfos() {
   std::vector<libkineto::ResourceInfo> result;
   for (const auto& [device_id, sycl_queue_id] : resourceInfo_) {
-    result.emplace_back(
-        device_id,
-        sycl_queue_id,
-        sycl_queue_id,
-        fmt::format("Stream {}", sycl_queue_id));
+    result.push_back(
+        {.id = sycl_queue_id,
+         .sortIndex = sycl_queue_id,
+         .deviceId = device_id,
+         .name = fmt::format("Stream {}", sycl_queue_id)});
   }
   resourceInfo_.clear();
   return result;

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
@@ -169,10 +169,8 @@ void XpuptiActivityProfilerSession::enumDeviceUUIDs() {
 
 DeviceIndex_t XpuptiActivityProfilerSession::getDeviceIdxFromUUID(
     const uint8_t deviceUUID[16]) {
-  auto it = std::find_if(
-      deviceUUIDs_.begin(),
-      deviceUUIDs_.end(),
-      [deviceUUID](const DeviceUUIDsT& deviceUUIDinVec) {
+  auto it = std::ranges::find_if(
+      deviceUUIDs_, [deviceUUID](const DeviceUUIDsT& deviceUUIDinVec) {
         return std::equal(
             deviceUUIDinVec.begin(),
             deviceUUIDinVec.end(),

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 include(GoogleTest)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 if(KINETO_BACKEND STREQUAL "xpu")
     set(XPU_XPUPTI_LIBRARY ${PTI_LIBRARY} ${SYCL_LIBRARY})

--- a/libkineto/test/xpupti/CMakeLists.txt
+++ b/libkineto/test/xpupti/CMakeLists.txt
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 set(LINK_LIBRARIES
   gtest_main

--- a/libkineto/test/xpupti/compute/CMakeLists.txt
+++ b/libkineto/test/xpupti/compute/CMakeLists.txt
@@ -8,7 +8,7 @@ include(GoogleTest)
 cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 project(${PROJECT_NAME} LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-fsycl" has_sycl)


### PR DESCRIPTION
The rest of the PyTorch ecosystem has upgraded, so now it's our turn. At the same time, we're adopting better C++20 APIs. Changes:

1. Bump C++ standard from 17 to 20 — `CXX_STANDARD` 17→20 in all five CMakeLists.txt
2. Use `map`/`set::contains()` in place of `find`/`end` and `count`
3. Remove `AbstractConfig::endsWith` helper now just calls`std::string::ends_with`; I'll try to remove all callers in a follow-up.
4. `using enum ActivityType` in CUPTI enable/disable — drops the `ActivityType::` prefix from ~16 comparisons.                                                                                                       
5. Use designated initializers for `DeviceInfo` / `ResourceInfo` — convert the two POD sinks in `IActivityProfiler.h` to aggregates and update call sites. Incidentally fixes a footgun: `ResourceInfo`'s constructor took `(deviceId, id, sortIndex, name)` but stored fields in `(id, sortIndex, deviceId, name)` order, so positional brace-init at call sites was effectively swapping the first two arguments.
6. Use `std::ranges` algorithms and `std::erase` — `find` / `sort` / `find_if` / `all_of` / `replace` and the erase-remove idiom.                       