### PR TITLE
Add XPU toggleCollectionDynamic mechanism

### DIFF
--- a/libkineto/include/IActivityProfiler.h
+++ b/libkineto/include/IActivityProfiler.h
@@ -114,6 +114,8 @@ class IActivityProfilerSession {
   virtual void pushUserCorrelationId([[maybe_unused]] uint64_t id) {}
   virtual void popUserCorrelationId() {}
 
+  virtual void toggleCollectionDynamic([[maybe_unused]] bool enable) {}
+
   virtual std::string getDeviceProperties() {
     return "";
   }

--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -601,11 +601,17 @@ void GenericActivityProfiler::toggleCollectionDynamic(const bool enable) {
   //
   // Both to prevent the synchronization event from showing up in traces.
   if (!enable) {
+    for (auto& session : sessions_) {
+      session->toggleCollectionDynamic(enable);
+    }
     disableGpuTracing();
   }
   synchronizeGpuDevice();
   if (enable) {
     enableGpuTracing();
+    for (auto& session : sessions_) {
+      session->toggleCollectionDynamic(enable);
+    }
   }
 }
 

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
@@ -41,7 +41,7 @@ class XpuptiActivityProfilerSession : public libkineto::IActivityProfilerSession
 
   void start() override;
   void stop() override;
-  void toggleCollectionDynamic(const bool);
+  void toggleCollectionDynamic(const bool enable) override;
   std::vector<std::string> errors() override {
     return errors_;
   };


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/3479

PR fixing `test_dynamic_toggle` for XPU.

Mark `IActivityProfilerSession::toggleCollectionDynamic(bool)` as virtual and make sure it will be called from: `GenericActivityProfiler::toggleCollectionDynamic(const bool enable)` for properly handling of dynamic toggle mechanism for XPU Profiler