### PR TITLE
Speedup and fix PyTorch CI build

### DIFF
--- a/.github/scripts/config_cpu.sh
+++ b/.github/scripts/config_cpu.sh
@@ -30,6 +30,12 @@ export USE_NCCL=0
 export USE_ROCM=0
 export BUILD_TEST=1
 
+# --- PyTorch build caching ---
+# This arch's CI runner is an AWS instance, so it can reach PyTorch's shared
+# S3 sccache bucket. pytorch_build_test.sh reads this to cache the build.
+# shellcheck disable=SC2034
+KINETO_USE_SCCACHE=1
+
 # --- Deselected PyTorch profiler tests ---
 # Each entry is a pytest node ID passed as a --deselect argument.
 #

--- a/.github/scripts/config_cpu.sh
+++ b/.github/scripts/config_cpu.sh
@@ -32,7 +32,7 @@ export BUILD_TEST=1
 
 # --- PyTorch build caching ---
 # This arch's CI runner is an AWS instance, so it can reach PyTorch's shared
-# S3 sccache bucket. pytorch_build_test.sh reads this to cache the build.
+# S3 sccache bucket.
 # shellcheck disable=SC2034
 KINETO_USE_SCCACHE=1
 

--- a/.github/scripts/config_cuda.sh
+++ b/.github/scripts/config_cuda.sh
@@ -28,7 +28,7 @@ export BUILD_TEST=1
 
 # --- PyTorch build caching ---
 # This arch's CI runner is an AWS instance, so it can reach PyTorch's shared
-# S3 sccache bucket. pytorch_build_test.sh reads this to cache the build.
+# S3 sccache bucket.
 # shellcheck disable=SC2034
 KINETO_USE_SCCACHE=1
 

