### PR TITLE
Add TypedMetadata to CUPTI activities (#1434)

### DIFF
--- a/libkineto/src/CudaMetadataFields.h
+++ b/libkineto/src/CudaMetadataFields.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "TypedMetadata.h"
+
+namespace libkineto::CudaMetadataFields {
+inline constexpr MetadataField<int64_t> kActiveBlocksPerMultiprocessor{"activeBlocksPerMultiprocessor"};
+inline constexpr MetadataField<int64_t> kAllocatedRegistersPerBlock{"allocatedRegistersPerBlock"};
+inline constexpr MetadataField<int64_t> kAllocatedSharedMemPerBlock{"allocatedSharedMemPerBlock"};
+inline constexpr MetadataField<std::vector<int64_t>> kBlock{"block"};
+inline constexpr MetadataField<int64_t> kBlockLimitBarriers{"blockLimitBarriers"};
+inline constexpr MetadataField<int64_t> kBlockLimitBlocks{"blockLimitBlocks"};
+inline constexpr MetadataField<int64_t> kBlockLimitRegs{"blockLimitRegs"};
+inline constexpr MetadataField<int64_t> kBlockLimitSharedMem{"blockLimitSharedMem"};
+inline constexpr MetadataField<int64_t> kBlockLimitWarps{"blockLimitWarps"};
+inline constexpr MetadataField<double> kBlocksPerSm{"blocks per SM"};
+inline constexpr MetadataField<int64_t> kBytes{"bytes"};
+inline constexpr MetadataField<int64_t> kCbid{"cbid"};
+inline constexpr MetadataField<int64_t> kChannel{"channel"};
+inline constexpr MetadataField<int64_t> kChannelType{"channel_type"};
+inline constexpr MetadataField<int64_t> kContext{"context"};
+inline constexpr MetadataField<int64_t> kCorrelation{"correlation"};
+inline constexpr MetadataField<std::string> kCudaSyncKind{"cuda_sync_kind"};
+inline constexpr MetadataField<int64_t> kDevice{"device"};
+inline constexpr MetadataField<int64_t> kEstAchievedOccupancyPercent{"est. achieved occupancy %"};
+inline constexpr MetadataField<int64_t> kEventId{"event_id"};
+inline constexpr MetadataField<int64_t> kFromContext{"fromContext"};
+inline constexpr MetadataField<int64_t> kFromDevice{"fromDevice"};
+inline constexpr MetadataField<int64_t> kGraphId{"graph id"};
+inline constexpr MetadataField<int64_t> kGraphNodeId{"graph node id"};
+inline constexpr MetadataField<std::vector<int64_t>> kGrid{"grid"};
+inline constexpr MetadataField<int64_t> kInContext{"inContext"};
+inline constexpr MetadataField<int64_t> kInDevice{"inDevice"};
+inline constexpr MetadataField<std::string> kLimitingFactors{"limitingFactors"};
+inline constexpr MetadataField<double> kMemoryBandwidthGbps{"memory bandwidth (GB/s)"};
+inline constexpr MetadataField<int64_t> kPriority{"priority"};
+inline constexpr MetadataField<int64_t> kQueued{"queued"};
+inline constexpr MetadataField<int64_t> kRegistersPerThread{"registers per thread"};
+inline constexpr MetadataField<int64_t> kSharedMemory{"shared memory"};
+inline constexpr MetadataField<int64_t> kStream{"stream"};
+inline constexpr MetadataField<int64_t> kToContext{"toContext"};
+inline constexpr MetadataField<int64_t> kToDevice{"toDevice"};
+inline constexpr MetadataField<int64_t> kWaitOnCudaEventId{"wait_on_cuda_event_id"};
+inline constexpr MetadataField<int64_t> kWaitOnCudaEventRecordCorrId{"wait_on_cuda_event_record_corr_id"};
+inline constexpr MetadataField<int64_t> kWaitOnStream{"wait_on_stream"};
+inline constexpr MetadataField<double> kWarpsPerSm{"warps per SM"};
+} // namespace libkineto::CudaMetadataFields

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -15,6 +15,7 @@
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include "ApproximateClock.h"
+#include "CudaMetadataFields.h"
 #include "CuptiCbidRegistry.h"
 #include "Demangle.h"
 #include "DeviceProperties.h"
@@ -122,6 +123,7 @@ struct RuntimeActivity : public CuptiActivity<CUpti_ActivityAPI> {
   }
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
+  TypedMetadata typedMetadata() const override;
 
  private:
   const int32_t threadId_;
@@ -147,6 +149,7 @@ struct DriverActivity : public CuptiActivity<CUpti_ActivityAPI> {
   const std::string name() const override;
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
+  TypedMetadata typedMetadata() const override;
 
  private:
   const int32_t threadId_;
@@ -197,6 +200,7 @@ struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
   }
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
+  TypedMetadata typedMetadata() const override;
 
  private:
   const int32_t threadId_;
@@ -223,6 +227,7 @@ struct CudaSyncActivity : public CuptiActivity<CUpti_ActivitySynchronization> {
   const std::string name() const override;
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
+  TypedMetadata typedMetadata() const override;
   const CUpti_ActivitySynchronization& raw() const {
     return CuptiActivity<CUpti_ActivitySynchronization>::raw();
   }
@@ -283,6 +288,7 @@ struct CudaEventActivity : public CuptiActivity<CUpti_ActivityCudaEventType> {
   const std::string name() const override;
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
+  TypedMetadata typedMetadata() const override;
   const CUpti_ActivityCudaEventType& raw() const {
     return CuptiActivity<CUpti_ActivityCudaEventType>::raw();
   }
@@ -309,6 +315,7 @@ struct GpuActivity : public CuptiActivity<T> {
   const std::string name() const override;
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
+  TypedMetadata typedMetadata() const override;
   const T& raw() const {
     return CuptiActivity<T>::raw();
   }
@@ -336,6 +343,15 @@ inline bool isEventSync(CUpti_ActivitySynchronizationType type) {
           type == CUPTI_ACTIVITY_SYNCHRONIZATION_TYPE_STREAM_WAIT_EVENT);
 }
 
+inline int32_t streamIdForTrace(uint32_t streamId) {
+  // CUPTI uses all bits set when no stream applies. Preserve the legacy trace
+  // representation where that sentinel appears as -1 instead of 4294967295.
+  if (streamId == static_cast<uint32_t>(CUPTI_SYNCHRONIZATION_INVALID_VALUE)) {
+    return -1;
+  }
+  return static_cast<int32_t>(streamId);
+}
+
 inline std::string eventSyncInfo(const CUpti_ActivitySynchronization& act, int32_t srcStream, int32_t srcCorrId) {
   return fmt::format(
       R"JSON(
@@ -356,11 +372,7 @@ inline int64_t CudaSyncActivity::deviceId() const {
 }
 
 inline int64_t CudaSyncActivity::resourceId() const {
-  // For Context and Device Sync events stream ID is invalid and
-  // set to CUPTI_SYNCHRONIZATION_INVALID_VALUE (-1)
-  // converting to an integer will automatically wrap the number to -1
-  // in the trace.
-  return static_cast<int32_t>(raw().streamId);
+  return streamIdForTrace(raw().streamId);
 }
 
 inline void CudaSyncActivity::log(ActivityLogger& logger) const {
@@ -376,12 +388,28 @@ inline const std::string CudaSyncActivity::metadataJson() const {
       "device": {}, "context": {})JSON",
       syncTypeString(sync.type),
       isEventSync(raw().type) ? eventSyncInfo(raw(), srcStream_, srcCorrId_) : "",
-      static_cast<int32_t>(sync.streamId),
+      streamIdForTrace(sync.streamId),
       sync.correlationId,
       deviceId(),
       sync.contextId);
   // clang-format on
   return "";
+}
+
+inline TypedMetadata CudaSyncActivity::typedMetadata() const {
+  const CUpti_ActivitySynchronization& sync = raw();
+  TypedMetadata metadata;
+  metadata.set(CudaMetadataFields::kCudaSyncKind, std::string{syncTypeString(sync.type)});
+  if (isEventSync(sync.type)) {
+    metadata.set(CudaMetadataFields::kWaitOnStream, static_cast<int64_t>(srcStream_));
+    metadata.set(CudaMetadataFields::kWaitOnCudaEventRecordCorrId, static_cast<int64_t>(srcCorrId_));
+    metadata.set(CudaMetadataFields::kWaitOnCudaEventId, static_cast<int64_t>(sync.cudaEventId));
+  }
+  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(streamIdForTrace(sync.streamId)));
+  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(sync.correlationId));
+  metadata.set(CudaMetadataFields::kDevice, deviceId());
+  metadata.set(CudaMetadataFields::kContext, static_cast<int64_t>(sync.contextId));
+  return metadata;
 }
 
 inline const std::string CudaEventActivity::name() const {
@@ -393,7 +421,7 @@ inline int64_t CudaEventActivity::deviceId() const {
 }
 
 inline int64_t CudaEventActivity::resourceId() const {
-  return static_cast<int32_t>(raw().streamId);
+  return streamIdForTrace(raw().streamId);
 }
 
 inline void CudaEventActivity::log(ActivityLogger& logger) const {
@@ -408,11 +436,22 @@ inline const std::string CudaEventActivity::metadataJson() const {
       "stream": {}, "correlation": {},
       "device": {}, "context": {})JSON",
       event.eventId,
-      static_cast<int32_t>(event.streamId),
+      streamIdForTrace(event.streamId),
       event.correlationId,
       deviceId(),
       event.contextId);
   // clang-format on
+}
+
+inline TypedMetadata CudaEventActivity::typedMetadata() const {
+  const CUpti_ActivityCudaEventType& event = raw();
+  TypedMetadata metadata;
+  metadata.set(CudaMetadataFields::kEventId, static_cast<int64_t>(event.eventId));
+  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(streamIdForTrace(event.streamId)));
+  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(event.correlationId));
+  metadata.set(CudaMetadataFields::kDevice, deviceId());
+  metadata.set(CudaMetadataFields::kContext, static_cast<int64_t>(event.contextId));
+  return metadata;
 }
 
 template <class T>
