### PR TITLE
Repair ROCm kernel stream attribution (#1416)

### DIFF
--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -142,7 +142,7 @@ class GenericTraceActivity : public ITraceActivity {
   int64_t endTime{0};
   int32_t id{0};
   int32_t device{0};
-  int32_t resource{0};
+  int64_t resource{0};
   int32_t threadId{0};
   ActivityType activityType;
   std::string activityName;

--- a/libkineto/sample_programs/README.md
+++ b/libkineto/sample_programs/README.md
@@ -33,3 +33,39 @@ $(buck2 build @//mode/opt -m ovr_config//gpu:amd --show-full-simple-output fbcod
 ```
 
 Expected output includes runtime activities with `hipMemcpyAsync kind=1` and `hipMemcpyWithStream kind=2`, plus matching GPU memcpy summaries for `Memcpy HtoD` and `Memcpy DtoH`. If the ROCm/Kineto direction attribution issue reproduces in this focused case, a runtime copy with kind `1` or `2` will instead pair with a GPU activity summary such as `Memcpy DtoD kind=DtoD`.
+
+## ROCm Stream-Interleave Repro
+
+`kineto_rocm_stream_interleave_repro.cpp` is a focused AMD/Kineto repro for checking Issue C: whether compute kernels from independent host workers collapse onto too few streams or appear spread across unexpected streams. The program creates one host thread and one HIP stream per worker, launches an identifiable kernel family on each worker's stream, then prints Kineto's kernel stream distribution.
+
+Build it with the AMD Buck modifier:
+
+```bash
+buck2 build @//mode/opt -m ovr_config//gpu:amd --show-full-output fbcode//kineto/libkineto/sample_programs:kineto_rocm_stream_interleave_repro
+```
+
+Run a 4-worker control on an AMD devgpu host:
+
+```bash
+$(buck2 build @//mode/opt -m ovr_config//gpu:amd --show-full-simple-output fbcode//kineto/libkineto/sample_programs:kineto_rocm_stream_interleave_repro) \
+  --workers 4 \
+  --launches 16 \
+  --elements 262144 \
+  --kernel-iters 512 \
+  --print-limit 0 \
+  --trace-path /tmp/kineto_rocm_stream_interleave_repro_4w.json
+```
+
+Then run an 8-worker stress case:
+
+```bash
+$(buck2 build @//mode/opt -m ovr_config//gpu:amd --show-full-simple-output fbcode//kineto/libkineto/sample_programs:kineto_rocm_stream_interleave_repro) \
+  --workers 8 \
+  --launches 32 \
+  --elements 262144 \
+  --kernel-iters 512 \
+  --print-limit 0 \
+  --trace-path /tmp/kineto_rocm_stream_interleave_repro.json
+```
+
+Expected healthy output has `workers * launches` Issue C kernel activities and at least one distinct non-zero stream per worker. If Issue C reproduces in this focused case, the summary will show kernel work collapsing onto fewer streams than workers, or one identifiable worker kernel name appearing across multiple streams. On `devgpu015`, the 4-worker control mapped to 4 Kineto streams, while the 8-worker stress case created 8 distinct HIP stream handles but Kineto reported only 4 kernel streams with worker kernel pairs sharing those stream IDs.

--- a/libkineto/sample_programs/README.md
+++ b/libkineto/sample_programs/README.md
@@ -8,3 +8,28 @@ To run `kineto_playground.cpp` in the `sample_programs` folder, you can use the 
     - this generates binary called `main`
 3. Run `./main`
     - runs your code defined in `kineto_playground.cpp`
+
+## ROCm Memcpy-Kind Repro
+
+`kineto_rocm_memcpy_kind_repro.cpp` is a focused AMD/Kineto repro for checking whether ROCm copy activity records preserve the HIP runtime copy direction. It directly runs:
+
+1. `hipMemcpyAsync(..., hipMemcpyHostToDevice, stream)`
+2. `hipMemcpyWithStream(..., hipMemcpyDeviceToHost, stream)`
+
+Build it with the AMD Buck modifier so the binary uses the ROCm activity profiler path:
+
+```bash
+buck2 build @//mode/opt -m ovr_config//gpu:amd --show-full-output fbcode//kineto/libkineto/sample_programs:kineto_rocm_memcpy_kind_repro
+```
+
+Run the built binary on an AMD devgpu host:
+
+```bash
+$(buck2 build @//mode/opt -m ovr_config//gpu:amd --show-full-simple-output fbcode//kineto/libkineto/sample_programs:kineto_rocm_memcpy_kind_repro) \
+  --bytes 1048576 \
+  --iterations 64 \
+  --print-limit 40 \
+  --trace-path /tmp/kineto_rocm_memcpy_kind_repro.json
+```
+
+Expected output includes runtime activities with `hipMemcpyAsync kind=1` and `hipMemcpyWithStream kind=2`, plus matching GPU memcpy summaries for `Memcpy HtoD` and `Memcpy DtoH`. If the ROCm/Kineto direction attribution issue reproduces in this focused case, a runtime copy with kind `1` or `2` will instead pair with a GPU activity summary such as `Memcpy DtoD kind=DtoD`.

--- a/libkineto/sample_programs/kineto_rocm_memcpy_kind_repro.cpp
+++ b/libkineto/sample_programs/kineto_rocm_memcpy_kind_repro.cpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <hip/hip_runtime.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include <folly/init/Init.h>
+#include <libkineto.h>
+
+namespace {
+
+constexpr const char* kDefaultTracePath =
+    "/tmp/kineto_rocm_memcpy_kind_repro.json";
+
+struct Options {
+  std::size_t bytes{1 << 20};
+  int iterations{64};
+  int printLimit{40};
+  std::string tracePath{kDefaultTracePath};
+};
+
+[[noreturn]] void usage(const char* argv0) {
+  std::cerr << "Usage: " << argv0
+            << " [--bytes N] [--iterations N] [--print-limit N]"
+               " [--trace-path PATH]\n\n"
+            << "Runs a focused ROCm/Kineto memcpy-kind repro on AMD GPUs:\n"
+            << "  1. hipMemcpyAsync(..., hipMemcpyHostToDevice, stream)\n"
+            << "  2. hipMemcpyWithStream(..., hipMemcpyDeviceToHost, stream)\n"
+            << "Then prints Kineto runtime/GPU memcpy activities and saves a "
+               "Chrome trace JSON.\n";
+  std::exit(2);
+}
+
+Options parseOptions(int argc, char** argv) {
+  Options options;
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg(argv[i]);
+    auto requireValue = [&](const char* flag) -> const char* {
+      if (i + 1 >= argc) {
+        std::cerr << "Missing value for " << flag << "\n";
+        usage(argv[0]);
+      }
+      return argv[++i];
+    };
+
+    if (arg == "--bytes") {
+      options.bytes = std::stoull(requireValue("--bytes"));
+    } else if (arg == "--iterations") {
+      options.iterations = std::stoi(requireValue("--iterations"));
+    } else if (arg == "--print-limit") {
+      options.printLimit = std::stoi(requireValue("--print-limit"));
+    } else if (arg == "--trace-path") {
+      options.tracePath = requireValue("--trace-path");
+    } else if (arg == "-h" || arg == "--help") {
+      usage(argv[0]);
+    } else {
+      std::cerr << "Unknown argument: " << arg << "\n";
+      usage(argv[0]);
+    }
+  }
+
+  if (options.bytes == 0 || options.iterations <= 0 || options.printLimit < 0) {
+    throw std::invalid_argument(
+        "--bytes and --iterations must be positive; --print-limit must be non-negative");
+  }
+  return options;
+}
+
+void checkHip(
+    hipError_t status,
+    const char* expression,
+    const char* file,
+    int line) {
+  if (status == hipSuccess) {
+    return;
+  }
+  std::cerr << "HIP error at " << file << ":" << line << " while running "
+            << expression << ": " << hipGetErrorString(status) << "\n";
+  std::exit(1);
+}
+
+#define CHECK_HIP(expr) checkHip((expr), #expr, __FILE__, __LINE__)
+
+void fillHostBuffer(std::byte* buffer, std::size_t bytes) {
+  for (std::size_t i = 0; i < bytes; ++i) {
+    buffer[i] = static_cast<std::byte>(i & 0xff);
+  }
+}
+
+void runMemcpyPair(
+    void* deviceBuffer,
+    void* hostInput,
+    void* hostOutput,
+    std::size_t bytes,
+    hipStream_t stream) {
+  CHECK_HIP(hipMemcpyAsync(
+      deviceBuffer, hostInput, bytes, hipMemcpyHostToDevice, stream));
+  CHECK_HIP(hipMemcpyWithStream(
+      hostOutput, deviceBuffer, bytes, hipMemcpyDeviceToHost, stream));
+}
+
+bool isRelevantMemcpyActivity(const libkineto::ITraceActivity& activity) {
+  const auto type = activity.type();
+  const auto name = activity.name();
+  return type == libkineto::ActivityType::GPU_MEMCPY ||
+      (type == libkineto::ActivityType::CUDA_RUNTIME &&
+       name.find("Memcpy") != std::string::npos);
+}
+
+std::string extractKindForSummary(const std::string& metadata) {
+  constexpr const char* marker = "\"kind\": ";
+  const auto pos = metadata.find(marker);
+  if (pos == std::string::npos) {
+    return "kind=<missing>";
+  }
+
+  auto valueStart = pos + std::strlen(marker);
+  while (valueStart < metadata.size() && metadata[valueStart] == ' ') {
+    ++valueStart;
+  }
+  if (valueStart >= metadata.size()) {
+    return "kind=<missing>";
+  }
+  if (metadata[valueStart] == '"') {
+    const auto valueEnd = metadata.find('"', valueStart + 1);
+    if (valueEnd != std::string::npos) {
+      return "kind=" +
+          metadata.substr(valueStart + 1, valueEnd - valueStart - 1);
+    }
+  }
+
+  const auto valueEnd = metadata.find_first_of(",\n", valueStart);
+  return "kind=" + metadata.substr(valueStart, valueEnd - valueStart);
+}
+
+void printRelevantActivity(const libkineto::ITraceActivity& activity) {
+  const auto type = activity.type();
+  std::cout << "KINETO_ACTIVITY"
+            << " type=" << libkineto::toString(type) << " name=\""
+            << activity.name() << "\" resource=" << activity.resourceId()
+            << " correlation=" << activity.correlationId()
+            << " duration_ns=" << activity.duration()
+            << " metadata=" << activity.metadataJson() << "\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  const Options options = parseOptions(argc, argv);
+
+  int initArgc = 1;
+  char* initArgvStorage[] = {argv[0], nullptr};
+  char** initArgv = initArgvStorage;
+  const folly::Init init(&initArgc, &initArgv);
+
+  int deviceCount = 0;
+  CHECK_HIP(hipGetDeviceCount(&deviceCount));
+  if (deviceCount == 0) {
+    std::cerr << "No HIP devices found. Run this on an AMD devgpu host.\n";
+    return 1;
+  }
+
+  CHECK_HIP(hipSetDevice(0));
+  hipDeviceProp_t props{};
+  CHECK_HIP(hipGetDeviceProperties(&props, 0));
+  std::cout << "Using HIP device 0: " << props.name << "\n";
+  std::cout << "Runtime source of truth:\n"
+            << "  hipMemcpyAsync(..., kind=hipMemcpyHostToDevice/"
+            << static_cast<int>(hipMemcpyHostToDevice) << ")\n"
+            << "  hipMemcpyWithStream(..., kind=hipMemcpyDeviceToHost/"
+            << static_cast<int>(hipMemcpyDeviceToHost) << ")\n";
+
+  hipStream_t stream = nullptr;
+  CHECK_HIP(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+
+  void* deviceBuffer = nullptr;
+  void* hostInput = nullptr;
+  void* hostOutput = nullptr;
+  CHECK_HIP(hipMalloc(&deviceBuffer, options.bytes));
+  CHECK_HIP(hipHostMalloc(&hostInput, options.bytes));
+  CHECK_HIP(hipHostMalloc(&hostOutput, options.bytes));
+  fillHostBuffer(static_cast<std::byte*>(hostInput), options.bytes);
+  std::memset(hostOutput, 0, options.bytes);
+
+  runMemcpyPair(deviceBuffer, hostInput, hostOutput, options.bytes, stream);
+  CHECK_HIP(hipStreamSynchronize(stream));
+
+  libkineto_init(false, true);
+  libkineto::api().initProfilerIfRegistered();
+
+  std::set<libkineto::ActivityType> activityTypes = {
+      libkineto::ActivityType::GPU_MEMCPY,
+      libkineto::ActivityType::GPU_MEMSET,
+      libkineto::ActivityType::CONCURRENT_KERNEL,
+      libkineto::ActivityType::EXTERNAL_CORRELATION,
+      libkineto::ActivityType::CUDA_RUNTIME,
+      libkineto::ActivityType::CUDA_DRIVER,
+  };
+
+  auto& profiler = libkineto::api().activityProfiler();
+  profiler.prepareTrace(
+      activityTypes,
+      "ACTIVITIES_WARMUP_PERIOD_SECS=0\n"
+      "ACTIVITIES_DURATION_MSECS=0\n");
+
+  profiler.startTrace();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+  for (int i = 0; i < options.iterations; ++i) {
+    runMemcpyPair(deviceBuffer, hostInput, hostOutput, options.bytes, stream);
+  }
+  CHECK_HIP(hipStreamSynchronize(stream));
+
+  auto trace = profiler.stopTrace();
+  std::cout << "Stopped Kineto trace with " << trace->activities()->size()
+            << " activities\n";
+
+  int relevantCount = 0;
+  int printedCount = 0;
+  std::map<std::string, int> memcpyActivityCounts;
+  for (const auto& activity : *trace->activities()) {
+    if (!isRelevantMemcpyActivity(*activity)) {
+      continue;
+    }
+    ++relevantCount;
+    const auto summaryKey = std::string(libkineto::toString(activity->type())) +
+        " " + activity->name() + " " +
+        extractKindForSummary(activity->metadataJson());
+    ++memcpyActivityCounts[summaryKey];
+    if (printedCount < options.printLimit) {
+      printRelevantActivity(*activity);
+      ++printedCount;
+    }
+  }
+
+  std::cout << "Relevant memcpy activities: " << relevantCount << "\n";
+  for (const auto& [summaryKey, count] : memcpyActivityCounts) {
+    std::cout << "SUMMARY " << count << " x " << summaryKey << "\n";
+  }
+
+  trace->save(options.tracePath);
+  std::cout << "Saved trace: " << options.tracePath << "\n";
+
+  CHECK_HIP(hipHostFree(hostOutput));
+  CHECK_HIP(hipHostFree(hostInput));
+  CHECK_HIP(hipFree(deviceBuffer));
+  CHECK_HIP(hipStreamDestroy(stream));
+  return 0;
+}

--- a/libkineto/sample_programs/kineto_rocm_stream_interleave_repro.cpp
+++ b/libkineto/sample_programs/kineto_rocm_stream_interleave_repro.cpp
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "kineto/libkineto/sample_programs/kineto_rocm_stream_interleave_repro_kernels.h"
+
+#include <hip/hip_runtime.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <folly/init/Init.h>
+#include <libkineto.h>
+
+namespace {
+
+constexpr const char* kDefaultTracePath =
+    "/tmp/kineto_rocm_stream_interleave_repro.json";
+
+struct Options {
+  int workers{8};
+  int launches{32};
+  int elements{1 << 18};
+  int kernelIterations{512};
+  int printLimit{40};
+  std::string tracePath{kDefaultTracePath};
+};
+
+[[noreturn]] void usage(const char* argv0) {
+  std::cerr << "Usage: " << argv0
+            << " [--workers N] [--launches N] [--elements N]"
+               " [--kernel-iters N] [--print-limit N] [--trace-path PATH]\n\n"
+            << "Runs a focused ROCm/Kineto stream-interleave repro on AMD "
+               "GPUs. Each host worker owns one HIP stream and launches an "
+               "identifiable kernel family on that stream.\n";
+  std::exit(2);
+}
+
+Options parseOptions(int argc, char** argv) {
+  Options options;
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg(argv[i]);
+    auto requireValue = [&](const char* flag) -> const char* {
+      if (i + 1 >= argc) {
+        std::cerr << "Missing value for " << flag << "\n";
+        usage(argv[0]);
+      }
+      return argv[++i];
+    };
+
+    if (arg == "--workers") {
+      options.workers = std::stoi(requireValue("--workers"));
+    } else if (arg == "--launches") {
+      options.launches = std::stoi(requireValue("--launches"));
+    } else if (arg == "--elements") {
+      options.elements = std::stoi(requireValue("--elements"));
+    } else if (arg == "--kernel-iters") {
+      options.kernelIterations = std::stoi(requireValue("--kernel-iters"));
+    } else if (arg == "--print-limit") {
+      options.printLimit = std::stoi(requireValue("--print-limit"));
+    } else if (arg == "--trace-path") {
+      options.tracePath = requireValue("--trace-path");
+    } else if (arg == "-h" || arg == "--help") {
+      usage(argv[0]);
+    } else {
+      std::cerr << "Unknown argument: " << arg << "\n";
+      usage(argv[0]);
+    }
+  }
+
+  if (options.workers <= 0 ||
+      options.workers > kineto::samples::kIssueCMaxWorkers ||
+      options.launches <= 0 || options.elements <= 0 ||
+      options.kernelIterations <= 0 || options.printLimit < 0) {
+    throw std::invalid_argument(
+        "--workers must be in [1, 16]; --launches, --elements, and --kernel-iters must be positive; --print-limit must be non-negative");
+  }
+  return options;
+}
+
+void checkHip(
+    hipError_t status,
+    const char* expression,
+    const char* file,
+    int line) {
+  if (status == hipSuccess) {
+    return;
+  }
+  std::cerr << "HIP error at " << file << ":" << line << " while running "
+            << expression << ": " << hipGetErrorString(status) << "\n";
+  std::exit(1);
+}
+
+#define CHECK_HIP(expr) checkHip((expr), #expr, __FILE__, __LINE__)
+
+std::string streamSetToString(const std::set<int64_t>& streams) {
+  std::ostringstream out;
+  bool first = true;
+  for (const auto stream : streams) {
+    if (!first) {
+      out << ",";
+    }
+    out << stream;
+    first = false;
+  }
+  return out.str();
+}
+
+bool isIssueCKernel(const libkineto::ITraceActivity& activity) {
+  return activity.type() == libkineto::ActivityType::CONCURRENT_KERNEL &&
+      activity.name().find("kineto_issue_c_worker_kernel") != std::string::npos;
+}
+
+void printKernelActivity(const libkineto::ITraceActivity& activity) {
+  std::cout << "KINETO_KERNEL"
+            << " name=\"" << activity.name() << "\""
+            << " stream=" << activity.resourceId()
+            << " correlation=" << activity.correlationId()
+            << " duration_ns=" << activity.duration()
+            << " metadata=" << activity.metadataJson() << "\n";
+}
+
+void runWorkerLaunches(
+    int workerId,
+    float* buffer,
+    hipStream_t stream,
+    const Options& options,
+    std::atomic<int>& readyWorkers,
+    std::atomic<bool>& start,
+    std::string& error) {
+  readyWorkers.fetch_add(1, std::memory_order_release);
+  while (!start.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+
+  for (int i = 0; i < options.launches; ++i) {
+    const auto status = kineto::samples::launchIssueCWorkerKernel(
+        workerId, buffer, options.elements, options.kernelIterations, stream);
+    if (status != hipSuccess) {
+      error = hipGetErrorString(status);
+      return;
+    }
+  }
+
+  const auto status = hipStreamSynchronize(stream);
+  if (status != hipSuccess) {
+    error = hipGetErrorString(status);
+  }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  const Options options = parseOptions(argc, argv);
+
+  int initArgc = 1;
+  char* initArgvStorage[] = {argv[0], nullptr};
+  char** initArgv = initArgvStorage;
+  const folly::Init init(&initArgc, &initArgv);
+
+  int deviceCount = 0;
+  CHECK_HIP(hipGetDeviceCount(&deviceCount));
+  if (deviceCount == 0) {
+    std::cerr << "No HIP devices found. Run this on an AMD devgpu host.\n";
+    return 1;
+  }
+
+  CHECK_HIP(hipSetDevice(0));
+  hipDeviceProp_t props{};
+  CHECK_HIP(hipGetDeviceProperties(&props, 0));
+  std::cout << "Using HIP device 0: " << props.name << "\n";
+  std::cout << "Issue C source-of-truth workload:\n"
+            << "  workers=" << options.workers << "\n"
+            << "  one host thread and one HIP stream per worker\n"
+            << "  launches_per_worker=" << options.launches << "\n";
+
+  std::vector<hipStream_t> streams(options.workers, nullptr);
+  std::vector<float*> buffers(options.workers, nullptr);
+  for (int worker = 0; worker < options.workers; ++worker) {
+    CHECK_HIP(hipStreamCreateWithFlags(&streams[worker], hipStreamNonBlocking));
+    std::cout << "WORKER_STREAM worker=" << worker
+              << " hip_stream=" << streams[worker] << "\n";
+    CHECK_HIP(hipMalloc(&buffers[worker], options.elements * sizeof(float)));
+    CHECK_HIP(hipMemsetAsync(
+        buffers[worker], 0, options.elements * sizeof(float), streams[worker]));
+    CHECK_HIP(
+        kineto::samples::launchIssueCWorkerKernel(
+            worker,
+            buffers[worker],
+            options.elements,
+            options.kernelIterations,
+            streams[worker]));
+    CHECK_HIP(hipStreamSynchronize(streams[worker]));
+  }
+
+  libkineto_init(false, true);
+  libkineto::api().initProfilerIfRegistered();
+
+  std::set<libkineto::ActivityType> activityTypes = {
+      libkineto::ActivityType::CONCURRENT_KERNEL,
+      libkineto::ActivityType::EXTERNAL_CORRELATION,
+      libkineto::ActivityType::CUDA_RUNTIME,
+      libkineto::ActivityType::CUDA_DRIVER,
+  };
+
+  auto& profiler = libkineto::api().activityProfiler();
+  profiler.prepareTrace(
+      activityTypes,
+      "ACTIVITIES_WARMUP_PERIOD_SECS=0\n"
+      "ACTIVITIES_DURATION_MSECS=0\n");
+
+  profiler.startTrace();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+  std::atomic<int> readyWorkers{0};
+  std::atomic<bool> start{false};
+  std::vector<std::string> workerErrors(options.workers);
+  std::vector<std::thread> threads;
+  threads.reserve(options.workers);
+  for (int worker = 0; worker < options.workers; ++worker) {
+    threads.emplace_back(
+        runWorkerLaunches,
+        worker,
+        buffers[worker],
+        streams[worker],
+        std::cref(options),
+        std::ref(readyWorkers),
+        std::ref(start),
+        std::ref(workerErrors[worker]));
+  }
+
+  while (readyWorkers.load(std::memory_order_acquire) < options.workers) {
+    std::this_thread::yield();
+  }
+  start.store(true, std::memory_order_release);
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  for (int worker = 0; worker < options.workers; ++worker) {
+    if (!workerErrors[worker].empty()) {
+      std::cerr << "Worker " << worker << " failed: " << workerErrors[worker]
+                << "\n";
+      return 1;
+    }
+  }
+
+  auto trace = profiler.stopTrace();
+  std::cout << "Stopped Kineto trace with " << trace->activities()->size()
+            << " activities\n";
+
+  int kernelCount = 0;
+  int printedCount = 0;
+  std::map<int64_t, int> kernelsByStream;
+  std::map<std::string, int> kernelsByName;
+  std::map<std::string, std::set<int64_t>> streamsByName;
+  for (const auto& activity : *trace->activities()) {
+    if (!isIssueCKernel(*activity)) {
+      continue;
+    }
+    ++kernelCount;
+    ++kernelsByStream[activity->resourceId()];
+    ++kernelsByName[activity->name()];
+    streamsByName[activity->name()].insert(activity->resourceId());
+    if (printedCount < options.printLimit) {
+      printKernelActivity(*activity);
+      ++printedCount;
+    }
+  }
+
+  std::cout << "Issue C kernel activities: " << kernelCount << "\n";
+  std::cout << "Issue C distinct kernel streams: " << kernelsByStream.size()
+            << "\n";
+  for (const auto& [stream, count] : kernelsByStream) {
+    std::cout << "SUMMARY_STREAM stream=" << stream << " kernels=" << count
+              << "\n";
+  }
+  for (const auto& [name, count] : kernelsByName) {
+    std::cout << "SUMMARY_KERNEL name=\"" << name << "\" count=" << count
+              << " streams=" << streamSetToString(streamsByName[name]) << "\n";
+  }
+
+  if (kernelCount != options.workers * options.launches) {
+    std::cout << "ISSUE_C_WARNING expected_kernel_count="
+              << options.workers * options.launches
+              << " observed_kernel_count=" << kernelCount << "\n";
+  }
+  if (static_cast<int>(kernelsByStream.size()) < options.workers) {
+    std::cout << "ISSUE_C_WARNING expected_at_least_streams=" << options.workers
+              << " observed_streams=" << kernelsByStream.size() << "\n";
+  }
+  for (const auto& [name, streams] : streamsByName) {
+    if (streams.size() > 1) {
+      std::cout << "ISSUE_C_WARNING kernel_name_spread name=\"" << name
+                << "\" streams=" << streamSetToString(streams) << "\n";
+    }
+  }
+
+  trace->save(options.tracePath);
+  std::cout << "Saved trace: " << options.tracePath << "\n";
+
+  for (int worker = 0; worker < options.workers; ++worker) {
+    CHECK_HIP(hipFree(buffers[worker]));
+    CHECK_HIP(hipStreamDestroy(streams[worker]));
+  }
+  return 0;
+}

--- a/libkineto/sample_programs/kineto_rocm_stream_interleave_repro_kernels.h
+++ b/libkineto/sample_programs/kineto_rocm_stream_interleave_repro_kernels.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <hip/hip_runtime_api.h>
+
+namespace kineto::samples {
+
+constexpr int kIssueCMaxWorkers = 16;
+
+hipError_t launchIssueCWorkerKernel(int workerId, float* buffer, int elements, int iterations, hipStream_t stream);
+
+} // namespace kineto::samples

--- a/libkineto/sample_programs/kineto_rocm_stream_interleave_repro_kernels.hip
+++ b/libkineto/sample_programs/kineto_rocm_stream_interleave_repro_kernels.hip
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "kineto/libkineto/sample_programs/kineto_rocm_stream_interleave_repro_kernels.h"
+
+#include <hip/hip_runtime.h>
+
+namespace kineto::samples {
+namespace {
+
+template <int WorkerId>
+__global__ void kineto_issue_c_worker_kernel(
+    float* buffer,
+    int elements,
+    int iterations) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int stride = blockDim.x * gridDim.x;
+  for (int offset = idx; offset < elements; offset += stride) {
+    float value = buffer[offset] + static_cast<float>(WorkerId + 1);
+#pragma unroll 1
+    for (int i = 0; i < iterations; ++i) {
+      value = value * 1.000001f +
+          static_cast<float>((WorkerId + 1) * 0.000001f);
+    }
+    buffer[offset] = value;
+  }
+}
+
+template <int WorkerId>
+hipError_t launchTypedWorkerKernel(
+    float* buffer,
+    int elements,
+    int iterations,
+    hipStream_t stream) {
+  constexpr int kThreadsPerBlock = 256;
+  const int blocks = (elements + kThreadsPerBlock - 1) / kThreadsPerBlock;
+  hipLaunchKernelGGL(
+      (kineto_issue_c_worker_kernel<WorkerId>),
+      dim3(blocks),
+      dim3(kThreadsPerBlock),
+      0,
+      stream,
+      buffer,
+      elements,
+      iterations);
+  return hipGetLastError();
+}
+
+} // namespace
+
+hipError_t launchIssueCWorkerKernel(
+    int workerId,
+    float* buffer,
+    int elements,
+    int iterations,
+    hipStream_t stream) {
+  switch (workerId) {
+    case 0:
+      return launchTypedWorkerKernel<0>(buffer, elements, iterations, stream);
+    case 1:
+      return launchTypedWorkerKernel<1>(buffer, elements, iterations, stream);
+    case 2:
+      return launchTypedWorkerKernel<2>(buffer, elements, iterations, stream);
+    case 3:
+      return launchTypedWorkerKernel<3>(buffer, elements, iterations, stream);
+    case 4:
+      return launchTypedWorkerKernel<4>(buffer, elements, iterations, stream);
+    case 5:
+      return launchTypedWorkerKernel<5>(buffer, elements, iterations, stream);
+    case 6:
+      return launchTypedWorkerKernel<6>(buffer, elements, iterations, stream);
+    case 7:
+      return launchTypedWorkerKernel<7>(buffer, elements, iterations, stream);
+    case 8:
+      return launchTypedWorkerKernel<8>(buffer, elements, iterations, stream);
+    case 9:
+      return launchTypedWorkerKernel<9>(buffer, elements, iterations, stream);
+    case 10:
+      return launchTypedWorkerKernel<10>(buffer, elements, iterations, stream);
+    case 11:
+      return launchTypedWorkerKernel<11>(buffer, elements, iterations, stream);
+    case 12:
+      return launchTypedWorkerKernel<12>(buffer, elements, iterations, stream);
+    case 13:
+      return launchTypedWorkerKernel<13>(buffer, elements, iterations, stream);
+    case 14:
+      return launchTypedWorkerKernel<14>(buffer, elements, iterations, stream);
+    case 15:
+      return launchTypedWorkerKernel<15>(buffer, elements, iterations, stream);
+    default:
+      return hipErrorInvalidValue;
+  }
+}
+
+} // namespace kineto::samples

--- a/libkineto/src/RocLogger.h
+++ b/libkineto/src/RocLogger.h
@@ -145,6 +145,7 @@ struct rocprofKernelRow : public rocprofRow {
   unsigned int workgroupZ;
   size_t groupSegmentSize;
   hipStream_t stream;
+  std::string kernelName;
 };
 
 struct rocprofCopyRow : public rocprofRow {
@@ -211,5 +212,7 @@ struct rocprofAsyncRow : public rocprofBase {
   uint32_t op;
   int device;
   uint64_t queue;
+  uint64_t stream{0};
+  uint64_t tid{0};
   std::string kernelName;
 };

--- a/libkineto/src/RocmStreamQueue.h
+++ b/libkineto/src/RocmStreamQueue.h
@@ -11,10 +11,12 @@
 #ifdef HAS_ROCTRACER
 
 #include <cstdint>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include "Demangle.h"
 #include "RocLogger.h"
 
 namespace KINETO_NAMESPACE {
@@ -24,76 +26,163 @@ inline uint64_t streamIdFromHipStream(hipStream_t stream) {
   return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(stream));
 }
 
-inline uint64_t runtimeStreamId(const rocprofBase* item) {
+inline uint64_t runtimeKernelStreamId(const rocprofBase* item) {
   if (item->type == ROCTRACER_ACTIVITY_KERNEL) {
     return streamIdFromHipStream(reinterpret_cast<const rocprofKernelRow*>(item)->stream);
   }
+  return 0;
+}
+
+inline uint64_t runtimeCopyStreamId(const rocprofBase* item) {
   if (item->type == ROCTRACER_ACTIVITY_COPY) {
     return streamIdFromHipStream(reinterpret_cast<const rocprofCopyRow*>(item)->stream);
   }
   return 0;
 }
 
+inline uint64_t runtimeStreamId(const rocprofBase* item) {
+  if (const uint64_t streamId = runtimeKernelStreamId(item)) {
+    return streamId;
+  }
+  return runtimeCopyStreamId(item);
+}
+
+inline std::string canonicalKernelName(const std::string& name) {
+  constexpr char kRocmCloneSuffix[] = " [clone .kd]";
+  constexpr size_t kRocmCloneSuffixLength = sizeof(kRocmCloneSuffix) - 1;
+  if (name.size() >= kRocmCloneSuffixLength &&
+      name.compare(name.size() - kRocmCloneSuffixLength, kRocmCloneSuffixLength, kRocmCloneSuffix) == 0) {
+    return name.substr(0, name.size() - kRocmCloneSuffixLength);
+  }
+  return name;
+}
+
 struct StreamQueueMaps {
-  std::unordered_map<uint64_t, uint64_t> runtimeStreamByCorrelation;
+  std::unordered_map<uint64_t, uint64_t> runtimeCopyStreamByCorrelation;
+  std::unordered_map<uint64_t, uint64_t> runtimeKernelStreamByCorrelation;
+  std::unordered_map<uint64_t, uint64_t> runtimeKernelStreamByThread;
+  std::unordered_map<std::string, uint64_t> runtimeKernelStreamByName;
   std::unordered_map<uint64_t, uint64_t> asyncQueueByRuntimeStream;
+  std::unordered_set<uint64_t> duplicatedAsyncKernelCorrelations;
   // Prefer preserving stream 0 over guessing when one HIP stream maps to
   // multiple ROCm async queues in the same trace.
   std::unordered_set<uint64_t> ambiguousRuntimeStreams;
+  std::unordered_set<uint64_t> ambiguousRuntimeKernelThreads;
+  std::unordered_set<std::string> ambiguousRuntimeKernelNames;
 };
 
-inline void rememberCorrelationQueue(std::unordered_map<uint64_t, uint64_t>& asyncQueueByCorrelation,
-                                     std::unordered_set<uint64_t>& ambiguousCorrelations,
-                                     uint64_t correlationId,
-                                     uint64_t queue) {
-  if (ambiguousCorrelations.count(correlationId) > 0) {
+template <class Key, class Value>
+inline void rememberUniqueMapping(std::unordered_map<Key, Value>& mapping,
+                                  std::unordered_set<Key>& ambiguousKeys,
+                                  const Key& key,
+                                  Value value) {
+  if (ambiguousKeys.count(key) > 0) {
     return;
   }
-  const auto [queueIt, inserted] = asyncQueueByCorrelation.emplace(correlationId, queue);
-  if (!inserted && queueIt->second != queue) {
-    asyncQueueByCorrelation.erase(queueIt);
-    ambiguousCorrelations.insert(correlationId);
+  const auto [it, inserted] = mapping.emplace(key, value);
+  if (!inserted && it->second != value) {
+    mapping.erase(it);
+    ambiguousKeys.insert(key);
   }
 }
 
-inline void rememberQueueForRuntimeStream(StreamQueueMaps& maps, uint64_t stream, uint64_t queue) {
-  if (maps.ambiguousRuntimeStreams.count(stream) > 0) {
-    return;
-  }
-  const auto [queueIt, inserted] = maps.asyncQueueByRuntimeStream.emplace(stream, queue);
-  if (!inserted && queueIt->second != queue) {
-    maps.asyncQueueByRuntimeStream.erase(queueIt);
-    maps.ambiguousRuntimeStreams.insert(stream);
+inline void rememberDuplicateCorrelation(std::unordered_set<uint64_t>& seen,
+                                         std::unordered_set<uint64_t>& duplicated,
+                                         uint64_t correlationId) {
+  if (!seen.insert(correlationId).second) {
+    duplicated.insert(correlationId);
   }
 }
 
-inline StreamQueueMaps buildStreamQueueMaps(const std::vector<rocprofBase*>& rows) {
+inline std::string runtimeKernelName(const rocprofKernelRow& kernel) {
+  if (!kernel.kernelName.empty()) {
+    return kernel.kernelName;
+  }
+  if (kernel.functionAddr != nullptr) {
+    return demangle(hipKernelNameRefByPtr(kernel.functionAddr, kernel.stream));
+  }
+  if (kernel.function != nullptr) {
+    return demangle(hipKernelNameRef(kernel.function));
+  }
+  return "";
+}
+
+template <class IsAsyncKernel>
+inline StreamQueueMaps buildStreamQueueMaps(const std::vector<rocprofBase*>& rows,
+                                            bool includeCopies,
+                                            bool includeKernels,
+                                            IsAsyncKernel isAsyncKernel) {
   StreamQueueMaps maps;
   std::unordered_map<uint64_t, uint64_t> asyncQueueByCorrelation;
   std::unordered_set<uint64_t> ambiguousCorrelations;
+  std::unordered_set<uint64_t> asyncKernelCorrelations;
+  std::unordered_set<uint64_t> namedAsyncKernelCorrelations;
 
   for (const auto* item : rows) {
-    const uint64_t streamId = runtimeStreamId(item);
-    if (streamId != 0) {
-      maps.runtimeStreamByCorrelation[item->id] = streamId;
+    if (includeCopies) {
+      if (const uint64_t streamId = runtimeCopyStreamId(item)) {
+        maps.runtimeCopyStreamByCorrelation[item->id] = streamId;
+      }
+    }
+    if (includeKernels) {
+      if (const uint64_t streamId = runtimeKernelStreamId(item)) {
+        maps.runtimeKernelStreamByCorrelation[item->id] = streamId;
+        const auto* kernel = reinterpret_cast<const rocprofKernelRow*>(item);
+        if (kernel->tid != 0) {
+          rememberUniqueMapping(maps.runtimeKernelStreamByThread,
+                                maps.ambiguousRuntimeKernelThreads,
+                                static_cast<uint64_t>(kernel->tid),
+                                streamId);
+        }
+      }
     }
 
     if (item->type == ROCTRACER_ACTIVITY_ASYNC) {
       const auto* async = reinterpret_cast<const rocprofAsyncRow*>(item);
-      if (async->queue != 0) {
-        rememberCorrelationQueue(asyncQueueByCorrelation, ambiguousCorrelations, async->id, async->queue);
+      if (includeCopies && async->queue != 0) {
+        rememberUniqueMapping(asyncQueueByCorrelation, ambiguousCorrelations, async->id, async->queue);
+      }
+      if (includeKernels && isAsyncKernel(*async)) {
+        rememberDuplicateCorrelation(asyncKernelCorrelations, maps.duplicatedAsyncKernelCorrelations, async->id);
+        if (!async->kernelName.empty()) {
+          namedAsyncKernelCorrelations.insert(async->id);
+        }
       }
     }
   }
 
-  for (const auto* item : rows) {
-    const uint64_t streamId = runtimeStreamId(item);
-    if (streamId == 0 || ambiguousCorrelations.count(item->id) > 0) {
-      continue;
+  const bool buildCopyQueueMap = includeCopies && !asyncQueueByCorrelation.empty();
+  bool buildKernelNameMap = false;
+  if (includeKernels) {
+    for (const uint64_t correlation : maps.duplicatedAsyncKernelCorrelations) {
+      if (namedAsyncKernelCorrelations.count(correlation) > 0) {
+        buildKernelNameMap = true;
+        break;
+      }
     }
-    const auto queue = asyncQueueByCorrelation.find(item->id);
-    if (queue != asyncQueueByCorrelation.end()) {
-      rememberQueueForRuntimeStream(maps, streamId, queue->second);
+  }
+  if (!buildCopyQueueMap && !buildKernelNameMap) {
+    return maps;
+  }
+
+  for (const auto* item : rows) {
+    if (buildCopyQueueMap) {
+      const uint64_t streamId = runtimeStreamId(item);
+      if (streamId != 0 && ambiguousCorrelations.count(item->id) == 0) {
+        const auto queue = asyncQueueByCorrelation.find(item->id);
+        if (queue != asyncQueueByCorrelation.end()) {
+          rememberUniqueMapping(maps.asyncQueueByRuntimeStream, maps.ambiguousRuntimeStreams, streamId, queue->second);
+        }
+      }
+    }
+    if (buildKernelNameMap && item->type == ROCTRACER_ACTIVITY_KERNEL) {
+      const auto* kernel = reinterpret_cast<const rocprofKernelRow*>(item);
+      if (const uint64_t streamId = streamIdFromHipStream(kernel->stream)) {
+        const auto kernelName = canonicalKernelName(runtimeKernelName(*kernel));
+        if (!kernelName.empty()) {
+          rememberUniqueMapping(maps.runtimeKernelStreamByName, maps.ambiguousRuntimeKernelNames, kernelName, streamId);
+        }
+      }
     }
   }
 
@@ -101,9 +190,8 @@ inline StreamQueueMaps buildStreamQueueMaps(const std::vector<rocprofBase*>& row
 }
 
 template <class IsAsyncCopy>
-void backfillAsyncCopyStreams(std::vector<rocprofBase*>& rows, IsAsyncCopy isAsyncCopy) {
-  const auto maps = buildStreamQueueMaps(rows);
-  if (maps.runtimeStreamByCorrelation.empty() || maps.asyncQueueByRuntimeStream.empty()) {
+void backfillAsyncCopyStreams(std::vector<rocprofBase*>& rows, const StreamQueueMaps& maps, IsAsyncCopy isAsyncCopy) {
+  if (maps.runtimeCopyStreamByCorrelation.empty() || maps.asyncQueueByRuntimeStream.empty()) {
     return;
   }
   for (auto* item : rows) {
@@ -114,14 +202,77 @@ void backfillAsyncCopyStreams(std::vector<rocprofBase*>& rows, IsAsyncCopy isAsy
     if (!isAsyncCopy(*async) || async->queue != 0) {
       continue;
     }
-    const auto stream = maps.runtimeStreamByCorrelation.find(async->id);
-    if (stream == maps.runtimeStreamByCorrelation.end() || maps.ambiguousRuntimeStreams.count(stream->second) > 0) {
+    const auto stream = maps.runtimeCopyStreamByCorrelation.find(async->id);
+    if (stream == maps.runtimeCopyStreamByCorrelation.end()) {
       continue;
     }
     const auto queue = maps.asyncQueueByRuntimeStream.find(stream->second);
     if (queue != maps.asyncQueueByRuntimeStream.end()) {
       async->queue = queue->second;
     }
+  }
+}
+
+template <class IsAsyncKernel>
+void backfillAsyncKernelStreams(std::vector<rocprofBase*>& rows,
+                                const StreamQueueMaps& maps,
+                                IsAsyncKernel isAsyncKernel) {
+  if (maps.runtimeKernelStreamByCorrelation.empty() && maps.runtimeKernelStreamByThread.empty() &&
+      maps.runtimeKernelStreamByName.empty()) {
+    return;
+  }
+  for (auto* item : rows) {
+    if (item->type != ROCTRACER_ACTIVITY_ASYNC) {
+      continue;
+    }
+    auto* async = reinterpret_cast<rocprofAsyncRow*>(item);
+    if (!isAsyncKernel(*async)) {
+      continue;
+    }
+    const bool duplicatedCorrelation = maps.duplicatedAsyncKernelCorrelations.count(async->id) > 0;
+    if (duplicatedCorrelation && !async->kernelName.empty()) {
+      const auto kernelName = canonicalKernelName(async->kernelName);
+      const auto stream = maps.runtimeKernelStreamByName.find(kernelName);
+      if (stream != maps.runtimeKernelStreamByName.end()) {
+        async->stream = stream->second;
+        continue;
+      }
+    }
+    if (async->tid != 0) {
+      const auto stream = maps.runtimeKernelStreamByThread.find(async->tid);
+      if (stream != maps.runtimeKernelStreamByThread.end()) {
+        async->stream = stream->second;
+        continue;
+      }
+    }
+    if (duplicatedCorrelation) {
+      continue;
+    }
+    if (async->stream != 0) {
+      continue;
+    }
+    const auto stream = maps.runtimeKernelStreamByCorrelation.find(async->id);
+    if (stream != maps.runtimeKernelStreamByCorrelation.end()) {
+      async->stream = stream->second;
+    }
+  }
+}
+
+template <class IsAsyncCopy, class IsAsyncKernel>
+void backfillAsyncStreams(std::vector<rocprofBase*>& rows,
+                          bool includeCopies,
+                          bool includeKernels,
+                          IsAsyncCopy isAsyncCopy,
+                          IsAsyncKernel isAsyncKernel) {
+  if (!includeCopies && !includeKernels) {
+    return;
+  }
+  const auto maps = buildStreamQueueMaps(rows, includeCopies, includeKernels, isAsyncKernel);
+  if (includeCopies) {
+    backfillAsyncCopyStreams(rows, maps, isAsyncCopy);
+  }
+  if (includeKernels) {
+    backfillAsyncKernelStreams(rows, maps, isAsyncKernel);
   }
 }
 

--- a/libkineto/src/RocprofActivity.h
+++ b/libkineto/src/RocprofActivity.h
@@ -99,7 +99,7 @@ struct GpuActivity : public RocprofActivity<rocprofAsyncRow> {
     return activity_.device;
   }
   int64_t resourceId() const override {
-    return activity_.queue;
+    return activity_.stream != 0 ? activity_.stream : activity_.queue;
   }
   ActivityType type() const override {
     return type_;

--- a/libkineto/src/RocprofActivityApi.cpp
+++ b/libkineto/src/RocprofActivityApi.cpp
@@ -30,6 +30,10 @@ namespace {
 bool isAsyncCopy(const rocprofAsyncRow& async) {
   return async.domain == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY;
 }
+
+bool isAsyncKernel(const rocprofAsyncRow& async) {
+  return async.domain == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH;
+}
 } // namespace
 
 RocprofActivityApi& RocprofActivityApi::singleton() {
@@ -127,9 +131,12 @@ int RocprofActivityApi::processActivities(
   // much better job.
   auto toffset = getTimeOffset();
 
-  if (isLogged(ActivityType::GPU_MEMCPY)) {
-    detail::backfillAsyncCopyStreams(d->rows_, isAsyncCopy);
-  }
+  detail::backfillAsyncStreams(
+      d->rows_,
+      isLogged(ActivityType::GPU_MEMCPY),
+      isLogged(ActivityType::CONCURRENT_KERNEL),
+      isAsyncCopy,
+      isAsyncKernel);
 
   // All Runtime API Calls
   for (auto& item : d->rows_) {

--- a/libkineto/src/RocprofActivity_inl.h
+++ b/libkineto/src/RocprofActivity_inl.h
@@ -112,7 +112,7 @@ inline const std::string GpuActivity::metadataJson() const {
       "device": {}, "stream": {},
       "correlation": {}, "kind": "{}",
       "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
-      gpuActivity.device, gpuActivity.queue,
+      gpuActivity.device, resourceId(),
       gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op),
       size, bandwidth_gib);
   }
@@ -123,14 +123,14 @@ inline const std::string GpuActivity::metadataJson() const {
       "device": {}, "stream": {},
       "correlation": {}, "kind": "{}",
       "grid": {}, "block": {})JSON",
-      gpuActivity.device, gpuActivity.queue,
+      gpuActivity.device, resourceId(),
       gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op),
       correlationToGrid[gpuActivity.id], correlationToBlock[gpuActivity.id]);
   } else {
     return fmt::format(R"JSON(
       "device": {}, "stream": {},
       "correlation": {}, "kind": "{}")JSON",
-      gpuActivity.device, gpuActivity.queue,
+      gpuActivity.device, resourceId(),
       gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op));
   }
   // clang-format on
@@ -162,7 +162,12 @@ inline void RuntimeActivity<T>::log(ActivityLogger& logger) const {
 template <>
 inline const std::string RuntimeActivity<rocprofKernelRow>::metadataJson() const {
   std::string kernel = "";
-  if ((raw().functionAddr != nullptr)) {
+  if (!raw().kernelName.empty()) {
+    kernel = fmt::format(
+        R"JSON(
+    "kernel": "{}", )JSON",
+        raw().kernelName);
+  } else if ((raw().functionAddr != nullptr)) {
     kernel = fmt::format(
         R"JSON(
     "kernel": "{}", )JSON",

--- a/libkineto/src/RocprofLogger.cpp
+++ b/libkineto/src/RocprofLogger.cpp
@@ -10,6 +10,7 @@
 
 #include <rocprofiler-sdk/context.h>
 #include <rocprofiler-sdk/cxx/name_info.hpp>
+#include <rocprofiler-sdk/external_correlation.h>
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/marker/api_id.h>
 #include <rocprofiler-sdk/registration.h>
@@ -41,6 +42,10 @@ using kernel_name_map_t =
 using rocprofiler::sdk::buffer_name_info;
 using rocprofiler::sdk::callback_name_info;
 using agent_info_map_t = std::unordered_map<uint64_t, rocprofiler_agent_v0_t>;
+
+uint64_t streamIdFromHipStream(hipStream_t stream) {
+  return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(stream));
+}
 
 // extract copy args
 struct copy_args {
@@ -82,8 +87,10 @@ auto extract_copy_args =
 
 // extract kernel args
 struct kernel_args {
-  // const char *stream;
+  const void* functionAddr{nullptr};
+  hipFunction_t function{nullptr};
   hipStream_t stream{nullptr};
+  bool pushedStreamCorrelation{false};
   uint32_t privateSize{0};
   uint32_t groupSize{0};
   rocprofiler_dim3_t workgroupSize{0, 0, 0};
@@ -103,9 +110,15 @@ auto extract_kernel_args =
        [[maybe_unused]] int32_t dereference_count,
        void* cb_data) -> int {
   auto& args = *(static_cast<kernel_args*>(cb_data));
-  if (strcmp("stream", arg_name) == 0)
+  if (strcmp("function_address", arg_name) == 0 ||
+      strcmp("functionAddress", arg_name) == 0 ||
+      strcmp("func", arg_name) == 0) {
+    args.functionAddr = *(reinterpret_cast<const void* const*>(arg_value_addr));
+  } else if (strcmp("f", arg_name) == 0 || strcmp("function", arg_name) == 0) {
+    args.function = *(reinterpret_cast<const hipFunction_t*>(arg_value_addr));
+  } else if (strcmp("stream", arg_name) == 0) {
     args.stream = *(reinterpret_cast<const hipStream_t*>(arg_value_addr));
-  else if (strcmp("numBlocks", arg_name) == 0)
+  } else if (strcmp("numBlocks", arg_name) == 0)
     args.workgroupSize =
         *(reinterpret_cast<const rocprofiler_dim3_t*>(arg_value_addr));
   else if (strcmp("dimBlocks", arg_name) == 0)
@@ -549,17 +562,12 @@ void RocprofLogger::api_callback(
     [[maybe_unused]] rocprofiler_user_data_t* user_data,
     [[maybe_unused]] void* callback_data) {
   thread_local std::unordered_map<uint64_t, uint64_t> timestamps;
+  thread_local std::unordered_map<uint64_t, kernel_args>
+      kernelArgsByCorrelation;
 
   if (record.kind == ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API) {
     if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
       timestamps[record.correlation_id.internal] = getApproximateTime();
-    } // ROCPROFILER_CALLBACK_PHASE_ENTER
-    else { // ROCPROFILER_CALLBACK_PHASE_EXIT
-      uint64_t startTime = timestamps[record.correlation_id.internal];
-      timestamps.erase(record.correlation_id.internal);
-      uint64_t endTime = getApproximateTime();
-
-      // Kernel Launch Records
       if (isKernelApi(record.operation)) {
         kernel_args args;
         rocprofiler_iterate_callback_tracing_kind_operation_args(
@@ -568,6 +576,40 @@ void RocprofLogger::api_callback(
             1 /*max_deref*/
             ,
             &args);
+        rocprofiler_user_data_t streamCorrelation{};
+        streamCorrelation.value = streamIdFromHipStream(args.stream);
+        if (streamCorrelation.value != 0 &&
+            rocprofiler_push_external_correlation_id(
+                record.context_id, record.thread_id, streamCorrelation) ==
+                ROCPROFILER_STATUS_SUCCESS) {
+          args.pushedStreamCorrelation = true;
+        }
+        kernelArgsByCorrelation[record.correlation_id.internal] = args;
+      }
+    } // ROCPROFILER_CALLBACK_PHASE_ENTER
+    else { // ROCPROFILER_CALLBACK_PHASE_EXIT
+      uint64_t startTime = timestamps[record.correlation_id.internal];
+      timestamps.erase(record.correlation_id.internal);
+      uint64_t endTime = getApproximateTime();
+      bool popStreamCorrelation = false;
+
+      // Kernel Launch Records
+      if (isKernelApi(record.operation)) {
+        kernel_args args;
+        auto argsIt =
+            kernelArgsByCorrelation.find(record.correlation_id.internal);
+        if (argsIt != kernelArgsByCorrelation.end()) {
+          args = argsIt->second;
+          kernelArgsByCorrelation.erase(argsIt);
+        } else {
+          rocprofiler_iterate_callback_tracing_kind_operation_args(
+              record,
+              extract_kernel_args,
+              1 /*max_deref*/
+              ,
+              &args);
+        }
+        popStreamCorrelation = args.pushedStreamCorrelation;
 
         rocprofKernelRow* row = new rocprofKernelRow(
             record.correlation_id.internal,
@@ -577,8 +619,8 @@ void RocprofLogger::api_callback(
             systemThreadId(),
             startTime,
             endTime,
-            nullptr,
-            nullptr,
+            args.functionAddr,
+            args.function,
             args.workgroupSize.x,
             args.workgroupSize.y,
             args.workgroupSize.z,
@@ -660,6 +702,11 @@ void RocprofLogger::api_callback(
               record.correlation_id.internal, t_externalIds[it].back());
         }
       }
+      if (popStreamCorrelation) {
+        rocprofiler_user_data_t poppedCorrelation{};
+        rocprofiler_pop_external_correlation_id(
+            record.context_id, record.thread_id, &poppedCorrelation);
+      }
     } // ROCPROFILER_CALLBACK_PHASE_EXIT
   } // ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API
 }
@@ -705,6 +752,8 @@ void RocprofLogger::buffer_callback(
             record.start_timestamp,
             record.end_timestamp,
             kernel_name);
+        row->stream = record.correlation_id.external.value;
+        row->tid = record.thread_id;
         insert_row_to_buffer(row);
       } else if (header->kind == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY) {
         auto& record =
@@ -728,6 +777,7 @@ void RocprofLogger::buffer_callback(
             record.start_timestamp,
             record.end_timestamp,
             "");
+        row->tid = record.thread_id;
         insert_row_to_buffer(row);
       }
     }

--- a/libkineto/src/RoctracerActivity.h
+++ b/libkineto/src/RoctracerActivity.h
@@ -110,7 +110,7 @@ struct GpuActivity : public RoctracerActivity<rocprofAsyncRow> {
     return activity_.device;
   }
   int64_t resourceId() const override {
-    return activity_.queue;
+    return activity_.stream != 0 ? activity_.stream : activity_.queue;
   }
   ActivityType type() const override {
     return type_;

--- a/libkineto/src/RoctracerActivityApi.cpp
+++ b/libkineto/src/RoctracerActivityApi.cpp
@@ -40,6 +40,10 @@ bool isAsyncCopy(const rocprofAsyncRow& async) {
       return false;
   }
 }
+
+bool isAsyncKernel(const rocprofAsyncRow& async) {
+  return async.kind == HIP_OP_DISPATCH_KIND_KERNEL_;
+}
 } // namespace
 
 RoctracerActivityApi& RoctracerActivityApi::singleton() {
@@ -135,9 +139,12 @@ int RoctracerActivityApi::processActivities(
   // much better job.
   auto toffset = getTimeOffset();
 
-  if (isLogged(ActivityType::GPU_MEMCPY)) {
-    detail::backfillAsyncCopyStreams(d->rows_, isAsyncCopy);
-  }
+  detail::backfillAsyncStreams(
+      d->rows_,
+      isLogged(ActivityType::GPU_MEMCPY),
+      isLogged(ActivityType::CONCURRENT_KERNEL),
+      isAsyncCopy,
+      isAsyncKernel);
 
   // All Runtime API Calls
   for (auto& item : d->rows_) {

--- a/libkineto/src/RoctracerActivity_inl.h
+++ b/libkineto/src/RoctracerActivity_inl.h
@@ -112,7 +112,7 @@ inline const std::string GpuActivity::metadataJson() const {
       "device": {}, "stream": {},
       "correlation": {}, "kind": "{}",
       "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
-      gpuActivity.device, gpuActivity.queue,
+      gpuActivity.device, resourceId(),
       gpuActivity.id, getGpuActivityKindString(gpuActivity.kind),
       size, bandwidth_gib);
   }
@@ -123,14 +123,14 @@ inline const std::string GpuActivity::metadataJson() const {
       "device": {}, "stream": {},
       "correlation": {}, "kind": "{}",
       "grid": {}, "block": {})JSON",
-      gpuActivity.device, gpuActivity.queue,
+      gpuActivity.device, resourceId(),
       gpuActivity.id, getGpuActivityKindString(gpuActivity.kind),
       correlationToGrid[gpuActivity.id], correlationToBlock[gpuActivity.id]);
   } else {
     return fmt::format(R"JSON(
       "device": {}, "stream": {},
       "correlation": {}, "kind": "{}")JSON",
-      gpuActivity.device, gpuActivity.queue,
+      gpuActivity.device, resourceId(),
       gpuActivity.id, getGpuActivityKindString(gpuActivity.kind));
   }
   // clang-format on
@@ -156,7 +156,12 @@ inline void RuntimeActivity<T>::log(ActivityLogger& logger) const {
 template <>
 inline const std::string RuntimeActivity<rocprofKernelRow>::metadataJson() const {
   std::string kernel = "";
-  if ((raw().functionAddr != nullptr)) {
+  if (!raw().kernelName.empty()) {
+    kernel = fmt::format(
+        R"JSON(
+    "kernel": "{}", )JSON",
+        raw().kernelName);
+  } else if ((raw().functionAddr != nullptr)) {
     kernel = fmt::format(
         R"JSON(
     "kernel": "{}", )JSON",

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -17,6 +17,9 @@
 #include <cstdlib>
 #include <fstream>
 #include <iterator>
+#include <memory>
+#include <set>
+#include <utility>
 
 #include <unistd.h>
 
@@ -109,6 +112,14 @@ bool isAsyncCopy(const rocprofAsyncRow& async) {
   return async.domain == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY;
 #endif
 }
+
+bool isAsyncKernel(const rocprofAsyncRow& async) {
+#ifdef ROCTRACER_FALLBACK
+  return async.kind == HIP_OP_DISPATCH_KIND_KERNEL_;
+#else
+  return async.domain == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH;
+#endif
+}
 } // namespace
 
 // Provides ability to easily create a test CPU-side ops
@@ -155,13 +166,15 @@ struct MockRocLogger {
       int64_t start_ns,
       int64_t end_ns,
       int64_t correlation,
-      uint64_t stream = 0) {
-    rocprofKernelRow* row = new rocprofKernelRow(
+      uint64_t stream = 0,
+      uint32_t tid = 0,
+      std::string kernelName = "") {
+    rocprofKernelRow* row = emplaceActivity<rocprofKernelRow>(
         correlation,
         RUNTIME_DOMAIN,
         cid,
         processId(),
-        systemThreadId(),
+        tid == 0 ? systemThreadId() : tid,
         start_ns,
         end_ns,
         nullptr,
@@ -174,7 +187,7 @@ struct MockRocLogger {
         0,
         0,
         reinterpret_cast<hipStream_t>(stream));
-    activities_.push_back(row);
+    row->kernelName = kernelName;
   }
 
   void addRuntimeMallocActivity(
@@ -182,7 +195,7 @@ struct MockRocLogger {
       int64_t start_ns,
       int64_t end_ns,
       int64_t correlation) {
-    rocprofMallocRow* row = new rocprofMallocRow(
+    emplaceActivity<rocprofMallocRow>(
         correlation,
         RUNTIME_DOMAIN,
         cid,
@@ -192,7 +205,6 @@ struct MockRocLogger {
         end_ns,
         nullptr,
         1);
-    activities_.push_back(row);
   }
 
   void addRuntimeCopyActivity(
@@ -202,7 +214,7 @@ struct MockRocLogger {
       int64_t correlation,
       hipMemcpyKind kind = hipMemcpyHostToHost,
       uint64_t stream = 0) {
-    rocprofCopyRow* row = new rocprofCopyRow(
+    emplaceActivity<rocprofCopyRow>(
         correlation,
         RUNTIME_DOMAIN,
         cid,
@@ -215,16 +227,18 @@ struct MockRocLogger {
         1,
         kind,
         reinterpret_cast<hipStream_t>(stream));
-    activities_.push_back(row);
   }
 
   void addKernelActivity(
       int64_t start_ns,
       int64_t end_ns,
       int64_t correlation,
-      uint64_t queue = 1) {
+      uint64_t queue = 1,
+      uint64_t tid = 0,
+      uint64_t stream = 0,
+      std::string kernelName = "kernel") {
 #ifdef ROCTRACER_FALLBACK
-    rocprofAsyncRow* row = new rocprofAsyncRow(
+    rocprofAsyncRow* row = emplaceActivity<rocprofAsyncRow>(
         correlation,
         ACTIVITY_DOMAIN_HIP_API,
         HIP_OP_DISPATCH_KIND_KERNEL_,
@@ -233,9 +247,9 @@ struct MockRocLogger {
         queue,
         start_ns,
         end_ns,
-        std::string("kernel"));
+        kernelName);
 #else
-    rocprofAsyncRow* row = new rocprofAsyncRow(
+    rocprofAsyncRow* row = emplaceActivity<rocprofAsyncRow>(
         correlation,
         ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
         0,
@@ -244,9 +258,10 @@ struct MockRocLogger {
         queue,
         start_ns,
         end_ns,
-        std::string("kernel"));
+        kernelName);
 #endif
-    activities_.push_back(row);
+    row->tid = tid;
+    row->stream = stream;
   }
 
   void addMemcpyH2DActivity(
@@ -255,7 +270,7 @@ struct MockRocLogger {
       int64_t correlation,
       uint64_t queue = 2) {
 #ifdef ROCTRACER_FALLBACK
-    rocprofAsyncRow* row = new rocprofAsyncRow(
+    emplaceActivity<rocprofAsyncRow>(
         correlation,
         ACTIVITY_DOMAIN_HIP_API,
         HIP_OP_COPY_KIND_HOST_TO_DEVICE_,
@@ -266,7 +281,7 @@ struct MockRocLogger {
         end_ns,
         std::string());
 #else
-    rocprofAsyncRow* row = new rocprofAsyncRow(
+    emplaceActivity<rocprofAsyncRow>(
         correlation,
         ROCPROFILER_BUFFER_TRACING_MEMORY_COPY,
         0,
@@ -277,7 +292,6 @@ struct MockRocLogger {
         end_ns,
         std::string());
 #endif
-    activities_.push_back(row);
   }
 
   void addMemcpyD2HActivity(
@@ -285,7 +299,7 @@ struct MockRocLogger {
       int64_t end_ns,
       int64_t correlation) {
 #ifdef ROCTRACER_FALLBACK
-    rocprofAsyncRow* row = new rocprofAsyncRow(
+    emplaceActivity<rocprofAsyncRow>(
         correlation,
         ACTIVITY_DOMAIN_HIP_API,
         HIP_OP_COPY_KIND_DEVICE_TO_HOST_,
@@ -296,7 +310,7 @@ struct MockRocLogger {
         end_ns,
         std::string());
 #else
-    rocprofAsyncRow* row = new rocprofAsyncRow(
+    emplaceActivity<rocprofAsyncRow>(
         correlation,
         ROCPROFILER_BUFFER_TRACING_MEMORY_COPY,
         0,
@@ -307,20 +321,28 @@ struct MockRocLogger {
         end_ns,
         std::string());
 #endif
-    activities_.push_back(row);
-  }
-
-  ~MockRocLogger() {
-    while (!activities_.empty()) {
-      auto act = activities_.back();
-      activities_.pop_back();
-      free(act);
-    }
   }
 
   std::vector<rocprofBase*> activities_;
   std::vector<std::pair<uint64_t, uint64_t>>
       externalCorrelations_[RocLogger::CorrelationDomain::size];
+
+ private:
+  template <class T>
+  static void deleteActivity(void* activity) {
+    delete static_cast<T*>(activity);
+  }
+
+  template <class T, class... Args>
+  T* emplaceActivity(Args&&... args) {
+    auto activity = std::make_unique<T>(std::forward<Args>(args)...);
+    T* rawActivity = activity.get();
+    ownedActivities_.emplace_back(activity.release(), deleteActivity<T>);
+    activities_.push_back(rawActivity);
+    return rawActivity;
+  }
+
+  std::vector<std::unique_ptr<void, void (*)(void*)>> ownedActivities_;
 };
 
 // Mock parts of the ActivityApi - select the correct base class
@@ -347,7 +369,12 @@ class MockRocActivities : public RocprofActivityApi {
       }
       externalCorrelations.clear();
     }
-    detail::backfillAsyncCopyStreams(activityLogger->activities_, isAsyncCopy);
+    detail::backfillAsyncStreams(
+        activityLogger->activities_,
+        /*includeCopies=*/true,
+        /*includeKernels=*/true,
+        isAsyncCopy,
+        isAsyncKernel);
     for (auto& item : activityLogger->activities_) {
       handler(item);
       ++count;
@@ -645,6 +672,149 @@ TEST_F(
   EXPECT_EQ(memcpyActivity->resourceId(), 0);
 }
 
+TEST_F(RocmActivityProfilerTest, KernelUsesRuntimeStreamWhenQueuesAreShared) {
+  RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  auto gpuOps = std::make_unique<MockRocLogger>();
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, start_time_ns + 10, start_time_ns + 15, 1, 101);
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, start_time_ns + 20, start_time_ns + 25, 2, 202);
+  gpuOps->addRuntimeCopyActivity(
+      HIP_MEMCPY,
+      start_time_ns + 26,
+      start_time_ns + 27,
+      1,
+      hipMemcpyHostToDevice,
+      999);
+  gpuOps->addKernelActivity(start_time_ns + 30, start_time_ns + 35, 1, 4);
+  gpuOps->addKernelActivity(start_time_ns + 40, start_time_ns + 45, 2, 4);
+  rocActivities_.activityLogger = std::move(gpuOps);
+
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  std::set<int64_t> kernelStreams;
+  for (const auto& activity : *trace.activities()) {
+    if (activity->type() == ActivityType::CONCURRENT_KERNEL &&
+        activity->name() == "kernel") {
+      kernelStreams.insert(activity->resourceId());
+    }
+  }
+
+  EXPECT_EQ(kernelStreams, (std::set<int64_t>{101, 202}));
+
+#ifdef __linux__
+  char filename[] = "/tmp/libkineto_testXXXXXX.json";
+  createTempTraceFile(filename);
+  trace.save(filename);
+
+  std::ifstream file(filename);
+  ASSERT_TRUE(file.is_open());
+  std::string jsonStr(
+      (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  nlohmann::json jsonData = nlohmann::json::parse(jsonStr);
+
+  std::set<int64_t> jsonKernelStreams;
+  for (const auto& event : jsonData["traceEvents"]) {
+    if (event.value("cat", "") == "kernel" &&
+        event["args"].value("kind", "") == "Dispatch Kernel" &&
+        (event["args"].value("correlation", 0) == 1 ||
+         event["args"].value("correlation", 0) == 2)) {
+      jsonKernelStreams.insert(event["args"]["stream"].get<int64_t>());
+    }
+  }
+  EXPECT_EQ(jsonKernelStreams, (std::set<int64_t>{101, 202}));
+#endif
+}
+
+TEST_F(RocmActivityProfilerTest, KernelUsesRuntimeNameWhenCorrelationRepeats) {
+  RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
+  int64_t start_time_ns =
+      libkineto::timeSinceEpoch(std::chrono::system_clock::now());
+  int64_t duration_ns = 300;
+  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  profiler.configure(*cfg_, start_time);
+  profiler.startTrace(start_time);
+  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+
+  auto gpuOps = std::make_unique<MockRocLogger>();
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL,
+      start_time_ns + 10,
+      start_time_ns + 15,
+      10,
+      111,
+      1001,
+      "kernel_a");
+  gpuOps->addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL,
+      start_time_ns + 20,
+      start_time_ns + 25,
+      11,
+      222,
+      1002,
+      "kernel_b");
+  // ROCProfiler can report two kernel dispatches with the same internal
+  // correlation under concurrent launches, and the duplicated record can carry
+  // the wrong launch thread. When the runtime kernel name maps to one stream,
+  // that name is the safer stream source for the duplicated dispatch.
+  gpuOps->addKernelActivity(
+      start_time_ns + 30, start_time_ns + 35, 11, 4, 1002, 222, "kernel_a");
+  gpuOps->addKernelActivity(
+      start_time_ns + 40, start_time_ns + 45, 11, 4, 1002, 222, "kernel_b");
+  rocActivities_.activityLogger = std::move(gpuOps);
+
+  auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
+  profiler.processTrace(*logger);
+  profiler.reset();
+
+  ActivityTrace trace(std::move(logger), loggerFactory);
+  std::set<int64_t> kernelStreams;
+  for (const auto& activity : *trace.activities()) {
+    if (activity->type() == ActivityType::CONCURRENT_KERNEL &&
+        (activity->name() == "kernel_a" || activity->name() == "kernel_b")) {
+      kernelStreams.insert(activity->resourceId());
+    }
+  }
+
+  EXPECT_EQ(kernelStreams, (std::set<int64_t>{111, 222}));
+}
+
+TEST_F(RocmActivityProfilerTest, KernelDoesNotGuessWhenCorrelationRepeats) {
+  MockRocLogger gpuOps;
+  gpuOps.addRuntimeKernelActivity(
+      HIP_LAUNCH_KERNEL, 10, 15, 7, 111, 1001, "kernel_a");
+  gpuOps.addKernelActivity(30, 35, 7, 4, 0, 0, "unknown_a");
+  gpuOps.addKernelActivity(40, 45, 7, 4, 0, 0, "unknown_b");
+
+  detail::backfillAsyncStreams(
+      gpuOps.activities_,
+      /*includeCopies=*/false,
+      /*includeKernels=*/true,
+      isAsyncCopy,
+      isAsyncKernel);
+
+  std::set<uint64_t> kernelStreams;
+  for (const auto* activity : gpuOps.activities_) {
+    if (activity->type == ROCTRACER_ACTIVITY_ASYNC) {
+      kernelStreams.insert(
+          reinterpret_cast<const rocprofAsyncRow*>(activity)->stream);
+    }
+  }
+
+  EXPECT_EQ(kernelStreams, std::set<uint64_t>{0});
+}
+
 TEST_F(RocmActivityProfilerTest, GpuNCCLCollectiveTest) {
   // Set logging level for debugging purpose
   std::vector<std::string> log_modules(
@@ -844,11 +1014,14 @@ TEST_F(RocmActivityProfilerTest, GpuUserAnnotationTest) {
 
   // set up a couple of GPU events and correlate with above CPU event.
   // RocLogger::CorrelationDomain::Domain1 is used for user annotations.
+  const uint64_t kLargeStreamId = 0x7fce546deb80;
   auto gpuOps = std::make_unique<MockRocLogger>();
   gpuOps->addCorrelationActivity(1, RocLogger::CorrelationDomain::Domain1, 1);
-  gpuOps->addKernelActivity(kernelLaunchTime + 5, kernelLaunchTime + 10, 1);
+  gpuOps->addKernelActivity(
+      kernelLaunchTime + 5, kernelLaunchTime + 10, 1, 1, 0, kLargeStreamId);
   gpuOps->addCorrelationActivity(1, RocLogger::CorrelationDomain::Domain1, 1);
-  gpuOps->addKernelActivity(kernelLaunchTime + 15, kernelLaunchTime + 25, 1);
+  gpuOps->addKernelActivity(
+      kernelLaunchTime + 15, kernelLaunchTime + 25, 1, 1, 0, kLargeStreamId);
   rocActivities_.activityLogger = std::move(gpuOps);
 
   // process trace
@@ -880,6 +1053,7 @@ TEST_F(RocmActivityProfilerTest, GpuUserAnnotationTest) {
       gpu_annotation->duration(),
       kernel2->timestamp() + kernel2->duration() - kernel1->timestamp());
   EXPECT_EQ(gpu_annotation->deviceId(), kernel1->deviceId());
+  EXPECT_EQ(kernel1->resourceId(), kLargeStreamId);
   EXPECT_EQ(gpu_annotation->resourceId(), kernel1->resourceId());
   EXPECT_EQ(gpu_annotation->correlationId(), annotation->correlationId());
   EXPECT_EQ(gpu_annotation->name(), annotation->name());


### PR DESCRIPTION
Summary:

**Problem**

ROCm Kineto traces can show kernels from independent HIP streams on the wrong stream, making unrelated worker activity look mixed together.

**Why**

ROCProfiler can deliver async kernel dispatch records where multiple kernels share one correlation and another runtime launch correlation is missing. Trusting correlation alone means Kineto can collapse or spread kernels onto the wrong stream. The repaired ROCm stream id is a 64-bit HIP stream value, and GPU user annotations also need to preserve that full value so Perfetto keeps annotations nested on the same lane as the kernels they cover.

**Fix**

Keep the HIP stream and demangled kernel name from runtime callbacks, carry dispatch thread and external stream data on async rows, and repair ambiguous duplicated kernel correlations only when runtime thread or canonical kernel name maps to exactly one stream. Preserve the full 64-bit resource id when creating generic GPU user annotations so `Stage::...` annotations stay aligned with repaired ROCm kernel lanes. The implementation limits overhead by building copy and kernel repair maps only for activity types requested by the trace, building the kernel-name map only when duplicated async kernel correlations are present, and tracking pushed stream correlations in cached kernel args instead of adding another thread-local hash set per kernel launch. If the evidence is ambiguous, Kineto preserves the original async stream instead of guessing.

Differential Revision: D104473177


