### PR TITLE
Move around methods so they are accurately described by the comments

### DIFF
--- a/libkineto/include/ActivityProfilerInterface.h
+++ b/libkineto/include/ActivityProfilerInterface.h
@@ -44,6 +44,10 @@ class ActivityProfilerInterface {
   // Tracing terminates when either condition is met.
   virtual void scheduleTrace([[maybe_unused]] const std::string& configStr) {}
 
+  // Re-evaluate internal state to allow for triggering operations based
+  // on number of iteration. each implicitly increments the iteration count
+  virtual void step() {}
+
   // *** Synchronous API ***
   // These must be called in order:
   // prepareTrace -> startTrace -> stopTrace.
@@ -68,10 +72,6 @@ class ActivityProfilerInterface {
   virtual std::unique_ptr<ActivityTraceInterface> stopTrace() {
     return nullptr;
   }
-
-  // Re-evaluate internal state to allow for triggering operations based
-  // on number of iteration. each implicitly increments the iteration count
-  virtual void step() {}
 
   // *** TraceActivity API ***
   // FIXME: Pass activityProfiler interface into clientInterface?

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -52,12 +52,12 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   bool canAcceptConfig() override;
   void acceptConfig(const Config& config) override;
   void scheduleTrace(const Config& config);
+  void step();
 
   // These API are used for Synchronous Tracing.
   void prepareTrace(const Config& config);
   void toggleCollectionDynamic(const bool enable);
   void startTrace();
-  void step();
   std::unique_ptr<ActivityTraceInterface> stopTrace();
 
   bool isActive();

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -31,6 +31,15 @@ void ActivityProfilerProxy::init() {
   }
 }
 
+bool ActivityProfilerProxy::isActive() {
+  return controller_->isActive();
+}
+
+bool ActivityProfilerProxy::isStopped() const {
+  return controller_->isStopped();
+}
+
+// Async/on-demand tracing functions.
 void ActivityProfilerProxy::scheduleTrace(const std::string& configStr) {
   resetTLS();
   Config config;
@@ -42,6 +51,11 @@ void ActivityProfilerProxy::scheduleTrace(const Config& config) {
   controller_->scheduleTrace(config);
 }
 
+void ActivityProfilerProxy::step() {
+  controller_->step();
+}
+
+// Sync/auto-trace tracing functions.
 void ActivityProfilerProxy::prepareTrace(
     const std::set<ActivityType>& activityTypes,
     const std::string& configStr) {
@@ -84,18 +98,7 @@ std::unique_ptr<ActivityTraceInterface> ActivityProfilerProxy::stopTrace() {
   return controller_->stopTrace();
 }
 
-void ActivityProfilerProxy::step() {
-  controller_->step();
-}
-
-bool ActivityProfilerProxy::isActive() {
-  return controller_->isActive();
-}
-
-bool ActivityProfilerProxy::isStopped() const {
-  return controller_->isStopped();
-}
-
+// TraceActivity API.
 void ActivityProfilerProxy::pushCorrelationId(uint64_t id) {
   controller_->pushCorrelationId(id);
 }

--- a/libkineto/src/ActivityProfilerProxy.h
+++ b/libkineto/src/ActivityProfilerProxy.h
@@ -47,19 +47,20 @@ class ActivityProfilerProxy : public ActivityProfilerInterface {
   bool isActive() override;
   bool isStopped() const override;
 
-  void recordThreadInfo() override;
-
+  // These API are used for async/on-demand tracing.
   void scheduleTrace(const std::string& configStr) override;
   void scheduleTrace(const Config& config);
+  void step() override;
 
+  // These API are used for sync/auto-trace tracing.
   void prepareTrace(const std::set<ActivityType>& activityTypes, const std::string& configStr = "") override;
 
   void toggleCollectionDynamic(const bool enable) override;
 
   void startTrace() override;
-  void step() override;
   std::unique_ptr<ActivityTraceInterface> stopTrace() override;
 
+  // TraceActivity API.
   void pushCorrelationId(uint64_t id) override;
   void popCorrelationId() override;
 
@@ -67,6 +68,8 @@ class ActivityProfilerProxy : public ActivityProfilerInterface {
   void popUserCorrelationId() override;
 
   void transferCpuTrace(std::unique_ptr<CpuTraceBuffer> traceBuffer) override;
+
+  void recordThreadInfo() override;
 
   void addMetadata(const std::string& key, const std::string& value) override;
 


### PR DESCRIPTION
Summary: Move methods around (in the same file) so they are properly explained by the comments above them.

Differential Revision: D108311226