@@ -462,6 +501,36 @@ inline std::string getChannelMetadata([[maybe_unused]] const T& activity) {
 #else
   return "";
 #endif
+}
+
+template <class T>
+inline void addGraphNodeTypedMetadata([[maybe_unused]] TypedMetadata& metadata, [[maybe_unused]] const T& activity) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+  metadata.set(CudaMetadataFields::kGraphId, static_cast<int64_t>(activity.graphId));
+  metadata.set(CudaMetadataFields::kGraphNodeId, static_cast<int64_t>(activity.graphNodeId));
+#endif
+}
+
+template <class T>
+inline void addPriorityTypedMetadata([[maybe_unused]] TypedMetadata& metadata, [[maybe_unused]] const T& kernel) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 13010
+  metadata.set(CudaMetadataFields::kPriority, static_cast<int64_t>(kernel.priority));
+#endif
+}
+
+template <class T>
+inline void addChannelTypedMetadata([[maybe_unused]] TypedMetadata& metadata, [[maybe_unused]] const T& activity) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+  metadata.set(CudaMetadataFields::kChannel, static_cast<int64_t>(activity.channelID));
+  metadata.set(CudaMetadataFields::kChannelType, static_cast<int64_t>(activity.channelType));
+#endif
+}
+
+inline void addBandwidthTypedMetadata([[maybe_unused]] TypedMetadata& metadata, uint64_t bytes, int64_t duration) {
+  if (duration == 0) {
+    return;
+  }
+  metadata.set(CudaMetadataFields::kMemoryBandwidthGbps, static_cast<double>(bytes) / static_cast<double>(duration));
 }
 
 // Convert limitingFactors bitmask to human-readable string