--- a/.github/scripts/config_cuda.sh
+++ b/.github/scripts/config_cuda.sh
@@ -42,17 +42,12 @@ KINETO_USE_SCCACHE=1
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(
   test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize
-  # The device-generic TestProfilerDevice suite (pytorch/pytorch#182434) does
-  # not hold on GPU runners: its CUDA instances error during setup (on ROCm/HIP
-  # one also asserts a CUDA-specific event count), and forked_process deadlocks
-  # once a GPU runtime is initialized. A class node ID deselects all its methods
-  # because pytest matches --deselect by node-ID prefix. Remove when fixed upstream.
+
+  # https://github.com/pytorch/kineto/issues/1429
   test/profiler/test_profiler.py::TestProfilerDeviceCUDA
   test/profiler/test_profiler.py::TestProfilerDeviceCPU::test_forked_process_cpu
-  # On this CUDA runner CUPTI is built in but captures no GPU kernel events at
-  # runtime, so every test that inspects kernel activity in the trace fails with
-  # "No kernel activity found in trace". These are the kernel-metadata JSON
-  # format tests; they pass on ROCm, so this is CUDA-runner-specific.
+
+  # https://github.com/pytorch/kineto/issues/1430
   test/profiler/test_profiler.py::TestMetadataJsonFormat::test_kernel_metadata_field_types
   test/profiler/test_profiler.py::TestMetadataJsonFormat::test_kernel_metadata_has_expected_fields
   test/profiler/test_profiler.py::TestMetadataJsonFormat::test_metadata_json_is_valid_json_fragment

--- a/.github/scripts/config_cuda.sh
+++ b/.github/scripts/config_cuda.sh
@@ -49,4 +49,12 @@ DESELECTED_TESTS=(
   # because pytest matches --deselect by node-ID prefix. Remove when fixed upstream.
   test/profiler/test_profiler.py::TestProfilerDeviceCUDA
   test/profiler/test_profiler.py::TestProfilerDeviceCPU::test_forked_process_cpu
+  # On this CUDA runner CUPTI is built in but captures no GPU kernel events at
+  # runtime, so every test that inspects kernel activity in the trace fails with
+  # "No kernel activity found in trace". These are the kernel-metadata JSON
+  # format tests; they pass on ROCm, so this is CUDA-runner-specific.
+  test/profiler/test_profiler.py::TestMetadataJsonFormat::test_kernel_metadata_field_types
+  test/profiler/test_profiler.py::TestMetadataJsonFormat::test_kernel_metadata_has_expected_fields
+  test/profiler/test_profiler.py::TestMetadataJsonFormat::test_metadata_json_is_valid_json_fragment
+  test/profiler/test_profiler.py::TestMetadataJsonFormat::test_metadata_json_key_value_format
 )

--- a/.github/scripts/config_cuda.sh
+++ b/.github/scripts/config_cuda.sh
@@ -26,6 +26,12 @@ KINETO_CMAKE_FLAGS=(
 export USE_CUDA=1
 export BUILD_TEST=1
 
+# --- PyTorch build caching ---
+# This arch's CI runner is an AWS instance, so it can reach PyTorch's shared
+# S3 sccache bucket. pytorch_build_test.sh reads this to cache the build.
+# shellcheck disable=SC2034
+KINETO_USE_SCCACHE=1
+
 # --- Deselected PyTorch profiler tests ---
 # Each entry is a pytest node ID passed as a --deselect argument.
 #

--- a/.github/scripts/config_cuda.sh
+++ b/.github/scripts/config_cuda.sh
@@ -42,4 +42,11 @@ KINETO_USE_SCCACHE=1
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(
   test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize
+  # The device-generic TestProfilerDevice suite (pytorch/pytorch#182434) does
+  # not hold on GPU runners: its CUDA instances error during setup (on ROCm/HIP
+  # one also asserts a CUDA-specific event count), and forked_process deadlocks
+  # once a GPU runtime is initialized. A class node ID deselects all its methods
+  # because pytest matches --deselect by node-ID prefix. Remove when fixed upstream.
+  test/profiler/test_profiler.py::TestProfilerDeviceCUDA
+  test/profiler/test_profiler.py::TestProfilerDeviceCPU::test_forked_process_cpu
 )

--- a/.github/scripts/config_rocm.sh
+++ b/.github/scripts/config_rocm.sh
@@ -46,11 +46,8 @@ KINETO_USE_SCCACHE=0
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(
   test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize
-  # The device-generic TestProfilerDevice suite (pytorch/pytorch#182434) does
-  # not hold on GPU runners: its CUDA instances error during setup (on ROCm/HIP
-  # one also asserts a CUDA-specific event count), and forked_process deadlocks
-  # once a GPU runtime is initialized. A class node ID deselects all its methods
-  # because pytest matches --deselect by node-ID prefix. Remove when fixed upstream.
+
+  # https://github.com/pytorch/kineto/issues/1429
   test/profiler/test_profiler.py::TestProfilerDeviceCUDA
   test/profiler/test_profiler.py::TestProfilerDeviceCPU::test_forked_process_cpu
 )

--- a/.github/scripts/config_rocm.sh
+++ b/.github/scripts/config_rocm.sh
@@ -46,4 +46,11 @@ KINETO_USE_SCCACHE=0
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(
   test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize
+  # The device-generic TestProfilerDevice suite (pytorch/pytorch#182434) does
+  # not hold on GPU runners: its CUDA instances error during setup (on ROCm/HIP
+  # one also asserts a CUDA-specific event count), and forked_process deadlocks
+  # once a GPU runtime is initialized. A class node ID deselects all its methods
+  # because pytest matches --deselect by node-ID prefix. Remove when fixed upstream.
+  test/profiler/test_profiler.py::TestProfilerDeviceCUDA
+  test/profiler/test_profiler.py::TestProfilerDeviceCPU::test_forked_process_cpu
 )

--- a/.github/scripts/config_rocm.sh
+++ b/.github/scripts/config_rocm.sh
@@ -30,6 +30,12 @@ export USE_ROCM=1
 export BUILD_TEST=1
 export PYTORCH_TEST_WITH_ROCM=1
 
+# --- PyTorch build caching ---
+# This arch's CI runner is not on AWS and cannot reach PyTorch's S3 sccache
+# bucket, so the PyTorch build runs without a compiler cache.
+# shellcheck disable=SC2034
+KINETO_USE_SCCACHE=0
+
 # --- Deselected PyTorch profiler tests ---
 # Each entry is a pytest node ID passed as a --deselect argument.
 #

--- a/.github/scripts/config_rocm.sh
+++ b/.github/scripts/config_rocm.sh
@@ -32,7 +32,7 @@ export PYTORCH_TEST_WITH_ROCM=1
 
 # --- PyTorch build caching ---
 # This arch's CI runner is not on AWS and cannot reach PyTorch's S3 sccache
-# bucket, so the PyTorch build runs without a compiler cache.
+# bucket.
 # shellcheck disable=SC2034
 KINETO_USE_SCCACHE=0
 

--- a/.github/scripts/config_xpu.sh
+++ b/.github/scripts/config_xpu.sh
@@ -46,7 +46,7 @@ export TORCH_XPU_ARCH_LIST=pvc
 
 # --- PyTorch build caching ---
 # This arch's CI runner is not on AWS and cannot reach PyTorch's S3 sccache
-# bucket, so the PyTorch build runs without a compiler cache.
+# bucket.
 # shellcheck disable=SC2034
 KINETO_USE_SCCACHE=0
 

--- a/.github/scripts/config_xpu.sh
+++ b/.github/scripts/config_xpu.sh
@@ -44,6 +44,12 @@ export USE_MPI=0
 # TODO: better explanation
 export TORCH_XPU_ARCH_LIST=pvc
 
+# --- PyTorch build caching ---
+# This arch's CI runner is not on AWS and cannot reach PyTorch's S3 sccache
+# bucket, so the PyTorch build runs without a compiler cache.
+# shellcheck disable=SC2034
+KINETO_USE_SCCACHE=0
+
 # --- Deselected PyTorch profiler tests ---
 # Each entry is a pytest node ID passed as a --deselect argument.
 #

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -14,11 +14,17 @@ SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 KINETO_DIR=$(pwd)
 echo "====: Kineto directory: ${KINETO_DIR}"
 
-# Clone PyTorch and replace its Kineto with PR version
-git clone --recursive --branch viable/strict https://github.com/pytorch/pytorch.git
+# Clone PyTorch as a sibling of the Kineto checkout, never inside it. Below we
+# replace PyTorch's third_party/kineto with a symlink back to KINETO_DIR. If the
+# PyTorch tree lived inside KINETO_DIR, that symlink would point at a directory
+# that contains the clone, forming an endless path cycle
+# (third_party/kineto/pytorch/third_party/kineto/pytorch/...) that setuptools
+# follows for minutes while gathering license files.
+PYTORCH_DIR="$(dirname "${KINETO_DIR}")/pytorch"
+git clone --recursive --branch viable/strict https://github.com/pytorch/pytorch.git "${PYTORCH_DIR}"
 echo "====: Cloned PyTorch"
 
-pushd pytorch
+pushd "${PYTORCH_DIR}"
 rm -rf third_party/kineto
 ln -s "${KINETO_DIR}" third_party/kineto
 echo "====: Linked PR version of Kineto to PyTorch (${KINETO_DIR} -> third_party/kineto)"

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -106,12 +106,13 @@ for t in "${DESELECTED_TESTS[@]}"; do
   DESELECT_ARGS+=(--deselect="$t")
 done
 
-# Run PyTorch profiler tests. Bound each test so a single hang (e.g. slow stack
-# symbolization on these runners) fails that one test instead of consuming the
-# whole job's timeout. The thread method aborts on hangs that hold the GIL in
-# native code, which the signal method cannot interrupt, and dumps the stack so
-# the hang is diagnosable.
+# Run PyTorch profiler tests under a per-test timeout so a hang fails that one
+# test instead of consuming the whole job's timeout. Use the signal method, not
+# thread: the thread method's watchdog thread is captured by the profiler and
+# inflates the thread counts that some profiler tests assert on. The tradeoff is
+# that signal cannot interrupt a hang holding the GIL in native code; such a
+# hang still rides the job timeout, which we will address separately.
 pip install pytest pytest-timeout
-python -m pytest test/profiler/ -v --timeout=300 --timeout-method=thread "${DESELECT_ARGS[@]}"
+python -m pytest test/profiler/ -v --timeout=300 --timeout-method=signal "${DESELECT_ARGS[@]}"
 popd
 echo "====: Ran PyTorch profiler tests"

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -106,8 +106,12 @@ for t in "${DESELECTED_TESTS[@]}"; do
   DESELECT_ARGS+=(--deselect="$t")
 done
 
-# Run PyTorch profiler tests
-pip install pytest
-python -m pytest test/profiler/ -v "${DESELECT_ARGS[@]}"
+# Run PyTorch profiler tests. Bound each test so a single hang (e.g. slow stack
+# symbolization on these runners) fails that one test instead of consuming the
+# whole job's timeout. The thread method aborts on hangs that hold the GIL in
+# native code, which the signal method cannot interrupt, and dumps the stack so
+# the hang is diagnosable.
+pip install pytest pytest-timeout
+python -m pytest test/profiler/ -v --timeout=300 --timeout-method=thread "${DESELECT_ARGS[@]}"
 popd
 echo "====: Ran PyTorch profiler tests"

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -28,38 +28,45 @@ echo "====: Linked PR version of Kineto to PyTorch (${KINETO_DIR} -> third_party
 source "${SCRIPTS_DIR}/config_${GPU_ARCH}.sh"
 
 # Enable sccache so PyTorch object files persist across CI runs. Most Kineto
-# PRs touch only Kineto, so the bulk of PyTorch's thousands of objects are
-# cache hits on warm runs. PyTorch's CMake picks up the compiler launchers
-# below, so we only install the binary and point it at S3. Credentials come
-# from the runner's AWS instance role, the same fleet PyTorch CI uses.
-#
-# All callers of this script run on Linux; select the binary by host
-# architecture so the same script works on x86_64 and aarch64 runners. An
-# unrecognized architecture warns and builds uncached rather than failing.
-case "$(uname -m)" in
-  x86_64)        SCCACHE_ARCH=x86_64 ;;
-  aarch64|arm64) SCCACHE_ARCH=aarch64 ;;
-  *) echo "====: Unsupported arch for sccache: $(uname -m); building uncached" >&2
-     SCCACHE_ARCH="" ;;
-esac
+# PRs touch only Kineto, so the bulk of PyTorch's objects are cache hits on
+# warm runs. Whether the runner can reach the S3 cache is architecture
+# specific (only the AWS-hosted runners can), so each config_<arch>.sh opts
+# in via KINETO_USE_SCCACHE.
+if [[ "${KINETO_USE_SCCACHE:-0}" == "1" ]]; then
+  # Callers run on Linux; select the prebuilt binary by host architecture.
+  case "$(uname -m)" in
+    x86_64)        SCCACHE_ARCH=x86_64 ;;
+    aarch64|arm64) SCCACHE_ARCH=aarch64 ;;
+    *) SCCACHE_ARCH="" ;;
+  esac
 
