### PR TITLE
Add nlohmann/json as a top-level third_party submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "libkineto/third_party/dynolog"]
 	path = libkineto/third_party/dynolog
 	url = https://github.com/facebookincubator/dynolog.git
+[submodule "libkineto/third_party/json"]
+	path = libkineto/third_party/json
+	url = https://github.com/nlohmann/json.git

--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -339,16 +339,11 @@ if(KINETO_BUILD_TESTS)
     endif()
   endif()
   if(NOT TARGET nlohmann_json)
-    # nlohmann/json v3.10.5 declares cmake_minimum_required(VERSION 3.1),
-    # which CMake 4.x rejects. Allow it via CMAKE_POLICY_VERSION_MINIMUM.
-    # TODO: should we just take a direct third-party dependency on
-    #       nlohmann/json?
-    set(_saved_cmake_policy_version_minimum "${CMAKE_POLICY_VERSION_MINIMUM}")
-    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+    set(JSON_BuildTests OFF CACHE INTERNAL "")
+    set(JSON_Install OFF CACHE INTERNAL "")
     add_subdirectory(
-      "${LIBKINETO_THIRDPARTY_DIR}/dynolog/third_party/json"
+      "${LIBKINETO_THIRDPARTY_DIR}/json"
       "${LIBKINETO_BINARY_DIR}/json")
-    set(CMAKE_POLICY_VERSION_MINIMUM "${_saved_cmake_policy_version_minimum}")
   endif()
   enable_testing()
   add_subdirectory(test)


### PR DESCRIPTION
**Problem** — libkineto's tests depend on nlohmann/json, but the dependency is satisfied by reaching into a sub-submodule of dynolog (`libkineto/third_party/dynolog/third_party/json`). Kineto's json version is therefore whatever dynolog happens to pin, even though kineto and dynolog use json for unrelated purposes. The version dynolog pins (v3.10.5) also declares `cmake_minimum_required(3.1)`, which CMake 4.x rejects, forcing a `CMAKE_POLICY_VERSION_MINIMUM` workaround in libkineto's CMakeLists.

**Fix** — register nlohmann/json at v3.12.0 as a top-level submodule at `libkineto/third_party/json`, mirroring the fmt and googletest pattern. This avoids CMake hacks.

Note that I rejected an alternative where we just vendor what we need from nlohmann/json directly as source code. That would reduce recursive clone time and use less disk space; we're adding about 150 MB by doing this. But I don't want to be in the business of manually copying source from a project. Making it a proper sub-module is easier. If space usage ever becomes an issue, we can revisit.