@@ -545,6 +614,52 @@ inline const std::string GpuActivity<CUpti_ActivityKernelType>::metadataJson() c
   // clang-format on
 }
 
+template <>
+inline TypedMetadata GpuActivity<CUpti_ActivityKernelType>::typedMetadata() const {
+  const CUpti_ActivityKernelType& kernel = raw();
+  const float blocksPerSmVal = blocksPerSm(kernel);
+  const float warpsPerSmVal = warpsPerSm(kernel);
+  const OccupancyMetrics occMetrics = computeOccupancyMetrics(kernel);
+
+  TypedMetadata metadata;
+  metadata.set(CudaMetadataFields::kQueued, static_cast<int64_t>(kernel.queued));
+  metadata.set(CudaMetadataFields::kDevice, static_cast<int64_t>(kernel.deviceId));
+  metadata.set(CudaMetadataFields::kContext, static_cast<int64_t>(kernel.contextId));
+  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(kernel.streamId));
+  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(kernel.correlationId));
+  metadata.set(CudaMetadataFields::kRegistersPerThread, static_cast<int64_t>(kernel.registersPerThread));
+  metadata.set(CudaMetadataFields::kSharedMemory,
+               static_cast<int64_t>(kernel.staticSharedMemory + kernel.dynamicSharedMemory));
+  metadata.set(CudaMetadataFields::kBlocksPerSm, static_cast<double>(blocksPerSmVal));
+  metadata.set(CudaMetadataFields::kWarpsPerSm, static_cast<double>(warpsPerSmVal));
+  metadata.set(
+      CudaMetadataFields::kGrid,
+      std::vector<int64_t>{
+          static_cast<int64_t>(kernel.gridX), static_cast<int64_t>(kernel.gridY), static_cast<int64_t>(kernel.gridZ)});
+  metadata.set(CudaMetadataFields::kBlock,
+               std::vector<int64_t>{static_cast<int64_t>(kernel.blockX),
+                                    static_cast<int64_t>(kernel.blockY),
+                                    static_cast<int64_t>(kernel.blockZ)});
+  metadata.set(CudaMetadataFields::kEstAchievedOccupancyPercent,
+               static_cast<int64_t>(std::lround(occMetrics.occupancy * 100.0)));
+  metadata.set(CudaMetadataFields::kActiveBlocksPerMultiprocessor,
+               static_cast<int64_t>(occMetrics.result.activeBlocksPerMultiprocessor));
+  metadata.set(CudaMetadataFields::kLimitingFactors, limitingFactorsToString(occMetrics.result.limitingFactors));
+  metadata.set(CudaMetadataFields::kBlockLimitRegs, static_cast<int64_t>(occMetrics.result.blockLimitRegs));
+  metadata.set(CudaMetadataFields::kBlockLimitSharedMem, static_cast<int64_t>(occMetrics.result.blockLimitSharedMem));
+  metadata.set(CudaMetadataFields::kBlockLimitWarps, static_cast<int64_t>(occMetrics.result.blockLimitWarps));
+  metadata.set(CudaMetadataFields::kBlockLimitBlocks, static_cast<int64_t>(occMetrics.result.blockLimitBlocks));
+  metadata.set(CudaMetadataFields::kBlockLimitBarriers, static_cast<int64_t>(occMetrics.result.blockLimitBarriers));
+  metadata.set(CudaMetadataFields::kAllocatedRegistersPerBlock,
+               static_cast<int64_t>(occMetrics.result.allocatedRegistersPerBlock));
+  metadata.set(CudaMetadataFields::kAllocatedSharedMemPerBlock,
+               static_cast<int64_t>(occMetrics.result.allocatedSharedMemPerBlock));
+  addGraphNodeTypedMetadata(metadata, kernel);
+  addPriorityTypedMetadata(metadata, kernel);
+  addChannelTypedMetadata(metadata, kernel);
+  return metadata;
+}
+
 inline std::string memcpyName(uint8_t kind, uint8_t src, uint8_t dst) {
   return fmt::format("Memcpy {} ({} -> {})",
                      memcpyKindString((CUpti_ActivityMemcpyKind)kind),
@@ -583,6 +698,21 @@ inline const std::string GpuActivity<CUpti_ActivityMemcpyType>::metadataJson() c
 }
 
 template <>
+inline TypedMetadata GpuActivity<CUpti_ActivityMemcpyType>::typedMetadata() const {
+  const CUpti_ActivityMemcpyType& memcpy = raw();
+  TypedMetadata metadata;
+  metadata.set(CudaMetadataFields::kDevice, static_cast<int64_t>(memcpy.deviceId));
+  metadata.set(CudaMetadataFields::kContext, static_cast<int64_t>(memcpy.contextId));
+  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(memcpy.streamId));
+  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(memcpy.correlationId));
+  metadata.set(CudaMetadataFields::kBytes, static_cast<int64_t>(memcpy.bytes));
+  addBandwidthTypedMetadata(metadata, memcpy.bytes, duration());
+  addGraphNodeTypedMetadata(metadata, memcpy);
+  addChannelTypedMetadata(metadata, memcpy);
+  return metadata;
+}
+
+template <>
 inline ActivityType GpuActivity<CUpti_ActivityMemcpyPtoPType>::type() const {
   return ActivityType::GPU_MEMCPY;
 }
