### PR TITLE
Re-enable most PyTorch tests

### DIFF
--- a/.github/scripts/config_cpu.sh
+++ b/.github/scripts/config_cpu.sh
@@ -39,14 +39,5 @@ export BUILD_TEST=1
 
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(
-  test/profiler/test_memory_profiler.py::TestDataFlow::test_data_flow_graph_complicated
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_sequential_fwd_bwd
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd_step
-  test/profiler/test_profiler.py::TestProfiler::test_python_gc_event
   test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize
-  test/profiler/test_torch_tidy.py::TestTorchTidyProfiler::test_tensorimpl_invalidation_scalar_args
-
-  # https://github.com/pytorch/kineto/issues/1230
-  test/profiler/test_profiler_tree.py::TestProfilerTree::test_profiler_experimental_tree_with_stack_and_modules
 )

--- a/.github/scripts/config_cuda.sh
+++ b/.github/scripts/config_cuda.sh
@@ -35,20 +35,5 @@ export BUILD_TEST=1
 
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(
-  test/profiler/test_memory_profiler.py::TestDataFlow::test_data_flow_graph_complicated
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_sequential_fwd_bwd
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd_step
-
-  # https://github.com/pytorch/kineto/issues/1253
-  test/profiler/test_profiler.py::TestProfiler::test_python_gc_event
-
-  # https://github.com/pytorch/kineto/issues/1308
-  test/profiler/test_profiler.py::TestProfiler::test_record_function_fast
-
-  # https://github.com/pytorch/kineto/issues/1319
-  test/profiler/test_profiler.py::TestProfiler::test_schedule_function_count
-
   test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize
-  test/profiler/test_torch_tidy.py::TestTorchTidyProfiler::test_tensorimpl_invalidation_scalar_args
 )

--- a/.github/scripts/config_rocm.sh
+++ b/.github/scripts/config_rocm.sh
@@ -39,17 +39,5 @@ export PYTORCH_TEST_WITH_ROCM=1
 
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(
-  test/profiler/test_memory_profiler.py::TestDataFlow::test_data_flow_graph_complicated
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_sequential_fwd_bwd
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd_step
-  test/profiler/test_profiler.py::TestProfiler::test_python_gc_event
   test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize
-  test/profiler/test_torch_tidy.py::TestTorchTidyProfiler::test_tensorimpl_invalidation_scalar_args
-
-  # https://github.com/pytorch/kineto/issues/1243
-  test/profiler/test_profiler.py::TestProfiler::test_profiler_cuda_sync_events
-
-  # https://github.com/pytorch/kineto/issues/1241
-  test/profiler/test_profiler.py::TestProfilerCUDA::test_mem_leak
 )

--- a/.github/scripts/config_xpu.sh
+++ b/.github/scripts/config_xpu.sh
@@ -49,14 +49,5 @@ export TORCH_XPU_ARCH_LIST=pvc
 #
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(
-  test/profiler/test_memory_profiler.py::TestDataFlow::test_data_flow_graph_complicated
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_sequential_fwd_bwd
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd
-  test/profiler/test_memory_profiler.py::TestMemoryProfilerE2E::test_categories_e2e_simple_fwd_bwd_step
-  test/profiler/test_profiler.py::TestProfiler::test_kineto
-  test/profiler/test_profiler.py::TestProfiler::test_user_annotation
-  test/profiler/test_profiler.py::TestProfiler::test_python_gc_event
   test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize
-  test/profiler/test_profiler.py::TestExperimentalUtils::test_profiler_debug_autotuner
-  test/profiler/test_torch_tidy.py::TestTorchTidyProfiler::test_tensorimpl_invalidation_scalar_args
 )


### PR DESCRIPTION
Landing https://github.com/pytorch/pytorch/pull/180454 fixed all of these. We still have that fuzz test remaining which seems to be a real failure.