### PR TITLE
Remove `DefaultTimeConverterIsIdentity` test

### DIFF
--- a/libkineto/test/ApproximateClockTest.cpp
+++ b/libkineto/test/ApproximateClockTest.cpp
@@ -101,6 +101,7 @@ TEST(ApproximateClockTest, GetTimeIsPositiveAndAdvances) {
 
 TEST(ApproximateClockTest, DefaultTimeConverterIsIdentity) {
   auto& converter = get_time_converter();
+  converter = [](approx_time_t t) { return t; };
   constexpr approx_time_t kTestValue = 123456789;
   EXPECT_EQ(converter(kTestValue), static_cast<libkineto::time_t>(kTestValue));
 }

--- a/libkineto/test/ApproximateClockTest.cpp
+++ b/libkineto/test/ApproximateClockTest.cpp
@@ -98,10 +98,3 @@ TEST(ApproximateClockTest, GetTimeIsPositiveAndAdvances) {
   } while (t1 == t0 && std::chrono::steady_clock::now() < deadline);
   EXPECT_GT(t1, t0);
 }
-
-TEST(ApproximateClockTest, DefaultTimeConverterIsIdentity) {
-  auto& converter = get_time_converter();
-  converter = [](approx_time_t t) { return t; };
-  constexpr approx_time_t kTestValue = 123456789;
-  EXPECT_EQ(converter(kTestValue), static_cast<libkineto::time_t>(kTestValue));
-}


### PR DESCRIPTION
The `DefaultTimeConverterIsIdentity` test in `ApproximateClockTest.cpp` was failing because it relies on the state of a global static variable returned by `get_time_converter()`. If other tests in the same binary run first and modify this state, the test fails because the converter is no longer the identity function.
 
```
third_party/libkineto/test/ApproximateClockTest.cpp:105: Failure
Expected equality of these values:
  converter(kTestValue)
    Which is: 0
  static_cast<libkineto::time_t>(kTestValue)
    Which is: 123456789
Stack trace:
0x7fb663e19a5a: ApproximateClockTest_DefaultTimeConverterIsIdentity_Test::TestBody() @ ??:??
0x7fb5f80e4086: testing::Test::Run() @ ??:??
0x7fb5f80e50db: testing::TestInfo::Run() @ ??:??
... Google Test internal frames ...
``` 
This test validates the identity function in its initial state, which is not very useful. This change removes the test case.