### PR TITLE
Remove deprecated `REQUEST_TIMESTAMP` config key

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -235,22 +235,12 @@ class Config : public AbstractConfig {
     activitiesCudaSyncWaitEvents_ = enable;
   }
 
-  // Timestamp at which the profiling to start, requested by the user.
   [[nodiscard]] std::chrono::time_point<std::chrono::system_clock> requestTimestamp() const {
-    if (profileStartTime_.time_since_epoch().count()) {
-      return profileStartTime_;
-    }
-    // If no one requested timestamp, return 0.
-    if (requestTimestamp_.time_since_epoch().count() == 0) {
-      return requestTimestamp_;
-    }
-
-    // TODO(T94634890): Deprecate requestTimestamp
-    return requestTimestamp_ + maxRequestAge() + activitiesWarmupDuration();
+    return profileStartTime_;
   }
 
   [[nodiscard]] bool hasProfileStartTime() const {
-    return requestTimestamp_.time_since_epoch().count() > 0 || profileStartTime_.time_since_epoch().count() > 0;
+    return profileStartTime_.time_since_epoch().count() > 0;
   }
 
   [[nodiscard]] int profileStartIteration() const {
@@ -486,9 +476,6 @@ class Config : public AbstractConfig {
   // Or start iterations.
   int profileStartIteration_;
   int profileStartIterationRoundUp_;
-
-  // DEPRECATED
-  std::chrono::time_point<std::chrono::system_clock> requestTimestamp_;
 
   // Enable IPC Fabric instead of thrift communication
   bool enableIpcFabric_;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -123,9 +123,6 @@ constexpr char kRoctracerSetMaxEvents[] = "ROCTRACER_MAX_EVENTS";
 // an error somehow - no checks are done at config parse time.
 // Note PROFILE_START_ITERATION has higher precedence
 constexpr char kProfileStartTimeKey[] = "PROFILE_START_TIME";
-// DEPRECATED - USE PROFILE_START_TIME instead
-constexpr char kRequestTimestampKey[] = "REQUEST_TIMESTAMP";
-
 // Alternatively if the application supports reporting iterations
 // start the profile at specific iteration. If the iteration count
 // is >= this value the profile is started immediately.
@@ -247,7 +244,6 @@ Config::Config()
       profileStartTime_(milliseconds(0)),
       profileStartIteration_(-1),
       profileStartIterationRoundUp_(-1),
-      requestTimestamp_(milliseconds(0)),
       enableIpcFabric_(false),
       onDemandConfigUpdateIntervalSecs_(
           kDefaultOnDemandConfigUpdateIntervalSecs),
@@ -297,26 +293,6 @@ static std::string getTimeStr(time_point<system_clock> t) {
   std::tm tm{};
   get_local_time(&t_c, &tm);
   return fmt::format("{:%H:%M:%S}", tm);
-}
-
-static time_point<system_clock> handleRequestTimestamp(int64_t ms) {
-  auto t = time_point<system_clock>(milliseconds(ms));
-  auto now = system_clock::now();
-  if (t > now) {
-    throw std::invalid_argument(
-        fmt::format(
-            "Invalid {}: {} - time is in future",
-            kRequestTimestampKey,
-            getTimeStr(t)));
-  } else if ((now - t) > kMaxRequestAge) {
-    throw std::invalid_argument(
-        fmt::format(
-            "Invalid {}: {} - time is more than {}s in the past",
-            kRequestTimestampKey,
-            getTimeStr(t),
-            kMaxRequestAge.count()));
-  }
-  return t;
 }
 
 static time_point<system_clock> handleProfileStartTime(int64_t start_time_ms) {
@@ -465,11 +441,7 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   }
 
   // Common
-  else if (!name.compare(kRequestTimestampKey)) {
-    LOG(INFO) << kRequestTimestampKey << " has been deprecated - please use "
-              << kProfileStartTimeKey;
-    requestTimestamp_ = handleRequestTimestamp(toInt64(val));
-  } else if (!name.compare(kProfileStartTimeKey)) {
+  else if (!name.compare(kProfileStartTimeKey)) {
     profileStartTime_ = handleProfileStartTime(toInt64(val));
   } else if (!name.compare(kProfileStartIterationKey)) {
     profileStartIteration_ = toInt32(val);

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -299,30 +299,6 @@ TEST(ParseTest, DeviceMask) {
   EXPECT_FALSE(cfg.parse("EVENTS_ENABLED_DEVICES = 1.0"));
 }
 
-TEST(ParseTest, RequestTime) {
-  Config cfg;
-  system_clock::time_point now = system_clock::now();
-  int64_t tgood_ms =
-      duration_cast<milliseconds>(now.time_since_epoch()).count();
-  EXPECT_TRUE(cfg.parse(fmt::format("REQUEST_TIMESTAMP = {}", tgood_ms)));
-
-  tgood_ms = duration_cast<milliseconds>((now - seconds(5)).time_since_epoch())
-                 .count();
-  EXPECT_TRUE(cfg.parse(fmt::format("REQUEST_TIMESTAMP = {}", tgood_ms)));
-
-  int64_t tbad_ms =
-      duration_cast<milliseconds>((now - seconds(20)).time_since_epoch())
-          .count();
-  EXPECT_FALSE(cfg.parse(fmt::format("REQUEST_TIMESTAMP = {}", tbad_ms)));
-
-  EXPECT_FALSE(cfg.parse("REQUEST_TIMESTAMP = 0"));
-  EXPECT_FALSE(cfg.parse("REQUEST_TIMESTAMP = -1"));
-
-  tbad_ms = duration_cast<milliseconds>((now + seconds(10)).time_since_epoch())
-                .count();
-  EXPECT_FALSE(cfg.parse(fmt::format("REQUEST_TIMESTAMP = {}", tbad_ms)));
-}
-
 TEST(ParseTest, ProfileStartTime) {
   Config cfg;
   system_clock::time_point now = system_clock::now();


### PR DESCRIPTION
Summary:
Remove the deprecated `REQUEST_TIMESTAMP` config option from kineto/libkineto. This config key was explicitly marked deprecated with the replacement `PROFILE_START_TIME` already fully implemented. The runtime was emitting a deprecation warning log whenever `REQUEST_TIMESTAMP` was used.

Changes:
- Remove `kRequestTimestampKey` constant and `handleRequestTimestamp()` function from `Config.cpp`
- Remove the `REQUEST_TIMESTAMP` handler branch in `Config::handleOption()`
- Remove the deprecated `requestTimestamp_` member variable from `Config.h`
- Simplify `requestTimestamp()` to directly return `profileStartTime_`
- Simplify `hasProfileStartTime()` to only check `profileStartTime_`
- Remove the `RequestTime` test that exercised the deprecated code path

Differential Revision: D105728502


