### PR TITLE
Add logging for async rejections (#1422)

### DIFF
--- a/libkineto/include/ILoggerObserver.h
+++ b/libkineto/include/ILoggerObserver.h
@@ -12,6 +12,10 @@
 #include <string>
 
 // Stages in libkineto used when pushing logs to UST Logger.
+// Emitted when a trace request is cancelled: rejected before it runs
+// (busy/pending/can't-start) or an in-flight trace preempted by a
+// higher-priority request.
+constexpr char kCancellationStage[] = "Cancellation";
 constexpr char kWarmUpStage[] = "Warm Up";
 constexpr char kCollectionStage[] = "Collection";
 constexpr char kPostProcessingStage[] = "Post Processing";
@@ -59,6 +63,12 @@ class ILoggerObserver {
   // survives across traces and must not be used for per-trace values.
   virtual void addPersistentMetadata([[maybe_unused]] const std::string& key,
                                      [[maybe_unused]] const std::string& value) {}
+  // Emit a standalone record that an on-demand trace request was cancelled,
+  // attributed to the cancelled request's trace id. Stateless: does not read or
+  // mutate the observer's per-trace state (a trace may be active).
+  virtual void writeStageCancellation([[maybe_unused]] const std::string& trace_id,
+                                      [[maybe_unused]] const std::string& group_trace_id,
+                                      [[maybe_unused]] const std::string& reason) {}
 };
 
 } // namespace libkineto

--- a/libkineto/include/ILoggerObserver.h
+++ b/libkineto/include/ILoggerObserver.h
@@ -54,6 +54,11 @@ class ILoggerObserver {
   virtual void addDestination(const std::string& dest) = 0;
   virtual void setTriggerOnDemand() {}
   virtual void addMetadata(const std::string& key, const std::string& value) = 0;
+  // Metadata that is constant for the process lifetime (e.g. GPU/driver
+  // versions). Unlike addMetadata, this is NOT cleared by reset(), so it
+  // survives across traces and must not be used for per-trace values.
+  virtual void addPersistentMetadata([[maybe_unused]] const std::string& key,
+                                     [[maybe_unused]] const std::string& value) {}
 };
 
 } // namespace libkineto

