### PR TITLE
surface HSA queue ID (#1425)

### DIFF
--- a/libkineto/src/RocprofActivity_inl.h
+++ b/libkineto/src/RocprofActivity_inl.h
@@ -109,10 +109,10 @@ inline const std::string GpuActivity::metadataJson() const {
     size_t size = correlationToSize[gpuActivity.id];
     std::string bandwidth_gib = (bandwidth(size, gpuActivity.end - gpuActivity.begin));
     return fmt::format(R"JSON(
-      "device": {}, "stream": {},
+      "device": {}, "stream": {}, "hsa_queue": {},
       "correlation": {}, "kind": "{}",
       "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
-      gpuActivity.device, resourceId(),
+      gpuActivity.device, resourceId(), gpuActivity.queue,
       gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op),
       size, bandwidth_gib);
   }
@@ -120,17 +120,17 @@ inline const std::string GpuActivity::metadataJson() const {
   // if compute kernel, add grid and block
   else if (correlationToGrid.count(gpuActivity.id) > 0) {
     return fmt::format(R"JSON(
-      "device": {}, "stream": {},
+      "device": {}, "stream": {}, "hsa_queue": {},
       "correlation": {}, "kind": "{}",
       "grid": {}, "block": {})JSON",
-      gpuActivity.device, resourceId(),
+      gpuActivity.device, resourceId(), gpuActivity.queue,
       gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op),
       correlationToGrid[gpuActivity.id], correlationToBlock[gpuActivity.id]);
   } else {
     return fmt::format(R"JSON(
-      "device": {}, "stream": {},
+      "device": {}, "stream": {}, "hsa_queue": {},
       "correlation": {}, "kind": "{}")JSON",
-      gpuActivity.device, resourceId(),
+      gpuActivity.device, resourceId(), gpuActivity.queue,
       gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op));
   }
   // clang-format on

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -538,6 +538,11 @@ TEST_F(RocmActivityProfilerTest, HtoDMemcpyPrefersRuntimeStreamOverAsyncQueue) {
   // Even though the async copy carries a nonzero HW queue (42), it is grouped
   // by its real HIP stream (7) -- shared with the kernel -> dense index 1.
   EXPECT_EQ(memcpyActivity->resourceId(), 1);
+  // The raw HSA queue (42) is still logged in the event metadata for debugging,
+  // even though track placement uses the stream.
+  EXPECT_NE(
+      memcpyActivity->metadataJson().find("\"hsa_queue\": 42"),
+      std::string::npos);
 }
 
 TEST_F(


### PR DESCRIPTION
Summary:

Having the HSA queue ID is still important information. Surface it as a field to be easily queried across, rather than UI track provenance.

Reviewed By: sanrise

Differential Revision: D107568026


