### PR TITLE
ci: declare workflow-level `contents: read` on 5 workflows

### DIFF
--- a/.github/workflows/linux_cpu_kineto.yml
+++ b/.github/workflows/linux_cpu_kineto.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pr-test:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/.github/workflows/linux_cpu_pytorch.yml
+++ b/.github/workflows/linux_cpu_pytorch.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pr-test:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/.github/workflows/linux_cuda_kineto.yml
+++ b/.github/workflows/linux_cuda_kineto.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pr-test:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/.github/workflows/linux_cuda_pytorch.yml
+++ b/.github/workflows/linux_cuda_pytorch.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pr-test:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/.github/workflows/mac_cpu.yml
+++ b/.github/workflows/mac_cpu.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pr-test:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 5 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.