### PR TITLE
Remove LIBKINETO_NO* compatibility shim

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -55,17 +55,11 @@ endif()
 # Selection is explicit: if the chosen toolkit isn't available, configuration
 # fails. Use KINETO_BACKEND=cpu to build without GPU support.
 
-# Backwards-compat shim: derive KINETO_BACKEND from legacy LIBKINETO_NO* flags
-# when the user hasn't set KINETO_BACKEND directly.
-# TODO: remove after PyTorch migrates to KINETO_BACKEND.
+# Track whether the user explicitly set KINETO_BACKEND before the default
+# fires below, so we can warn when we fall back to cpu.
+set(_kineto_backend_explicit ON)
 if(NOT DEFINED CACHE{KINETO_BACKEND} AND NOT DEFINED KINETO_BACKEND)
-  if(DEFINED LIBKINETO_NOROCTRACER AND NOT LIBKINETO_NOROCTRACER)
-    set(KINETO_BACKEND "rocm" CACHE STRING "")
-  elseif(DEFINED LIBKINETO_NOCUPTI AND NOT LIBKINETO_NOCUPTI)
-    set(KINETO_BACKEND "cuda" CACHE STRING "")
-  elseif(DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
-    set(KINETO_BACKEND "xpu" CACHE STRING "")
-  endif()
+  set(_kineto_backend_explicit OFF)
 endif()
 
 set(KINETO_BACKEND "cpu" CACHE STRING
@@ -81,29 +75,12 @@ endif()
 unset(_KINETO_BACKEND_VALID)
 message(STATUS "KINETO_BACKEND = ${KINETO_BACKEND}")
 
-# Warn if legacy LIBKINETO_NO* flags disagree with the cached KINETO_BACKEND.
-# The shim only fires on initial configure; once KINETO_BACKEND is in the
-# cache, subsequent legacy-flag changes are silently ignored. Detect that and
-# tell the user. TODO: remove with the rest of the legacy shim.
-if(DEFINED LIBKINETO_NOCUPTI OR DEFINED LIBKINETO_NOROCTRACER OR DEFINED LIBKINETO_NOXPUPTI)
-  if(DEFINED LIBKINETO_NOROCTRACER AND NOT LIBKINETO_NOROCTRACER)
-    set(_legacy_implied_backend "rocm")
-  elseif(DEFINED LIBKINETO_NOCUPTI AND NOT LIBKINETO_NOCUPTI)
-    set(_legacy_implied_backend "cuda")
-  elseif(DEFINED LIBKINETO_NOXPUPTI AND NOT LIBKINETO_NOXPUPTI)
-    set(_legacy_implied_backend "xpu")
-  else()
-    set(_legacy_implied_backend "cpu")
-  endif()
-  if(NOT KINETO_BACKEND STREQUAL _legacy_implied_backend)
-    message(WARNING
-      "Legacy LIBKINETO_NO* flags imply KINETO_BACKEND=${_legacy_implied_backend} "
-      "but KINETO_BACKEND=${KINETO_BACKEND} (cached from a previous configure). "
-      "Legacy flags are ignored. Pass -DKINETO_BACKEND=${_legacy_implied_backend} "
-      "explicitly or remove the build directory to switch backends.")
-  endif()
-  unset(_legacy_implied_backend)
+if(NOT _kineto_backend_explicit)
+  message(WARNING
+    "KINETO_BACKEND was not set; defaulting to 'cpu'. "
+    "Pass -DKINETO_BACKEND={cpu,cuda,rocm,xpu} explicitly to silence this warning.")
 endif()
+unset(_kineto_backend_explicit)
 
 # Per-backend configure-time setup.
 if(KINETO_BACKEND STREQUAL "cuda")


### PR DESCRIPTION
The CMake refactor (#1388) replaced `LIBKINETO_NOCUPTI`, `LIBKINETO_NOROCTRACER`, and `LIBKINETO_NOXPUPTI` with a single `KINETO_BACKEND` variable, but kept a shim that translated the legacy flags during the cross-repo migration window. https://github.com/pytorch/pytorch/pull/183388 migrated PyTorch's `cmake/Dependencies.cmake` and `torch/csrc/autograd/init.cpp` have now both been migrated to use `KINETO_BACKEND` / `HAS_*` directly. The shim has no remaining caller.

**Approach**

Delete the shim block and the cached-vs-new-legacy-flags conflict warning that existed only to ease the migration. Replace with a simpler guard that warns when `KINETO_BACKEND` wasn't set at all and the build defaulted to `cpu`. This catches stragglers passing legacy `LIBKINETO_NO*` flags as a side effect — they'll be silently ignored, `KINETO_BACKEND` will default to `cpu`, and the new warning will tell them how to pick a backend explicitly. The new code carries no knowledge of the legacy flag names, so the kineto repo is now free of all `LIBKINETO_NO*` references.

The warning fires only on initial configure (subsequent re-runs find `KINETO_BACKEND` populated in the cache) and on a freshly-wiped build directory.