### PR TITLE
Introduce TypedMetadata structs

### DIFF
--- a/libkineto/include/ITraceActivity.h
+++ b/libkineto/include/ITraceActivity.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "ActivityType.h"
+#include "TypedMetadata.h"
 
 namespace libkineto {
 
@@ -50,6 +51,9 @@ struct ITraceActivity {
   // Return json formatted metadata
   // FIXME: Return iterator to dynamic type map here instead
   [[nodiscard]] virtual const std::string metadataJson() const = 0;
+  [[nodiscard]] virtual TypedMetadata typedMetadata() const {
+    return {};
+  }
   // Return the metadata value in string format with key
   // @lint-ignore CLANGTIDY: clang-diagnostic-unused-parameter
   [[nodiscard]] virtual const std::string getMetadataValue([[maybe_unused]] const std::string& key) const {

--- a/libkineto/include/TypedMetadata.h
+++ b/libkineto/include/TypedMetadata.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace libkineto {
+
+using TypedValue = std::variant<int64_t, double, bool, std::string, std::vector<int64_t>, std::vector<std::string>>;
+
+template <typename T>
+struct MetadataField {
+  using FieldType = T;
+
+  std::string_view name;
+};
+
+/*
+ * TypedMetadata is a per-activity map for structured metadata with
+ * field-level type checking.
+ *
+ * Usage:
+ *   // Declare each field once. FieldType is int64_t here, and set/get enforce
+ *   // that declared type.
+ *   inline constexpr MetadataField<int64_t> kCorrelation{"correlation"};
+ *
+ *   // Producer: populate metadata from ITraceActivity::typedMetadata().
+ *   TypedMetadata metadata;
+ *   metadata.set(kCorrelation, int64_t{activity.correlationId});
+ *
+ *   // Consumer: read a known field with its declared type.
+ *   std::optional<int64_t> correlation = metadata.get(kCorrelation);
+ *
+ *   // Consumer: iterate over all fields for generic output conversion.
+ *   metadata.visit([](std::string_view name, const TypedValue& value) {
+ *     ...
+ *   });
+ */
+class TypedMetadata {
+ public:
+  template <typename T, typename V>
+  void set(const MetadataField<T>& field, V&& value) {
+    using FieldType = typename MetadataField<T>::FieldType;
+    static_assert(std::is_same_v<FieldType, std::decay_t<V>>, "value type must match field's declared type");
+    entries_.insert_or_assign(std::string{field.name}, TypedValue{std::forward<V>(value)});
+  }
+
+  [[nodiscard]] std::optional<TypedValue> get(std::string_view key) const {
+    auto it = entries_.find(key);
+    if (it == entries_.end()) {
+      return std::nullopt;
+    }
+    return it->second;
+  }
+
+  template <typename T>
+  [[nodiscard]] std::optional<typename MetadataField<T>::FieldType> get(const MetadataField<T>& field) const {
+    using FieldType = typename MetadataField<T>::FieldType;
+    auto it = entries_.find(field.name);
+    if (it == entries_.end()) {
+      return std::nullopt;
+    }
+    return std::get<FieldType>(it->second);
+  }
+
+  template <typename Fn>
+  void visit(Fn&& fn) const {
+    for (const auto& [name, value] : entries_) {
+      fn(std::string_view{name}, value);
+    }
+  }
+
+  [[nodiscard]] bool empty() const {
+    return entries_.empty();
+  }
+
+ private:
+  std::map<std::string, TypedValue, std::less<>> entries_;
+};
+
+} // namespace libkineto

--- a/libkineto/test/TypedMetadataTest.cpp
+++ b/libkineto/test/TypedMetadataTest.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "include/TypedMetadata.h"
+
+#include <gtest/gtest.h>
+#include <map>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using namespace libkineto;
+
+namespace {
+
+constexpr MetadataField<int64_t> kCount{"count"};
+constexpr MetadataField<int64_t> kMissing{"missing"};
+constexpr MetadataField<std::vector<int64_t>> kIds{"ids"};
+constexpr MetadataField<std::string> kLabel{"label"};
+constexpr MetadataField<double> kRatio{"ratio"};
+constexpr MetadataField<bool> kEnabled{"enabled"};
+constexpr MetadataField<std::vector<std::string>> kNames{"names"};
+
+} // namespace
+
+TEST(TypedMetadataTest, StoresAndRetrievesTypedValues) {
+  TypedMetadata metadata;
+  metadata.set(kCount, int64_t{5});
+  metadata.set(kIds, std::vector<int64_t>{1, 2});
+  metadata.set(kLabel, std::string{"label"});
+  metadata.set(kRatio, 1.5);
+  metadata.set(kEnabled, true);
+  metadata.set(kNames, std::vector<std::string>{"a", "b"});
+
+  EXPECT_FALSE(metadata.empty());
+  EXPECT_EQ(metadata.get(kCount), int64_t{5});
+  EXPECT_EQ(metadata.get(kIds), std::vector<int64_t>({1, 2}));
+  EXPECT_EQ(metadata.get(kLabel), std::string{"label"});
+  EXPECT_EQ(metadata.get(kRatio), 1.5);
+  EXPECT_EQ(metadata.get(kEnabled), true);
+  EXPECT_EQ(metadata.get(kNames), std::vector<std::string>({"a", "b"}));
+  EXPECT_FALSE(metadata.get(kMissing).has_value());
+
+  auto raw = metadata.get("count");
+  ASSERT_TRUE(raw.has_value());
+  EXPECT_EQ(std::get<int64_t>(*raw), int64_t{5});
+}
+
+TEST(TypedMetadataTest, VisitsStoredValuesByName) {
+  TypedMetadata metadata;
+  metadata.set(kCount, int64_t{5});
+  metadata.set(kLabel, std::string{"label"});
+
+  std::map<std::string, TypedValue> values;
+  metadata.visit([&](std::string_view name, const TypedValue& value) {
+    values.emplace(std::string{name}, value);
+  });
+
+  EXPECT_EQ(std::get<int64_t>(values.at("count")), int64_t{5});
+  EXPECT_EQ(std::get<std::string>(values.at("label")), std::string{"label"});
+}
+
+TEST(TypedMetadataTest, OverwritesDuplicateFields) {
+  TypedMetadata metadata;
+  metadata.set(kCount, int64_t{5});
+  metadata.set(kCount, int64_t{6});
+
+  EXPECT_EQ(metadata.get(kCount), int64_t{6});
+}


### PR DESCRIPTION
Summary:
Currently, Kineto’s structured per-event metadata is produced from typed profiling data which we convert to strings. While this makes the JSON path straightforward, it forces us to parse from string back to typed data anywhere we produce a non-JSON output. We want to avoid this by exposing typed metadata instead.

This diff adds a `TypedMetadata` container, which will be the source for typed metadata on `ITraceActivity` which is exposed to anyone who needs to consume Kineto results.

Reviewed By: scotts

Differential Revision: D107548537