-if [[ -n "${SCCACHE_ARCH}" ]]; then
-  SCCACHE_VERSION="v0.8.2"
-  SCCACHE_PKG="sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl"
-  curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${SCCACHE_PKG}.tar.gz" | tar -xz -C /tmp
-  install -m755 "/tmp/${SCCACHE_PKG}/sccache" /usr/local/bin/sccache
+  if [[ -z "${SCCACHE_ARCH}" ]]; then
+    echo "====: Unsupported arch for sccache: $(uname -m); building uncached" >&2
+  else
+    SCCACHE_VERSION="v0.8.2"
+    SCCACHE_PKG="sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl"
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${SCCACHE_PKG}.tar.gz" | tar -xz -C /tmp
+    install -m755 "/tmp/${SCCACHE_PKG}/sccache" /usr/local/bin/sccache
 
-  export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
-  export SCCACHE_REGION=us-east-1
-  export SCCACHE_S3_KEY_PREFIX=kineto
-  export SCCACHE_IDLE_TIMEOUT=0
-  export SCCACHE_ERROR_LOG=/tmp/sccache_error.log
-  export CMAKE_C_COMPILER_LAUNCHER=sccache
-  export CMAKE_CXX_COMPILER_LAUNCHER=sccache
-  export CMAKE_CUDA_COMPILER_LAUNCHER=sccache
-  sccache --start-server || true
-  sccache --zero-stats || true
-  echo "====: Enabled sccache (${SCCACHE_VERSION}, ${SCCACHE_ARCH})"
+    export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
+    export SCCACHE_REGION=us-east-1
+    export SCCACHE_S3_KEY_PREFIX=kineto
+    export SCCACHE_IDLE_TIMEOUT=0
+    export SCCACHE_ERROR_LOG=/tmp/sccache_error.log
+
+    # Route compilers through sccache only if the cache backend actually
+    # starts. A configured-but-unreachable bucket otherwise makes every
+    # compile fail, so this keeps a cache problem from breaking the build.
+    if sccache --start-server; then
+      sccache --zero-stats || true
+      export CMAKE_C_COMPILER_LAUNCHER=sccache
+      export CMAKE_CXX_COMPILER_LAUNCHER=sccache
+      export CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+      echo "====: Enabled sccache (${SCCACHE_VERSION}, ${SCCACHE_ARCH})"
+    else
+      echo "====: sccache cache unreachable; building without it" >&2
+    fi
+  fi
 fi
 
 # Build PyTorch from source

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -17,9 +17,7 @@ echo "====: Kineto directory: ${KINETO_DIR}"
 # Clone PyTorch as a sibling of the Kineto checkout, never inside it. Below we
 # replace PyTorch's third_party/kineto with a symlink back to KINETO_DIR. If the
 # PyTorch tree lived inside KINETO_DIR, that symlink would point at a directory
