### PR TITLE
Expose perfetto-trace flags

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -509,8 +509,20 @@ constexpr char kUseDaemonEnvVar[] = "KINETO_USE_DAEMON";
 bool isDaemonEnvVarSet();
 
 // Returns a reference to the protobuf trace enabled flag.
-// This allows the flag to be set externally (e.g., from JustKnobs in FBConfig)
-// and read in other components (e.g., ChromeTraceLogger).
+// This allows the flag to be set externally by downstream consumers
+// and read in trace output components.
 bool& get_protobuf_trace_enabled();
+
+// Returns a reference to the Perfetto trace enabled flag.
+// When true, a consumer writes a Perfetto-native trace via the
+// Perfetto SDK alongside other output formats.
+bool& get_perfetto_trace_enabled();
+
+// Returns a reference to the Perfetto packet compression enabled flag.
+// When true, in-process Perfetto SDK tracing sessions configure
+// `TraceConfig.compression_type = COMPRESSION_TYPE_DEFLATE`, producing
+// a smaller .pftrace at the cost of some CPU. The Perfetto UI and
+// trace_processor decompress transparently.
+bool& get_perfetto_packet_compression_enabled();
 
 } // namespace libkineto

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -598,10 +598,25 @@ void Config::setActivityDependentConfig() {
 }
 
 // Returns a reference to the protobuf trace enabled flag.
-// Default is false. FBConfig will set this based on JustKnobs.
+// Default is false. Downstream consumers override at startup.
 bool& get_protobuf_trace_enabled() {
   static bool _protobuf_trace_enabled = false;
   return _protobuf_trace_enabled;
+}
+
+// Returns a reference to the perfetto trace enabled flag.
+// Default is false. Downstream consumers override at startup.
+bool& get_perfetto_trace_enabled() {
+  static bool perfetto_trace_enabled = false;
+  return perfetto_trace_enabled;
+}
+
+// Returns a reference to the perfetto packet compression enabled flag.
+// Default is true (compression is on). Downstream consumers override at
+// startup.
+bool& get_perfetto_packet_compression_enabled() {
+  static bool perfetto_packet_compression_enabled = true;
+  return perfetto_packet_compression_enabled;
 }
 
 } // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Summary:
Adds two singleton boolean accessors in `Config.h` / `Config.cpp` for downstream consumers that want to opt into Perfetto-native (`.pftrace`) trace output:

- `get_perfetto_trace_enabled()` — toggles whether a consumer writes a Perfetto-native trace.
- `get_perfetto_packet_compression_enabled()` — controls whether in-process Perfetto SDK sessions set `TraceConfig.compression_type = COMPRESSION_TYPE_DEFLATE`, producing a smaller `.pftrace` at a small CPU cost (the Perfetto UI and `trace_processor` decompress transparently).

Defaults: trace off, compression on. Downstream consumers wire these to their configuration system.

Reviewed By: scotts

Differential Revision: D105689103


