### PR TITLE
Remove SIGUSR2 on-demand profiling path

### DIFF
--- a/libkineto/include/AbstractConfig.h
+++ b/libkineto/include/AbstractConfig.h
@@ -34,13 +34,6 @@ class AbstractConfig {
   // Returns true if successfully parsed the config string
   bool parse(const std::string& conf);
 
-  // Default setup for signal-triggered profiling
-  virtual void setSignalDefaults() {
-    for (auto& p : featureConfigs_) {
-      p.second->setSignalDefaults();
-    }
-  }
-
   // Default setup for client-triggered profiling
   virtual void setClientDefaults() {
     for (auto& p : featureConfigs_) {

--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -292,10 +292,6 @@ class Config : public AbstractConfig {
     return verboseLogModules_;
   }
 
-  [[nodiscard]] bool sigUsr2Enabled() const {
-    return enableSigUsr2_;
-  }
-
   [[nodiscard]] bool ipcFabricEnabled() const {
     return enableIpcFabric_;
   }
@@ -493,9 +489,6 @@ class Config : public AbstractConfig {
 
   // DEPRECATED
   std::chrono::time_point<std::chrono::system_clock> requestTimestamp_;
-
-  // Enable profiling via SIGUSR2
-  bool enableSigUsr2_;
 
   // Enable IPC Fabric instead of thrift communication
   bool enableIpcFabric_;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -150,10 +150,6 @@ constexpr char kProfileStartIterationRoundUpKey[] =
 constexpr char kRequestTraceID[] = "REQUEST_TRACE_ID";
 constexpr char kRequestGroupTraceID[] = "REQUEST_GROUP_TRACE_ID";
 
-// Enable on-demand trigger via kill -USR2 <pid>
-// When triggered in this way, /tmp/libkineto.conf will be used as config.
-constexpr char kEnableSigUsr2Key[] = "ENABLE_SIGUSR2";
-
 // Enable communication through IPC Fabric
 // and disable thrift communication with dynolog daemon
 constexpr char kEnableIpcFabricKey[] = "ENABLE_IPC_FABRIC";
@@ -252,7 +248,6 @@ Config::Config()
       profileStartIteration_(-1),
       profileStartIterationRoundUp_(-1),
       requestTimestamp_(milliseconds(0)),
-      enableSigUsr2_(false),
       enableIpcFabric_(false),
       onDemandConfigUpdateIntervalSecs_(
           kDefaultOnDemandConfigUpdateIntervalSecs),
@@ -480,8 +475,6 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     profileStartIteration_ = toInt32(val);
   } else if (!name.compare(kProfileStartIterationRoundUpKey)) {
     profileStartIterationRoundUp_ = toInt32(val);
-  } else if (!name.compare(kEnableSigUsr2Key)) {
-    enableSigUsr2_ = toBool(val);
   } else if (!name.compare(kEnableIpcFabricKey)) {
     enableIpcFabric_ = toBool(val);
   } else if (!name.compare(kOnDemandConfigUpdateIntervalSecsKey)) {

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -8,10 +8,6 @@
 
 #include "ConfigLoader.h"
 
-#ifdef __linux__
-#include <csignal>
-#endif
-
 #include <chrono>
 #include <cstdlib>
 #include <fstream>
@@ -30,64 +26,11 @@ namespace KINETO_NAMESPACE {
 constexpr char kConfigFileEnvVar[] = "KINETO_CONFIG";
 #ifdef __linux__
 constexpr char kConfigFile[] = "/etc/libkineto.conf";
-constexpr char kOnDemandConfigFile[] = "/tmp/libkineto.conf";
 #else
 constexpr char kConfigFile[] = "libkineto.conf";
-constexpr char kOnDemandConfigFile[] = "libkineto.conf";
 #endif
 
 constexpr std::chrono::seconds kConfigUpdateIntervalSecs(300);
-
-#ifdef __linux__
-static struct sigaction originalUsr2Handler = {};
-#endif
-
-// Use SIGUSR2 to initiate profiling.
-// Look for an on-demand config file.
-// If none is found, default to base config.
-// Try to not affect existing handlers
-static bool hasOriginalSignalHandler() {
-#ifdef __linux__
-  return originalUsr2Handler.sa_handler != nullptr ||
-      originalUsr2Handler.sa_sigaction != nullptr;
-#else
-  return false;
-#endif
-}
-
-static void handle_signal([[maybe_unused]] int signal) {
-#ifdef __linux__
-  if (signal == SIGUSR2) {
-    ConfigLoader::instance().handleOnDemandSignal();
-    if (hasOriginalSignalHandler()) {
-      // Invoke original handler and reinstate ours
-      struct sigaction act;
-      sigaction(SIGUSR2, &originalUsr2Handler, &act);
-      raise(SIGUSR2);
-      sigaction(SIGUSR2, &act, &originalUsr2Handler);
-    }
-  }
-#endif
-}
-
-static void setupSignalHandler([[maybe_unused]] bool enableSigUsr2) {
-#ifdef __linux__
-  if (enableSigUsr2) {
-    struct sigaction act = {};
-    act.sa_handler = &handle_signal;
-    act.sa_flags = SA_NODEFER;
-    if (sigaction(SIGUSR2, &act, &originalUsr2Handler) < 0) {
-      PLOG(ERROR) << "Failed to register SIGUSR2 handler";
-    }
-    if (originalUsr2Handler.sa_handler == &handle_signal) {
-      originalUsr2Handler = {};
-    }
-  } else if (hasOriginalSignalHandler()) {
-    sigaction(SIGUSR2, &originalUsr2Handler, nullptr);
-    originalUsr2Handler = {};
-  }
-#endif
-}
 
 // return an empty string if reading gets any errors. Otherwise a config string.
 static std::string readConfigFromConfigFile(
@@ -150,8 +93,7 @@ ConfigLoader::ConfigLoader()
       // on-demand config will be overwritten by the value read from the regular
       // config so the initial value is not important
       onDemandConfigUpdateIntervalSecs_(kConfigUpdateIntervalSecs),
-      stopFlag_(false),
-      onDemandSignal_(false) {}
+      stopFlag_(false) {}
 
 void ConfigLoader::startThread() {
   if (!updateThread_) {
@@ -185,14 +127,6 @@ ConfigLoader::~ConfigLoader() {
 #if !USE_GOOGLE_LOG
   Logger::clearLoggerObservers();
 #endif // !USE_GOOGLE_LOG
-}
-
-void ConfigLoader::handleOnDemandSignal() {
-  onDemandSignal_ = true;
-  {
-    std::lock_guard<std::mutex> lock(updateThreadMutex_);
-    updateThreadCondVar_.notify_one();
-  }
 }
 
 namespace {
@@ -243,24 +177,10 @@ void ConfigLoader::updateBaseConfig() {
     if (daemonConfigLoader()) {
       daemonConfigLoader()->setCommunicationFabric(config_->ipcFabricEnabled());
     }
-    setupSignalHandler(config_->sigUsr2Enabled());
     SET_LOG_VERBOSITY_LEVEL(
         config_->verboseLogLevel(), config_->verboseLogModules());
     VLOG(0) << "Detected base config change";
   }
-}
-
-void ConfigLoader::configureFromSignal(
-    [[maybe_unused]] time_point<system_clock> now,
-    Config& config) {
-  LOG(INFO) << "Received on-demand profiling signal, " << "reading config from "
-            << kOnDemandConfigFile;
-  // Reset start time to 0 in order to compute new default start time
-  const std::string config_str =
-      "PROFILE_START_TIME=0\n" + readConfigFromConfigFile(kOnDemandConfigFile);
-  config.parse(config_str);
-  config.setSignalDefaults();
-  notifyHandlers(config);
 }
 
 void ConfigLoader::configureFromDaemon(
@@ -317,11 +237,7 @@ void ConfigLoader::updateConfigThread() {
           config_->onDemandConfigUpdateIntervalSecs();
       prev_config_load_time = now;
     }
-    if (onDemandSignal_.exchange(false)) {
-      onDemandConfig = config_->clone();
-      configureFromSignal(now, *onDemandConfig);
-    } else if (
-        now > prev_on_demand_load_time + onDemandConfigUpdateIntervalSecs_) {
+    if (now > prev_on_demand_load_time + onDemandConfigUpdateIntervalSecs_) {
       onDemandConfig = std::make_unique<Config>();
       configureFromDaemon(now, *onDemandConfig);
       prev_on_demand_load_time = now;

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -81,8 +81,6 @@ class ConfigLoader {
   bool hasNewConfig(const Config& oldConfig);
   int contextCountForGpu(uint32_t device);
 
-  void handleOnDemandSignal();
-
   static void setDaemonConfigLoaderFactory(std::function<std::unique_ptr<IDaemonConfigLoader>()> factory);
 
   std::string getConfString();
@@ -97,9 +95,6 @@ class ConfigLoader {
   void stopThread();
   void updateConfigThread();
   void updateBaseConfig();
-
-  // Create configuration when receiving SIGUSR2
-  void configureFromSignal(std::chrono::time_point<std::chrono::system_clock> now, Config& config);
 
   // Create configuration when receiving request from a daemon
   void configureFromDaemon(std::chrono::time_point<std::chrono::system_clock> now, Config& config);
@@ -119,7 +114,6 @@ class ConfigLoader {
   std::condition_variable updateThreadCondVar_;
   std::mutex updateThreadMutex_;
   std::atomic_bool stopFlag_{false};
-  std::atomic_bool onDemandSignal_{false};
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiRangeProfilerConfig.h
+++ b/libkineto/src/CuptiRangeProfilerConfig.h
@@ -46,10 +46,6 @@ class CuptiRangeProfilerConfig : public AbstractConfig {
     return cuptiProfilerMaxRanges_;
   }
 
-  void setSignalDefaults() override {
-    setDefaults();
-  }
-
   void setClientDefaults() override {
     setDefaults();
   }

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerConfig.h
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerConfig.h
@@ -44,10 +44,6 @@ class XpuptiScopeProfilerConfig : public AbstractConfig {
     return xpuptiProfilerMaxScopes_;
   }
 
-  void setSignalDefaults() override {
-    setDefaults();
-  }
-
   void setClientDefaults() override {
     setDefaults();
   }

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -253,34 +253,6 @@ TEST(ParseTest, SamplesPerReport) {
   EXPECT_EQ(cfg.samplesPerReport(), 1);
 }
 
-TEST(ParseTest, EnableSigUsr2) {
-  Config cfg;
-  EXPECT_TRUE(cfg.parse("ENABLE_SIGUSR2=yes"));
-  EXPECT_TRUE(cfg.sigUsr2Enabled());
-  EXPECT_TRUE(cfg.parse("ENABLE_SIGUSR2=no"));
-  EXPECT_FALSE(cfg.sigUsr2Enabled());
-  EXPECT_TRUE(cfg.parse("ENABLE_SIGUSR2=YES"));
-  EXPECT_TRUE(cfg.sigUsr2Enabled());
-  EXPECT_TRUE(cfg.parse("ENABLE_SIGUSR2=NO"));
-  EXPECT_FALSE(cfg.sigUsr2Enabled());
-  EXPECT_TRUE(cfg.parse("ENABLE_SIGUSR2=Y"));
-  EXPECT_TRUE(cfg.sigUsr2Enabled());
-  EXPECT_TRUE(cfg.parse("ENABLE_SIGUSR2=N"));
-  EXPECT_FALSE(cfg.sigUsr2Enabled());
-  EXPECT_TRUE(cfg.parse("ENABLE_SIGUSR2=T"));
-  EXPECT_TRUE(cfg.sigUsr2Enabled());
-  EXPECT_TRUE(cfg.parse("ENABLE_SIGUSR2=F"));
-  EXPECT_FALSE(cfg.sigUsr2Enabled());
-  EXPECT_TRUE(cfg.parse("ENABLE_SIGUSR2=true"));
-  EXPECT_TRUE(cfg.sigUsr2Enabled());
-  EXPECT_TRUE(cfg.parse("ENABLE_SIGUSR2=false"));
-  EXPECT_FALSE(cfg.sigUsr2Enabled());
-  EXPECT_FALSE(cfg.parse("ENABLE_SIGUSR2=  "));
-  EXPECT_FALSE(cfg.parse("ENABLE_SIGUSR2=2"));
-  EXPECT_FALSE(cfg.parse("ENABLE_SIGUSR2=-1"));
-  EXPECT_FALSE(cfg.parse("ENABLE_SIGUSR2=yep"));
-}
-
 TEST(ParseTest, DeviceMask) {
   Config cfg;
   // Single device

--- a/libkineto/test/CuptiRangeProfilerConfigTest.cpp
+++ b/libkineto/test/CuptiRangeProfilerConfigTest.cpp
@@ -54,7 +54,7 @@ TEST_F(CuptiRangeProfilerConfigTest, RangesDefaults) {
   EXPECT_TRUE(cfg.parse("CUPTI_PROFILER_METRICS = kineto__cuda_core_flops"));
   EXPECT_TRUE(cfg.parse("CUPTI_PROFILER_ENABLE_PER_KERNEL = false"));
 
-  cfg.setSignalDefaults();
+  cfg.setClientDefaults();
 
   EXPECT_TRUE(
       cfg_auto.parse("CUPTI_PROFILER_METRICS = kineto__cuda_core_flops"));

--- a/libkineto/test/xpupti/XpuptiScopeProfilerConfigTest.cpp
+++ b/libkineto/test/xpupti/XpuptiScopeProfilerConfigTest.cpp
@@ -51,7 +51,7 @@ TEST_F(XpuptiScopeProfilerConfigTest, ScopesDefaults) {
   EXPECT_TRUE(cfg.parse("XPUPTI_PROFILER_METRICS = metric1"));
   EXPECT_TRUE(cfg.parse("XPUPTI_PROFILER_ENABLE_PER_KERNEL = false"));
 
-  cfg.setSignalDefaults();
+  cfg.setClientDefaults();
 
   EXPECT_TRUE(cfg_auto.parse("XPUPTI_PROFILER_METRICS = metric2"));
   EXPECT_TRUE(cfg_auto.parse("XPUPTI_PROFILER_ENABLE_PER_KERNEL = true"));


### PR DESCRIPTION
Summary:
**Problem** — `libkineto` installed a process-wide `SIGUSR2` handler for on-demand profiling. No infra depended on this mechanism, but stray `SIGUSR2` signals could end up causing a signal storm, occasionally cascading into `SIGABRT` and killing unrelated jobs. After a recent fleet-wide regression in this area (see S654102 / S654768), the path was disabled in production via chef (`ENABLE_SIGUSR2=NO`; see [Disabling SIGUSR2 On-Demand Tracing Fleet-Wide](https://fb.workplace.com/groups/ai.efficiency.tools.users/permalink/2328930840925714/) and D100840142).

**Why** — The async, signal-driven entry point pre-dates the daemon-based on-demand path and has no remaining production users. The daemon path (`configureFromDaemon` + `IDaemonConfigLoader`) provides the same "trigger profiling without restart" capability over IPC, which is the supported mechanism. With the production knob already off and no internal or PyTorch callers depending on it, keeping the code is pure liability: it's a foot-gun for any process that links `libkineto` (which is most ML training jobs).

**Fix** — Delete the SIGUSR2 machinery end-to-end.

Differential Revision: D105593070


