### PR TITLE
Fix intermittent Mac CI failure from conda channel reset

### DIFF
--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -9,10 +9,14 @@ set -eux
 
 echo "====: Working directory: $(pwd)"
 
-# Ensure cmake is at least the max version needed by PyTorch and Kineto
+# Ensure cmake is at least the max version needed by PyTorch and Kineto.
+# Use conda-forge with strict priority so we get an up-to-date cmake.
+# `--add channels` errors when the channel is already at the top of the
+# user condarc, which happens on reused runners where a previous job
+# already added it. Swallow that error so the script stays idempotent.
+conda config --add channels conda-forge 2>/dev/null || true
+conda config --set channel_priority strict
 conda config --show channels
-conda config --remove channels defaults
-conda config --add channels conda-forge
 conda install -y 'cmake>=3.27'
 echo "====: Installed cmake version: $(cmake --version)"
 


### PR DESCRIPTION
The Mac CPU CI jobs are sometimes failing when trying to set the conda-forge as the preferred package stream. But we were doing it in a hacky way: trying to remove default. That sometimes failed because default wasn't always there. It's better for us to add conda-forge and set it as the higher priority.