-# that contains the clone, forming an endless path cycle
-# (third_party/kineto/pytorch/third_party/kineto/pytorch/...) that setuptools
-# follows for minutes while gathering license files.
+# that contains the clone, forming an endless path cycle.
 PYTORCH_DIR="$(dirname "${KINETO_DIR}")/pytorch"
 git clone --recursive --branch viable/strict https://github.com/pytorch/pytorch.git "${PYTORCH_DIR}"
 echo "====: Cloned PyTorch"
@@ -39,7 +37,9 @@ source "${SCRIPTS_DIR}/config_${GPU_ARCH}.sh"
 # specific (only the AWS-hosted runners can), so each config_<arch>.sh opts
 # in via KINETO_USE_SCCACHE.
 if [[ "${KINETO_USE_SCCACHE:-0}" == "1" ]]; then
-  # Callers run on Linux; select the prebuilt binary by host architecture.
+  # Note that the sscache binary we use is hard-coded to be Linux specific.
+  # That's safe because we only have Linux specific callers. Also note that
+  # GPU_ARCH does not determine a CPU architecture, so we determine that here.
   case "$(uname -m)" in
     x86_64)        SCCACHE_ARCH=x86_64 ;;
     aarch64|arm64) SCCACHE_ARCH=aarch64 ;;
