### PR TITLE
map kernel and copy events to logical stream ID instead of HSA queue ID (#1424)

### DIFF
--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -142,7 +142,7 @@ class GenericTraceActivity : public ITraceActivity {
   int64_t endTime{0};
   int32_t id{0};
   int32_t device{0};
-  int32_t resource{0};
+  int64_t resource{0};
   int32_t threadId{0};
   ActivityType activityType;
   std::string activityName;

--- a/libkineto/src/GenericActivityProfiler.h
+++ b/libkineto/src/GenericActivityProfiler.h
@@ -327,12 +327,12 @@ class GenericActivityProfiler {
   // Process a single CPU trace
   void processCpuTrace(libkineto::CpuTraceBuffer& cpuTrace, ActivityLogger& logger);
 
-  inline bool hasDeviceResource(int device, int id) {
+  inline bool hasDeviceResource(int64_t device, int64_t id) {
     return resourceInfo_.contains({device, id});
   }
 
   // Create resource names for streams
-  inline void recordStream(int device, int id, const char* postfix) {
+  inline void recordStream(int64_t device, int64_t id, const char* postfix) {
     if (!hasDeviceResource(device, id)) {
       resourceInfo_.emplace(
           std::make_pair(device, id),

--- a/libkineto/src/RocLogger.h
+++ b/libkineto/src/RocLogger.h
@@ -211,5 +211,6 @@ struct rocprofAsyncRow : public rocprofBase {
   uint32_t op;
   int device;
   uint64_t queue;
+  uint64_t stream{0};
   std::string kernelName;
 };

--- a/libkineto/src/RocmStreamQueue.h
+++ b/libkineto/src/RocmStreamQueue.h
@@ -34,94 +34,95 @@ inline uint64_t runtimeStreamId(const rocprofBase* item) {
   return 0;
 }
 
-struct StreamQueueMaps {
-  std::unordered_map<uint64_t, uint64_t> runtimeStreamByCorrelation;
-  std::unordered_map<uint64_t, uint64_t> asyncQueueByRuntimeStream;
-  // Prefer preserving stream 0 over guessing when one HIP stream maps to
-  // multiple ROCm async queues in the same trace.
-  std::unordered_set<uint64_t> ambiguousRuntimeStreams;
-};
-
-inline void rememberCorrelationQueue(std::unordered_map<uint64_t, uint64_t>& asyncQueueByCorrelation,
-                                     std::unordered_set<uint64_t>& ambiguousCorrelations,
-                                     uint64_t correlationId,
-                                     uint64_t queue) {
-  if (ambiguousCorrelations.count(correlationId) > 0) {
-    return;
-  }
-  const auto [queueIt, inserted] = asyncQueueByCorrelation.emplace(correlationId, queue);
-  if (!inserted && queueIt->second != queue) {
-    asyncQueueByCorrelation.erase(queueIt);
-    ambiguousCorrelations.insert(correlationId);
-  }
-}
-
-inline void rememberQueueForRuntimeStream(StreamQueueMaps& maps, uint64_t stream, uint64_t queue) {
-  if (maps.ambiguousRuntimeStreams.count(stream) > 0) {
-    return;
-  }
-  const auto [queueIt, inserted] = maps.asyncQueueByRuntimeStream.emplace(stream, queue);
-  if (!inserted && queueIt->second != queue) {
-    maps.asyncQueueByRuntimeStream.erase(queueIt);
-    maps.ambiguousRuntimeStreams.insert(stream);
-  }
-}
-
-inline StreamQueueMaps buildStreamQueueMaps(const std::vector<rocprofBase*>& rows) {
-  StreamQueueMaps maps;
-  std::unordered_map<uint64_t, uint64_t> asyncQueueByCorrelation;
-  std::unordered_set<uint64_t> ambiguousCorrelations;
-
+// Assign logical stream ID to async kernel and copy rows. Remap to small index for proper display.
+// Recover logical stream ID from the correlated runtime row. isAsyncOp selects the async rows to process.
+template <class IsAsyncOp>
+void backfillAsyncStreams(std::vector<rocprofBase*>& rows, IsAsyncOp isAsyncOp) {
+  // Map correlation id -> HIP stream from the runtime kernel/copy rows.
+  std::unordered_map<uint64_t, uint64_t> streamByCorrelation;
   for (const auto* item : rows) {
-    const uint64_t streamId = runtimeStreamId(item);
-    if (streamId != 0) {
-      maps.runtimeStreamByCorrelation[item->id] = streamId;
-    }
-
-    if (item->type == ROCTRACER_ACTIVITY_ASYNC) {
-      const auto* async = reinterpret_cast<const rocprofAsyncRow*>(item);
-      if (async->queue != 0) {
-        rememberCorrelationQueue(asyncQueueByCorrelation, ambiguousCorrelations, async->id, async->queue);
-      }
+    const uint64_t sid = runtimeStreamId(item);
+    if (sid != 0) {
+      streamByCorrelation[item->id] = sid;
     }
   }
+  if (streamByCorrelation.empty()) {
+    return;
+  }
 
-  for (const auto* item : rows) {
-    const uint64_t streamId = runtimeStreamId(item);
-    if (streamId == 0 || ambiguousCorrelations.count(item->id) > 0) {
+  // Set stream from the correlation-matched runtime row.
+  for (auto* item : rows) {
+    if (item->type != ROCTRACER_ACTIVITY_ASYNC) {
       continue;
     }
-    const auto queue = asyncQueueByCorrelation.find(item->id);
-    if (queue != asyncQueueByCorrelation.end()) {
-      rememberQueueForRuntimeStream(maps, streamId, queue->second);
+    auto* async = reinterpret_cast<rocprofAsyncRow*>(item);
+    if (!isAsyncOp(*async) || async->stream != 0) {
+      continue;
+    }
+    const auto it = streamByCorrelation.find(async->id);
+    if (it != streamByCorrelation.end()) {
+      async->stream = it->second;
     }
   }
 
-  return maps;
-}
-
-template <class IsAsyncCopy>
-void backfillAsyncCopyStreams(std::vector<rocprofBase*>& rows, IsAsyncCopy isAsyncCopy) {
-  const auto maps = buildStreamQueueMaps(rows);
-  if (maps.runtimeStreamByCorrelation.empty() || maps.asyncQueueByRuntimeStream.empty()) {
-    return;
+  // Fallback: (e.g. ROCm-internal dispatches like __amd_rocclr_copyBuffer),
+  // infer the stream from the HSA queue, given the queue maps directly to a HIP stream
+  std::unordered_map<uint64_t, uint64_t> streamByQueue;
+  std::unordered_set<uint64_t> ambiguousQueues;
+  for (const auto* item : rows) {
+    if (item->type != ROCTRACER_ACTIVITY_ASYNC) {
+      continue;
+    }
+    const auto* async = reinterpret_cast<const rocprofAsyncRow*>(item);
+    if (!isAsyncOp(*async) || async->stream == 0 || async->queue == 0) {
+      continue;
+    }
+    if (ambiguousQueues.count(async->queue) > 0) {
+      continue;
+    }
+    const auto [it, inserted] = streamByQueue.emplace(async->queue, async->stream);
+    if (!inserted && it->second != async->stream) {
+      streamByQueue.erase(it);
+      ambiguousQueues.insert(async->queue);
+    }
   }
   for (auto* item : rows) {
     if (item->type != ROCTRACER_ACTIVITY_ASYNC) {
       continue;
     }
     auto* async = reinterpret_cast<rocprofAsyncRow*>(item);
-    if (!isAsyncCopy(*async) || async->queue != 0) {
+    if (!isAsyncOp(*async) || async->stream != 0) {
       continue;
     }
-    const auto stream = maps.runtimeStreamByCorrelation.find(async->id);
-    if (stream == maps.runtimeStreamByCorrelation.end() || maps.ambiguousRuntimeStreams.count(stream->second) > 0) {
+    const auto it = streamByQueue.find(async->queue);
+    if (it != streamByQueue.end()) {
+      async->stream = it->second;
+    }
+  }
+
+  // Remap raw HIP stream pointers to small per-device indices, avoiding misrenders of large 64-bit tid values.
+  // Fallback: if still no stream ID, use HSA queue ID tagged with high bit to avoid collisions with stream IDs
+  constexpr uint64_t kQueueKeyTag = uint64_t{1} << 63;
+  std::unordered_map<int, std::unordered_map<uint64_t, uint64_t>> deviceStreamToIndex;
+  for (auto* item : rows) {
+    if (item->type != ROCTRACER_ACTIVITY_ASYNC) {
       continue;
     }
-    const auto queue = maps.asyncQueueByRuntimeStream.find(stream->second);
-    if (queue != maps.asyncQueueByRuntimeStream.end()) {
-      async->queue = queue->second;
+    auto* async = reinterpret_cast<rocprofAsyncRow*>(item);
+    if (!isAsyncOp(*async)) {
+      continue;
     }
+    uint64_t key;
+    if (async->stream != 0) {
+      key = async->stream;
+    } else if (async->queue != 0) {
+      key = async->queue | kQueueKeyTag;
+    } else {
+      continue;
+    }
+    auto& mapping = deviceStreamToIndex[async->device];
+    auto [it, inserted] = mapping.emplace(key, mapping.size() + 1);
+    async->stream = it->second;
   }
 }
 

--- a/libkineto/src/RocprofActivity.h
+++ b/libkineto/src/RocprofActivity.h
@@ -99,7 +99,7 @@ struct GpuActivity : public RocprofActivity<rocprofAsyncRow> {
     return activity_.device;
   }
   int64_t resourceId() const override {
-    return activity_.queue;
+    return activity_.stream != 0 ? activity_.stream : activity_.queue;
   }
   ActivityType type() const override {
     return type_;

--- a/libkineto/src/RocprofActivityApi.cpp
+++ b/libkineto/src/RocprofActivityApi.cpp
@@ -30,6 +30,10 @@ namespace {
 bool isAsyncCopy(const rocprofAsyncRow& async) {
   return async.domain == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY;
 }
+
+bool isAsyncKernel(const rocprofAsyncRow& async) {
+  return async.domain == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH;
+}
 } // namespace
 
 RocprofActivityApi& RocprofActivityApi::singleton() {
@@ -127,8 +131,14 @@ int RocprofActivityApi::processActivities(
   // much better job.
   auto toffset = getTimeOffset();
 
-  if (isLogged(ActivityType::GPU_MEMCPY)) {
-    detail::backfillAsyncCopyStreams(d->rows_, isAsyncCopy);
+  const bool logCopies = isLogged(ActivityType::GPU_MEMCPY);
+  const bool logKernels = isLogged(ActivityType::CONCURRENT_KERNEL);
+  if (logCopies || logKernels) {
+    detail::backfillAsyncStreams(
+        d->rows_, [logCopies, logKernels](const rocprofAsyncRow& async) {
+          return (logCopies && isAsyncCopy(async)) ||
+              (logKernels && isAsyncKernel(async));
+        });
   }
 
   // All Runtime API Calls

--- a/libkineto/src/RocprofActivity_inl.h
+++ b/libkineto/src/RocprofActivity_inl.h
@@ -112,7 +112,7 @@ inline const std::string GpuActivity::metadataJson() const {
       "device": {}, "stream": {},
       "correlation": {}, "kind": "{}",
       "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
-      gpuActivity.device, gpuActivity.queue,
+      gpuActivity.device, resourceId(),
       gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op),
       size, bandwidth_gib);
   }
@@ -123,14 +123,14 @@ inline const std::string GpuActivity::metadataJson() const {
       "device": {}, "stream": {},
       "correlation": {}, "kind": "{}",
       "grid": {}, "block": {})JSON",
-      gpuActivity.device, gpuActivity.queue,
+      gpuActivity.device, resourceId(),
       gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op),
       correlationToGrid[gpuActivity.id], correlationToBlock[gpuActivity.id]);
   } else {
     return fmt::format(R"JSON(
       "device": {}, "stream": {},
       "correlation": {}, "kind": "{}")JSON",
-      gpuActivity.device, gpuActivity.queue,
+      gpuActivity.device, resourceId(),
       gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op));
   }
   // clang-format on

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -82,6 +82,10 @@ void createTempTraceFile(char* filename) {
 bool isAsyncCopy(const rocprofAsyncRow& async) {
   return async.domain == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY;
 }
+
+bool isAsyncKernel(const rocprofAsyncRow& async) {
+  return async.domain == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH;
+}
 } // namespace
 
 // Provides ability to easily create a test CPU-side ops
@@ -277,7 +281,10 @@ class MockRocActivities : public RocprofActivityApi {
       }
       externalCorrelations.clear();
     }
-    detail::backfillAsyncCopyStreams(activityLogger->activities_, isAsyncCopy);
+    detail::backfillAsyncStreams(
+        activityLogger->activities_, [](const rocprofAsyncRow& async) {
+          return isAsyncCopy(async) || isAsyncKernel(async);
+        });
     for (auto& item : activityLogger->activities_) {
       handler(item);
       ++count;
@@ -464,7 +471,9 @@ TEST_F(
   }
 
   ASSERT_NE(memcpyActivity, nullptr);
-  EXPECT_EQ(memcpyActivity->resourceId(), 23);
+  // The copy shares HIP stream 7 with the kernel (via runtime correlation), so
+  // both remap to the same dense per-device stream index (1).
+  EXPECT_EQ(memcpyActivity->resourceId(), 1);
 
 #ifdef __linux__
   char filename[] = "/tmp/libkineto_testXXXXXX.json";
@@ -481,14 +490,14 @@ TEST_F(
   for (const auto& event : jsonData["traceEvents"]) {
     if (event.value("name", "") == "Memcpy HtoD (Host -> Device)") {
       foundMemcpy = true;
-      EXPECT_EQ(event["args"]["stream"].get<int64_t>(), 23);
+      EXPECT_EQ(event["args"]["stream"].get<int64_t>(), 1);
     }
   }
   EXPECT_TRUE(foundMemcpy);
 #endif
 }
 
-TEST_F(RocmActivityProfilerTest, HtoDMemcpyKeepsNonzeroAsyncQueue) {
+TEST_F(RocmActivityProfilerTest, HtoDMemcpyPrefersRuntimeStreamOverAsyncQueue) {
   RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
@@ -526,12 +535,14 @@ TEST_F(RocmActivityProfilerTest, HtoDMemcpyKeepsNonzeroAsyncQueue) {
   }
 
   ASSERT_NE(memcpyActivity, nullptr);
-  EXPECT_EQ(memcpyActivity->resourceId(), 42);
+  // Even though the async copy carries a nonzero HW queue (42), it is grouped
+  // by its real HIP stream (7) -- shared with the kernel -> dense index 1.
+  EXPECT_EQ(memcpyActivity->resourceId(), 1);
 }
 
 TEST_F(
     RocmActivityProfilerTest,
-    HtoDMemcpyStaysOnZeroWhenRuntimeStreamMapsToMultipleQueues) {
+    HtoDMemcpyJoinsRuntimeStreamDespiteQueueAmbiguity) {
   RocmActivityProfiler profiler(rocActivities_, /*cpu only*/ false);
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
@@ -572,7 +583,10 @@ TEST_F(
   }
 
   ASSERT_NE(memcpyActivity, nullptr);
-  EXPECT_EQ(memcpyActivity->resourceId(), 0);
+  // The copy's stream is resolved directly from its runtime correlation (HIP
+  // stream 7), so HW-queue ambiguity no longer matters -- it joins the shared
+  // stream index 1 instead of being dropped to 0.
+  EXPECT_EQ(memcpyActivity->resourceId(), 1);
 }
 
 TEST_F(RocmActivityProfilerTest, GpuNCCLCollectiveTest) {


### PR DESCRIPTION
Summary:

Previously, `resourceId()` propagated the HSA queue ID for kernel events, rather than the logical stream ID. The AMD default is `GPU_MAX_HW_QUEUES=4`, which follows why stream interleaving was noticeable only when number of workers (total) >= 5 which is common on models with remote (additional remote workers). Therefore, there was stream interleaving as we were mapping > 5 streams to 4 HSA queues. The separate `backfillAsyncCopyStreams` for H2D/D2D was also propagating HW queue IDs. 

Switch to int64_t for stream ids to avoid truncation; HW queue IDs fit fine in int32. Return streamId with queueId fallback in`resourceId()`. Recover the real HIP stream from the correlated runtime row, resolving both kernels and copies to stream ID via `backfillAsyncStreams`. Remove separate `backfillAsyncCopyStreams`. Async rows carry only the HW queue, so we map correlation --> HIP stream from the runtime rows.

*Process*
1. Infer stream from queue when a queue maps unambiguously to one stream
2. Remap raw 64-bit HIP stream pointers to per-device indices since Perfetto misrenders large id values onto the same track
3. Kernels and copies share one per-device index space, so ops on the same HIP stream land on the same track. `resourceId()` returns the resolved streamId with a queueId <--> unambiguous stream map fallback


Add the HSA queue ID as a field in the trace, but not as the track provenance in next diff D107568026

Differential Revision: D107306915