@@ -608,6 +738,25 @@ inline const std::string GpuActivity<CUpti_ActivityMemcpyPtoPType>::metadataJson
       getGraphNodeMetadata(memcpy),
       getChannelMetadata(memcpy));
   // clang-format on
+}
+
+template <>
+inline TypedMetadata GpuActivity<CUpti_ActivityMemcpyPtoPType>::typedMetadata() const {
+  const CUpti_ActivityMemcpyPtoPType& memcpy = raw();
+  TypedMetadata metadata;
+  metadata.set(CudaMetadataFields::kFromDevice, static_cast<int64_t>(memcpy.srcDeviceId));
+  metadata.set(CudaMetadataFields::kInDevice, static_cast<int64_t>(memcpy.deviceId));
+  metadata.set(CudaMetadataFields::kToDevice, static_cast<int64_t>(memcpy.dstDeviceId));
+  metadata.set(CudaMetadataFields::kFromContext, static_cast<int64_t>(memcpy.srcContextId));
+  metadata.set(CudaMetadataFields::kInContext, static_cast<int64_t>(memcpy.contextId));
+  metadata.set(CudaMetadataFields::kToContext, static_cast<int64_t>(memcpy.dstContextId));
+  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(memcpy.streamId));
+  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(memcpy.correlationId));
+  metadata.set(CudaMetadataFields::kBytes, static_cast<int64_t>(memcpy.bytes));
+  addBandwidthTypedMetadata(metadata, memcpy.bytes, duration());
+  addGraphNodeTypedMetadata(metadata, memcpy);
+  addChannelTypedMetadata(metadata, memcpy);
+  return metadata;
 }
 
 template <>
