### PR TITLE
Restrict on-demand trace output path to a safe directory (#1426)

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -63,6 +63,11 @@ class Config : public AbstractConfig {
     activitiesLogUrl_ = url;
   }
 
+  // Called for configs from the daemon IPC path. See onDemand_.
+  void setOnDemand(bool onDemand) {
+    onDemand_ = onDemand;
+  }
+
   [[nodiscard]] bool activitiesLogToMemory() const {
     return activitiesLogToMemory_;
   }
@@ -439,6 +444,9 @@ class Config : public AbstractConfig {
 
   // Log activities to memory buffer
   bool activitiesLogToMemory_{false};
+
+  // Restricts trace output path when set (untrusted on-demand config).
+  bool onDemand_{false};
 
   int64_t activitiesMaxGpuBufferSize_;
   std::chrono::seconds activitiesWarmupDuration_;

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <mutex>
 #include <ostream>
+#include <string_view>
 #include <utility>
 
 #include "Logger.h"
@@ -220,6 +221,34 @@ static string defaultMemoryTraceFileName() {
   return fmt::format("/tmp/memory_snapshot_{}.pickle", processId());
 }
 
+namespace {
+
+// Dir that on-demand trace files are restricted to. Defaults to
+// /tmp; overridable locally via KINETO_ONDEMAND_TRACE_DIR.
+constexpr std::string_view kDefaultOnDemandTraceDir = "/tmp/";
+
+const string& allowedOnDemandTraceDir() {
+  static const string kDir = [] {
+    const char* env = std::getenv("KINETO_ONDEMAND_TRACE_DIR");
+    string d = (env != nullptr && *env != '\0')
+        ? string(env)
+        : string(kDefaultOnDemandTraceDir);
+    if (d.back() != '/') {
+      d.push_back('/');
+    }
+    return d;
+  }();
+  return kDir;
+}
+
+// Allowed only if under the allowed dir and free of ".." traversal.
+bool isAllowedOnDemandTraceFile(const string& path) {
+  const string& dir = allowedOnDemandTraceDir();
+  return path.starts_with(dir) && path.find("..") == string::npos;
+}
+
+} // namespace
+
 Config::Config()
     : verboseLogLevel_(-1),
       samplePeriod_(kDefaultSamplePeriodMsecs),
@@ -348,7 +377,13 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   } else if (!name.compare(kSamplesPerReportKey)) {
     samplesPerReport_ = toInt32(val);
   } else if (!name.compare(kEventsLogFileKey)) {
-    eventLogFile_ = val;
+    if (onDemand_ && !isAllowedOnDemandTraceFile(val)) {
+      LOG(WARNING) << "Ignoring on-demand " << kEventsLogFileKey
+                   << " outside allowed directory " << allowedOnDemandTraceDir()
+                   << ": " << val;
+    } else {
+      eventLogFile_ = val;
+    }
   } else if (!name.compare(kEventsEnabledDevicesKey)) {
     eventProfilerDeviceMask_ = createDeviceMask(val);
   } else if (!name.compare(kOnDemandDurationKey)) {
@@ -389,17 +424,23 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   } else if (!name.compare(kProfileMemoryDuration)) {
     profileMemoryDuration_ = toInt32(val);
   } else if (!name.compare(kActivitiesLogFileKey)) {
-    activitiesLogFile_ = val;
-    activitiesLogUrl_ = fmt::format("file://{}", val);
-    size_t jidx = activitiesLogUrl_.find(".pt.trace.json");
-    if (jidx != std::string::npos) {
-      activitiesLogUrl_.replace(
-          jidx, 14, fmt::format("_{}.pt.trace.json", processId()));
+    if (onDemand_ && !isAllowedOnDemandTraceFile(val)) {
+      LOG(WARNING) << "Ignoring on-demand " << kActivitiesLogFileKey
+                   << " outside allowed directory " << allowedOnDemandTraceDir()
+                   << ": " << val << " (trace will use the default path)";
     } else {
-      jidx = activitiesLogUrl_.find(".json");
+      activitiesLogFile_ = val;
+      activitiesLogUrl_ = fmt::format("file://{}", val);
+      size_t jidx = activitiesLogUrl_.find(".pt.trace.json");
       if (jidx != std::string::npos) {
         activitiesLogUrl_.replace(
-            jidx, 5, fmt::format("_{}.json", processId()));
+            jidx, 14, fmt::format("_{}.pt.trace.json", processId()));
+      } else {
+        jidx = activitiesLogUrl_.find(".json");
+        if (jidx != std::string::npos) {
+          activitiesLogUrl_.replace(
+              jidx, 5, fmt::format("_{}.json", processId()));
+        }
       }
     }
     activitiesOnDemandTimestamp_ = timestamp();

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -192,6 +192,8 @@ void ConfigLoader::configureFromDaemon(
   }
 
   LOG(INFO) << "Received config from dyno:\n" << config_str;
+  // Untrusted daemon IPC config; restrict trace output path.
+  config.setOnDemand(true);
   config.parse(config_str);
   notifyHandlers(config);
 }

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -324,3 +324,39 @@ TEST(ParseTest, RequestTraceIds) {
   EXPECT_TRUE(cfg.parse("REQUEST_GROUP_TRACE_ID=ABC"));
   EXPECT_EQ(cfg.requestGroupTraceID(), "ABC");
 }
+
+// Trusted base config may set any trace path.
+TEST(ParseTest, BaseConfigLogFileUnrestricted) {
+  Config cfg;
+  EXPECT_TRUE(cfg.parse("ACTIVITIES_LOG_FILE=/home/user/custom/trace.json"));
+  EXPECT_EQ(cfg.activitiesLogFile(), "/home/user/custom/trace.json");
+
+  EXPECT_TRUE(cfg.parse("EVENTS_LOG_FILE=/home/user/custom/events.log"));
+  EXPECT_EQ(cfg.eventLogFile(), "/home/user/custom/events.log");
+}
+
+// On-demand path under the allowed dir is accepted.
+TEST(ParseTest, OnDemandLogFileAllowed) {
+  Config cfg;
+  cfg.setOnDemand(true);
+  EXPECT_TRUE(cfg.parse("ACTIVITIES_LOG_FILE=/tmp/my_trace.json"));
+  EXPECT_EQ(cfg.activitiesLogFile(), "/tmp/my_trace.json");
+}
+
+// On-demand path outside the allowed dir (or with traversal) falls back.
+TEST(ParseTest, OnDemandLogFileRejectedOutsideAllowedDir) {
+  Config cfg;
+  cfg.setOnDemand(true);
+  const std::string original = cfg.activitiesLogFile();
+
+  EXPECT_TRUE(cfg.parse("ACTIVITIES_LOG_FILE=/etc/cron.d/payload"));
+  EXPECT_EQ(cfg.activitiesLogFile(), original);
+  EXPECT_EQ(cfg.activitiesLogFile().rfind("/tmp/", 0), 0u);
+
+  EXPECT_TRUE(cfg.parse("ACTIVITIES_LOG_FILE=/tmp/../etc/cron.d/payload"));
+  EXPECT_EQ(cfg.activitiesLogFile(), original);
+
+  const std::string originalEvents = cfg.eventLogFile();
+  EXPECT_TRUE(cfg.parse("EVENTS_LOG_FILE=/etc/passwd"));
+  EXPECT_EQ(cfg.eventLogFile(), originalEvents);
+}


### PR DESCRIPTION
Summary:

# What: 
An unauthenticated dynolog JSON-RPC caller (port 1778) can set `ACTIVITIES_LOG_FILE`/`EVENTS_LOG_FILE` in an on-demand config, making every libkineto worker write its trace to an attacker-chosen path under the worker uid (arbitrary file write).

# Why: 
This addresses a security issue where dynolog relays unauthenticated on-demand config strings verbatim to libkineto. This diff closes the file-write primitive at the point libkineto opens the trace output path, covering both OSS and internal on-demand tracing paths.

# Fix: 
libkineto now treats configs that arrive from the dynolog daemon (the on-demand trace requests) as untrusted, and restricts their trace output path to /tmp. A path outside /tmp, or one containing "..", is ignored and the trace falls back to the default /tmp location. The local /etc/libkineto.conf base config is trusted and stays unrestricted. The allowed directory can be widened on the host via KINETO_ONDEMAND_TRACE_DIR (which a remote requester cannot set). Prod on-demand tracing uses ACTIVITIES_MANIFOLD_PATH (Manifold upload), not ACTIVITIES_LOG_FILE, so prod traffic is unaffected.

Reviewed By: sanrise

Differential Revision: D107449793