@@ -110,8 +110,7 @@ done
 # test instead of consuming the whole job's timeout. Use the signal method, not
 # thread: the thread method's watchdog thread is captured by the profiler and
 # inflates the thread counts that some profiler tests assert on. The tradeoff is
-# that signal cannot interrupt a hang holding the GIL in native code; such a
-# hang still rides the job timeout, which we will address separately.
+# that signal cannot interrupt a hang holding the GIL in native code.
 pip install pytest pytest-timeout
 python -m pytest test/profiler/ -v --timeout=300 --timeout-method=signal "${DESELECT_ARGS[@]}"
 popd

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -27,6 +27,41 @@ echo "====: Linked PR version of Kineto to PyTorch (${KINETO_DIR} -> third_party
 # shellcheck source=/dev/null
 source "${SCRIPTS_DIR}/config_${GPU_ARCH}.sh"
 
+# Enable sccache so PyTorch object files persist across CI runs. Most Kineto
+# PRs touch only Kineto, so the bulk of PyTorch's thousands of objects are
+# cache hits on warm runs. PyTorch's CMake picks up the compiler launchers
+# below, so we only install the binary and point it at S3. Credentials come
+# from the runner's AWS instance role, the same fleet PyTorch CI uses.
+#
+# All callers of this script run on Linux; select the binary by host
+# architecture so the same script works on x86_64 and aarch64 runners. An
+# unrecognized architecture warns and builds uncached rather than failing.
+case "$(uname -m)" in
+  x86_64)        SCCACHE_ARCH=x86_64 ;;
+  aarch64|arm64) SCCACHE_ARCH=aarch64 ;;
+  *) echo "====: Unsupported arch for sccache: $(uname -m); building uncached" >&2
+     SCCACHE_ARCH="" ;;
+esac
+
+if [[ -n "${SCCACHE_ARCH}" ]]; then
+  SCCACHE_VERSION="v0.8.2"
+  SCCACHE_PKG="sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl"
+  curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${SCCACHE_PKG}.tar.gz" | tar -xz -C /tmp
+  install -m755 "/tmp/${SCCACHE_PKG}/sccache" /usr/local/bin/sccache
+
+  export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
+  export SCCACHE_REGION=us-east-1
+  export SCCACHE_S3_KEY_PREFIX=kineto
+  export SCCACHE_IDLE_TIMEOUT=0
+  export SCCACHE_ERROR_LOG=/tmp/sccache_error.log
+  export CMAKE_C_COMPILER_LAUNCHER=sccache
+  export CMAKE_CXX_COMPILER_LAUNCHER=sccache
+  export CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+  sccache --start-server || true
+  sccache --zero-stats || true
+  echo "====: Enabled sccache (${SCCACHE_VERSION}, ${SCCACHE_ARCH})"
+fi
+
 # Build PyTorch from source
 pip install -r requirements.txt
 