@@ -637,6 +786,21 @@ inline const std::string GpuActivity<CUpti_ActivityMemsetType>::metadataJson() c
   // clang-format on
 }
 
+template <>
+inline TypedMetadata GpuActivity<CUpti_ActivityMemsetType>::typedMetadata() const {
+  const CUpti_ActivityMemsetType& memset = raw();
+  TypedMetadata metadata;
+  metadata.set(CudaMetadataFields::kDevice, static_cast<int64_t>(memset.deviceId));
+  metadata.set(CudaMetadataFields::kContext, static_cast<int64_t>(memset.contextId));
+  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(memset.streamId));
+  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(memset.correlationId));
+  metadata.set(CudaMetadataFields::kBytes, static_cast<int64_t>(memset.bytes));
+  addBandwidthTypedMetadata(metadata, memset.bytes, duration());
+  addGraphNodeTypedMetadata(metadata, memset);
+  addChannelTypedMetadata(metadata, memset);
+  return metadata;
+}
+
 inline void RuntimeActivity::log(ActivityLogger& logger) const {
   logger.handleActivity(*this);
 }
@@ -657,6 +821,10 @@ inline const std::string OverheadActivity::metadataJson() const {
   return "";
 }
 
+inline TypedMetadata OverheadActivity::typedMetadata() const {
+  return {};
+}
+
 inline bool RuntimeActivity::flowStart() const {
   return CuptiCbidRegistry::instance().requiresFlowCorrelation(CallbackDomain::RUNTIME, activity_.cbid);
 }