--- a/libkineto/src/AsyncActivityProfilerHandler.cpp
+++ b/libkineto/src/AsyncActivityProfilerHandler.cpp
@@ -266,6 +266,7 @@ void AsyncActivityProfilerHandler::activateConfig(
     std::chrono::time_point<std::chrono::system_clock> now) {
   logger_ = ActivityProfilerController::makeLogger(*asyncRequestConfig_);
   profiler_.setLogger(logger_.get());
+  LOGGER_OBSERVER_RESET();
   LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND();
   profiler_.configure(*asyncRequestConfig_, now);
   asyncRequestConfig_ = nullptr;

--- a/libkineto/src/AsyncActivityProfilerHandler.cpp
+++ b/libkineto/src/AsyncActivityProfilerHandler.cpp
@@ -9,6 +9,7 @@
 #include "AsyncActivityProfilerHandler.h"
 
 #include <chrono>
+#include <string>
 
 #include "ActivityProfilerController.h"
 #include "Config.h"
@@ -20,6 +21,14 @@
 using namespace std::chrono;
 
 namespace KINETO_NAMESPACE {
+
+static void logAsyncRequestCancellation(
+    const Config& config,
+    const std::string& reason) {
+  LOGGER_OBSERVER_WRITE_STAGE_CANCELLATION(
+      config.requestTraceID(), config.requestGroupTraceID(), reason);
+  LOG(WARNING) << reason;
+}
 
 AsyncActivityProfilerHandler::AsyncActivityProfilerHandler(
     GenericActivityProfiler& profiler,
@@ -51,7 +60,7 @@ void AsyncActivityProfilerHandler::acceptConfig(const Config& config) {
 void AsyncActivityProfilerHandler::scheduleTrace(const Config& config) {
   VLOG(1) << "scheduleTrace";
   if (profiler_.isActive()) {
-    LOG(WARNING) << "Ignored request - profiler busy";
+    logAsyncRequestCancellation(config, "Ignored request - profiler busy");
     return;
   }
 
@@ -68,8 +77,9 @@ void AsyncActivityProfilerHandler::scheduleTrace(const Config& config) {
       configToSchedule = config.clone();
       configToSchedule->setProfileStartIteration(-1);
     } else {
-      LOG(WARNING) << "Ignored profile iteration count based request as "
-                   << "application is not updating iteration count";
+      logAsyncRequestCancellation(
+          config,
+          "Ignored profile iteration count based request as application is not updating iteration count");
       return;
     }
   } else {
@@ -86,7 +96,8 @@ void AsyncActivityProfilerHandler::scheduleTrace(const Config& config) {
     }
   }
   if (!newConfigScheduled) {
-    LOG(WARNING) << "Ignored request - another profile request is pending.";
+    logAsyncRequestCancellation(
+        config, "Ignored request - another profile request is pending.");
     return;
   }
 

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -97,10 +97,11 @@ void CuptiActivityProfiler::logGpuVersions() {
             << "; Runtime: " << cudaRuntimeVersion
             << "; Driver: " << cudaDriverVersion;
 
-  LOGGER_OBSERVER_ADD_METADATA("cupti_version", std::to_string(cuptiVersion));
-  LOGGER_OBSERVER_ADD_METADATA(
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
+      "cupti_version", std::to_string(cuptiVersion));
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
       "cuda_runtime_version", std::to_string(cudaRuntimeVersion));
-  LOGGER_OBSERVER_ADD_METADATA(
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
       "cuda_driver_version", std::to_string(cudaDriverVersion));
   addVersionMetadata("cupti_version", std::to_string(cuptiVersion));
   addVersionMetadata(

--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -60,12 +60,12 @@ bool ConfigDerivedState::canStart(
     return true;
   }
   if (profileStartTime_ < now) {
-    LOG(ERROR)
+    LOG(WARNING)
         << "Not starting tracing - start timestamp is in the past. Time difference (ms): "
         << duration_cast<milliseconds>(now - profileStartTime_).count();
     return false;
   } else if ((profileStartTime_ - now) < profileWarmupDuration_) {
-    LOG(ERROR)
+    LOG(WARNING)
         << "Not starting tracing - insufficient time for warmup. Time to warmup (ms): "
         << duration_cast<milliseconds>(profileStartTime_ - now).count();
     return false;
@@ -493,6 +493,10 @@ void GenericActivityProfiler::configure(
 
   // Check if now is a valid time to start.
   if (!derivedConfig_->canStart(now)) {
+    LOGGER_OBSERVER_WRITE_STAGE_CANCELLATION(
+        config_->requestTraceID(),
+        config_->requestGroupTraceID(),
+        "Trace request could not start at the scheduled time");
     return;
   }
 

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -182,6 +182,16 @@ void Logger::addLoggerObserverPersistentMetadata(
   }
 }
 
+void Logger::writeStageCancellation(
+    const std::string& trace_id,
+    const std::string& group_trace_id,
+    const std::string& reason) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->writeStageCancellation(trace_id, group_trace_id, reason);
+  }
+}
+
 USTLoggerStageGuard::~USTLoggerStageGuard() {
   try {
     UST_LOGGER_MARK_COMPLETED(stage_);

--- a/libkineto/src/Logger.cpp
+++ b/libkineto/src/Logger.cpp
@@ -157,12 +157,28 @@ void Logger::setLoggerObserverOnDemand() {
   }
 }
 
+void Logger::resetLoggerObservers() {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->reset();
+  }
+}
+
 void Logger::addLoggerObserverAddMetadata(
     const std::string& key,
     const std::string& value) {
   std::lock_guard<std::mutex> guard(loggerObserversMutex());
   for (auto observer : loggerObservers()) {
     observer->addMetadata(key, value);
+  }
+}
+
+void Logger::addLoggerObserverPersistentMetadata(
+    const std::string& key,
+    const std::string& value) {
+  std::lock_guard<std::mutex> guard(loggerObserversMutex());
+  for (auto observer : loggerObservers()) {
+    observer->addPersistentMetadata(key, value);
   }
 }
 

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -28,6 +28,7 @@
 #define LOGGER_OBSERVER_ADD_METADATA(key, value)
 #define LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(key, value)
 #define LOGGER_OBSERVER_RESET()
+#define LOGGER_OBSERVER_WRITE_STAGE_CANCELLATION(trace_id, group_trace_id, reason)
 #define UST_LOGGER_MARK_COMPLETED(stage)
 #define UST_LOGGER_STAGE_SCOPE(stage)
 #define USDT_LOGGER_EMIT_MESSAGE(usdt_type)
@@ -137,6 +138,10 @@ class Logger {
   static void addLoggerObserverAddMetadata(const std::string& key, const std::string& value);
 
   static void addLoggerObserverPersistentMetadata(const std::string& key, const std::string& value);
+
+  static void writeStageCancellation(const std::string& trace_id,
+                                     const std::string& group_trace_id,
+                                     const std::string& reason);
 
  private:
   std::stringstream buf_;
@@ -274,6 +279,10 @@ struct __to_constant__ {
 
 // Reset all logger observers to a clean per-trace state.
 #define LOGGER_OBSERVER_RESET() libkineto::Logger::resetLoggerObservers()
+
+// Record that an on-demand trace request was rejected.
+#define LOGGER_OBSERVER_WRITE_STAGE_CANCELLATION(trace_id, group_trace_id, reason) \
+  libkineto::Logger::writeStageCancellation(trace_id, group_trace_id, reason)
 
 // Record this was triggered by On-Demand.
 #define LOGGER_OBSERVER_ADD_METADATA(key, value) libkineto::Logger::addLoggerObserverAddMetadata(key, value)

--- a/libkineto/src/Logger.h
+++ b/libkineto/src/Logger.h
@@ -26,6 +26,8 @@
 #define LOGGER_OBSERVER_ADD_DESTINATION(dest)
 #define LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND()
 #define LOGGER_OBSERVER_ADD_METADATA(key, value)
+#define LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(key, value)
+#define LOGGER_OBSERVER_RESET()
 #define UST_LOGGER_MARK_COMPLETED(stage)
 #define UST_LOGGER_STAGE_SCOPE(stage)
 #define USDT_LOGGER_EMIT_MESSAGE(usdt_type)
@@ -130,7 +132,11 @@ class Logger {
 
   static void setLoggerObserverOnDemand();
 
+  static void resetLoggerObservers();
+
   static void addLoggerObserverAddMetadata(const std::string& key, const std::string& value);
+
+  static void addLoggerObserverPersistentMetadata(const std::string& key, const std::string& value);
 
  private:
   std::stringstream buf_;
@@ -266,8 +272,15 @@ struct __to_constant__ {
 // Record this was triggered by On-Demand.
 #define LOGGER_OBSERVER_SET_TRIGGER_ON_DEMAND() libkineto::Logger::setLoggerObserverOnDemand()
 
+// Reset all logger observers to a clean per-trace state.
+#define LOGGER_OBSERVER_RESET() libkineto::Logger::resetLoggerObservers()
+
 // Record this was triggered by On-Demand.
 #define LOGGER_OBSERVER_ADD_METADATA(key, value) libkineto::Logger::addLoggerObserverAddMetadata(key, value)
+
+// Metadata that is constant for the process lifetime and survives reset().
+#define LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(key, value) \
+  libkineto::Logger::addLoggerObserverPersistentMetadata(key, value)
 
 // UST Logger Semantics to describe when a stage is complete.
 // Use libkineto::Logger directly instead of the LOG/LOG_IS_ON macros, which

--- a/libkineto/src/LoggerCollector.h
+++ b/libkineto/src/LoggerCollector.h
@@ -41,6 +41,7 @@ class LoggerCollector : public ILoggerObserver {
   }
 
   void reset() override {
+    buckets_.clear();
     trace_duration_ms = 0;
     event_count = 0;
     destinations.clear();

--- a/libkineto/src/RocmActivityProfiler.cpp
+++ b/libkineto/src/RocmActivityProfiler.cpp
@@ -49,10 +49,11 @@ void RocmActivityProfiler::logGpuVersions() {
             << "; Runtime: " << hipRuntimeVersion
             << "; Driver: " << hipDriverVersion;
 
-  LOGGER_OBSERVER_ADD_METADATA("rocprofiler-sdk_version", rocprofVersion);
-  LOGGER_OBSERVER_ADD_METADATA(
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
+      "rocprofiler-sdk_version", rocprofVersion);
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
       "hip_runtime_version", std::to_string(hipRuntimeVersion));
-  LOGGER_OBSERVER_ADD_METADATA(
+  LOGGER_OBSERVER_ADD_PERSISTENT_METADATA(
       "hip_driver_version", std::to_string(hipDriverVersion));
   addVersionMetadata("rocprofiler-sdk_version", rocprofVersion);
   addVersionMetadata("hip_runtime_version", std::to_string(hipRuntimeVersion));

--- a/libkineto/src/SyncActivityProfilerHandler.cpp
+++ b/libkineto/src/SyncActivityProfilerHandler.cpp
@@ -44,6 +44,7 @@ void SyncActivityProfilerHandler::prepareTrace(const Config& config) {
     profiler_.reset();
   }
 
+  LOGGER_OBSERVER_RESET();
   profiler_.configure(config, now);
 }
 

--- a/libkineto/src/SyncActivityProfilerHandler.cpp
+++ b/libkineto/src/SyncActivityProfilerHandler.cpp
@@ -34,8 +34,9 @@ void SyncActivityProfilerHandler::prepareTrace(const Config& config) {
   auto now = system_clock::now();
   syncTraceActive_ = true;
   if (profiler_.isActive()) {
-    LOG(WARNING) << "Cancelling current trace request in order to start "
-                 << "higher priority synchronous request";
+    LOG(ERROR) << "Cancelling current trace request in order to start "
+               << "higher priority synchronous request";
+    UST_LOGGER_MARK_COMPLETED(kCancellationStage);
     if (libkineto::api().client()) {
       libkineto::api().client()->stop();
     }


### PR DESCRIPTION
Summary:

We do not currently allow async requests to be scheduled if there's an ongoing profiling session. When this happens, we log a warning and return early; there's no indication that the request failed unless the user is looking at the logs.

For better tracking, we should emit UST logs for these traces. We need to build some additional machinery here because the logger is seeded with metadata for the in-flight profiling session, and we can't clear it in order to write the async request rejection. So we add a write method which can independently write to the Scuba logs without messing with the existing logger state.

Reviewed By: scotts

Differential Revision: D103221867