@@ -38,6 +73,10 @@ fi
 
 python -m pip install --no-build-isolation -v -e .
 echo "====: Built PyTorch from source"
+
+# Surface cache hit rates so warm-vs-cold runs are diagnosable from the log.
+# Harmless when sccache was not enabled (no server running).
+sccache --show-stats || true
 
 # Download PyTorch's dynamic disabled tests list from S3. This is generated every
 # 15 minutes from DISABLED GitHub Issues in pytorch/pytorch, enabling automatic

--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -13,10 +13,5 @@ python -m pip install --upgrade pip
 echo "====: Installed pip version: $(python -m pip --version)"
 
 # Ensure cmake is at least the max version needed by PyTorch and Kineto.
-# Install from PyPI rather than conda: the cmake wheel ships a prebuilt
-# binary and installs in seconds. The old conda path added the conda-forge
-# channel with strict priority, which forced conda's classic solver to
-# re-solve the entire base environment onto conda-forge and took over an
-# hour on CI runners.
 python -m pip install --upgrade 'cmake>=3.27'
 echo "====: Installed cmake version: $(cmake --version)"

--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -9,16 +9,14 @@ set -eux
 
 echo "====: Working directory: $(pwd)"
 
-# Ensure cmake is at least the max version needed by PyTorch and Kineto.
-# Use conda-forge with strict priority so we get an up-to-date cmake.
-# `--add channels` errors when the channel is already at the top of the
-# user condarc, which happens on reused runners where a previous job
-# already added it. Swallow that error so the script stays idempotent.
-conda config --add channels conda-forge 2>/dev/null || true
-conda config --set channel_priority strict
-conda config --show channels
-conda install -y 'cmake>=3.27'
-echo "====: Installed cmake version: $(cmake --version)"
-
 python -m pip install --upgrade pip
 echo "====: Installed pip version: $(python -m pip --version)"
+
+# Ensure cmake is at least the max version needed by PyTorch and Kineto.
+# Install from PyPI rather than conda: the cmake wheel ships a prebuilt
+# binary and installs in seconds. The old conda path added the conda-forge
+# channel with strict priority, which forced conda's classic solver to
+# re-solve the entire base environment onto conda-forge and took over an
+# hour on CI runners.
+python -m pip install --upgrade 'cmake>=3.27'
+echo "====: Installed cmake version: $(cmake --version)"


### PR DESCRIPTION
**Problem**
Kineto's PyTorch-build CI jobs timeout. Two phases dominate the run:

1. Installing cmake takes ~62 minutes because setup.sh adds the conda-forge channel with strict priority, which forces conda's classic solver to re-solve the entire base environment onto conda-forge.
2. The PyTorch build then recompiles all ~8k objects from scratch on every run because no compiler cache is configured.

Addressing that also exposed more problems:

1. Infinite directory creation.
2. New actual failing tests.

**Fixes**
1. Install cmake from PyPI instead of conda. The cmake wheel ships a prebuilt binary and installs in seconds, and this removes conda from the critical path for all nine workflows that source setup.sh.
3. Enable sccache backed by PyTorch's S3 cache for the PyTorch build. Most Kineto PRs touch only Kineto, so the bulk of PyTorch's objects become cache hits on warm runs.
4. We also eliminate an infinite directory problem where we symlinked Kineto in the cloned PyTorch, but we cloned PyTorch in the Kineto directory.
5. Manually deselect the failing tests. We're created https://github.com/pytorch/kineto/issues/1430 and https://github.com/pytorch/kineto/issues/1429 to track.