@@ -667,6 +835,13 @@ inline const std::string RuntimeActivity::metadataJson() const {
       "cbid": {}, "correlation": {})JSON",
       activity_.cbid,
       activity_.correlationId);
+}
+
+inline TypedMetadata RuntimeActivity::typedMetadata() const {
+  TypedMetadata metadata;
+  metadata.set(CudaMetadataFields::kCbid, static_cast<int64_t>(activity_.cbid));
+  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(activity_.correlationId));
+  return metadata;
 }
 
 inline bool isTrackedDriverCbid(const CUpti_ActivityAPI& activity_) {
@@ -685,6 +860,13 @@ inline const std::string DriverActivity::metadataJson() const {
       activity_.correlationId);
 }
 
+inline TypedMetadata DriverActivity::typedMetadata() const {
+  TypedMetadata metadata;
+  metadata.set(CudaMetadataFields::kCbid, static_cast<int64_t>(activity_.cbid));
+  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(activity_.correlationId));
+  return metadata;
+}
+
 inline const std::string DriverActivity::name() const {
   return driverCbidName(activity_.cbid);
 }
@@ -692,6 +874,11 @@ inline const std::string DriverActivity::name() const {
 template <class T>
 inline const std::string GpuActivity<T>::metadataJson() const {
   return "";
+}
+
+template <class T>
+inline TypedMetadata GpuActivity<T>::typedMetadata() const {
+  return {};
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -31,6 +31,7 @@
 #include "include/time_since_epoch.h"
 #include "src/ActivityTrace.h"
 #include "src/ApproximateClock.h"
+#include "src/CudaMetadataFields.h"
 #include "src/CuptiActivityApi.h"
 #include "src/CuptiActivityProfiler.h"
 #include "src/output_json.h"
@@ -590,6 +591,16 @@ TEST_F(CuptiActivityProfilerTest, SyncEventCorrIdOutOfOrder) {
           << "Stream Wait Event corr_id should be populated despite out-of-order records";
       EXPECT_EQ(json["wait_on_stream"], kEventStreamId)
           << "Stream Wait Event should reference stream the event was recorded on";
+      const auto typedMetadata = activity->typedMetadata();
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventId),
+          static_cast<int64_t>(kEventId));
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventRecordCorrId),
+          static_cast<int64_t>(kRecordCorrId));
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnStream),
+          static_cast<int64_t>(kEventStreamId));
       streamWaitFound++;
     }
     if (metadata.find("Event Sync") != std::string::npos) {
@@ -600,6 +611,16 @@ TEST_F(CuptiActivityProfilerTest, SyncEventCorrIdOutOfOrder) {
           << "Event Sync corr_id should be populated despite out-of-order records";
       EXPECT_EQ(json["wait_on_stream"], kEventStreamId)
           << "Event Sync should reference stream the event was recorded on";
+      const auto typedMetadata = activity->typedMetadata();
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventId),
+          static_cast<int64_t>(kEventId));
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventRecordCorrId),
+          static_cast<int64_t>(kRecordCorrId));
+      EXPECT_EQ(
+          typedMetadata.get(CudaMetadataFields::kWaitOnStream),
+          static_cast<int64_t>(kEventStreamId));
       eventSyncFound++;
     }
   }


### PR DESCRIPTION
Summary:

Adds typed metadata producers for every CUPTI activity wrapper in `CuptiActivity.h`

Reviewed By: scotts

Differential Revision: D107561258


