### PR TITLE
Prefix internal controller sync/async methods (#1438)

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -210,19 +210,19 @@ void ActivityProfilerController::acceptConfig(const Config& config) {
   }
   asyncHandler_->acceptConfig(config);
 }
-void ActivityProfilerController::scheduleTrace(const Config& config) {
+void ActivityProfilerController::asyncScheduleTrace(const Config& config) {
   if (isActive()) {
     logRequestCancellation(config, "Ignored request - profiler busy");
     return;
   }
   asyncHandler_->scheduleTrace(config);
 }
-void ActivityProfilerController::step() {
+void ActivityProfilerController::asyncStep() {
   asyncHandler_->step();
 }
 
 // Sync-only functions
-void ActivityProfilerController::prepareTrace(const Config& config) {
+void ActivityProfilerController::syncPrepareTrace(const Config& config) {
   // Sync-trace requests preempt any active trace.
   asyncHandler_->cancel();
   if (syncHandler_->isSyncActive()) {
@@ -231,14 +231,15 @@ void ActivityProfilerController::prepareTrace(const Config& config) {
 
   syncHandler_->prepareTrace(config);
 }
-void ActivityProfilerController::toggleCollectionDynamic(const bool enable) {
+void ActivityProfilerController::syncToggleCollectionDynamic(
+    const bool enable) {
   syncHandler_->toggleCollectionDynamic(enable);
 }
-void ActivityProfilerController::startTrace() {
+void ActivityProfilerController::syncStartTrace() {
   syncHandler_->startTrace();
 }
 std::unique_ptr<ActivityTraceInterface> ActivityProfilerController::
-    stopTrace() {
+    syncStopTrace() {
   return syncHandler_->stopTrace();
 }
 

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -48,17 +48,19 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   static void setInvariantViolationsLoggerFactory(
       const std::function<std::unique_ptr<InvariantViolationsLogger>()>& factory);
 
-  // These API are used for On-Demand Tracing.
+  // ConfigLoader::ConfigHandler callback API.
   bool canAcceptConfig() override;
   void acceptConfig(const Config& config) override;
-  void scheduleTrace(const Config& config);
-  void step();
+
+  // These API are used for On-Demand Tracing.
+  void asyncScheduleTrace(const Config& config);
+  void asyncStep();
 
   // These API are used for Synchronous Tracing.
-  void prepareTrace(const Config& config);
-  void toggleCollectionDynamic(const bool enable);
-  void startTrace();
-  std::unique_ptr<ActivityTraceInterface> stopTrace();
+  void syncPrepareTrace(const Config& config);
+  void syncToggleCollectionDynamic(const bool enable);
+  void syncStartTrace();
+  std::unique_ptr<ActivityTraceInterface> syncStopTrace();
 
   bool isActive();
   bool isStopped() const;

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -44,15 +44,15 @@ void ActivityProfilerProxy::scheduleTrace(const std::string& configStr) {
   resetTLS();
   Config config;
   config.parse(configStr);
-  controller_->scheduleTrace(config);
+  controller_->asyncScheduleTrace(config);
 }
 
 void ActivityProfilerProxy::scheduleTrace(const Config& config) {
-  controller_->scheduleTrace(config);
+  controller_->asyncScheduleTrace(config);
 }
 
 void ActivityProfilerProxy::step() {
-  controller_->step();
+  controller_->asyncStep();
 }
 
 // Sync/auto-trace tracing functions.
@@ -83,19 +83,19 @@ void ActivityProfilerProxy::prepareTrace(
     config.validate(std::chrono::system_clock::now());
   }
 
-  controller_->prepareTrace(config);
+  controller_->syncPrepareTrace(config);
 }
 
 void ActivityProfilerProxy::toggleCollectionDynamic(const bool enable) {
-  controller_->toggleCollectionDynamic(enable);
+  controller_->syncToggleCollectionDynamic(enable);
 }
 
 void ActivityProfilerProxy::startTrace() {
-  controller_->startTrace();
+  controller_->syncStartTrace();
 }
 
 std::unique_ptr<ActivityTraceInterface> ActivityProfilerProxy::stopTrace() {
-  return controller_->stopTrace();
+  return controller_->syncStopTrace();
 }
 
 // TraceActivity API.

--- a/libkineto/test/ActivityProfilerControllerTest.cpp
+++ b/libkineto/test/ActivityProfilerControllerTest.cpp
@@ -61,9 +61,9 @@ TEST(ActivityProfilerController, PrepareTraceClearsPendingAsyncRequest) {
           filename));
   ASSERT_TRUE(success);
 
-  // Start an async request via scheduleTrace -- populate asyncRequestConfig_
+  // Start an async request via acceptConfig -- populate asyncRequestConfig_
   ActivityProfilerController controller(ConfigLoader::instance(), true);
-  controller.step();
+  controller.asyncStep();
   controller.acceptConfig(asyncCfg);
   EXPECT_FALSE(controller.isActive());
 
@@ -71,19 +71,19 @@ TEST(ActivityProfilerController, PrepareTraceClearsPendingAsyncRequest) {
   Config syncCfg;
   syncCfg.setClientDefaults();
   syncCfg.validate(system_clock::now());
-  controller.prepareTrace(syncCfg);
+  controller.syncPrepareTrace(syncCfg);
   EXPECT_TRUE(controller.isActive());
 
-  controller.startTrace();
+  controller.syncStartTrace();
 
   // When the sync trace stops, the async request should be completely inactive
-  auto trace = controller.stopTrace();
+  auto trace = controller.syncStopTrace();
   EXPECT_NE(trace, nullptr);
   EXPECT_FALSE(controller.isActive());
 
-  // Use .step() being no-op as a proxy to validate that async was cancelled
+  // Use asyncStep() being no-op as a proxy to validate that async was cancelled
   for (int i = 0; i < 10; ++i) {
-    controller.step();
+    controller.asyncStep();
     EXPECT_FALSE(controller.isActive());
   }
 
@@ -108,14 +108,14 @@ TEST(ActivityProfilerController, IgnoreAsyncRequestsWhileSyncTraceIsActive) {
   ASSERT_TRUE(success);
 
   ActivityProfilerController controller(ConfigLoader::instance(), true);
-  controller.step();
+  controller.asyncStep();
 
   Config syncCfg;
   syncCfg.setClientDefaults();
   syncCfg.validate(system_clock::now());
 
   // Start a sync trace
-  controller.prepareTrace(syncCfg);
+  controller.syncPrepareTrace(syncCfg);
   EXPECT_TRUE(controller.isActive());
   EXPECT_FALSE(controller.canAcceptConfig());
 
@@ -124,16 +124,16 @@ TEST(ActivityProfilerController, IgnoreAsyncRequestsWhileSyncTraceIsActive) {
   controller.acceptConfig(asyncCfg);
   EXPECT_TRUE(controller.isActive());
 
-  controller.startTrace();
-  auto trace = controller.stopTrace();
+  controller.syncStartTrace();
+  auto trace = controller.syncStopTrace();
   EXPECT_NE(trace, nullptr);
   EXPECT_FALSE(controller.isActive());
 
   // After sync runs to completion, check that the async request was not
   // accepted.
-  // Use .step() being no-op as a proxy to validate that async was cancelled
+  // Use asyncStep() being no-op as a proxy to validate that async was cancelled
   for (int i = 0; i < 10; ++i) {
-    controller.step();
+    controller.asyncStep();
     EXPECT_FALSE(controller.isActive());
   }
 
@@ -158,32 +158,32 @@ TEST(ActivityProfilerController, PrepareTracePreemptsActiveAsyncRequest) {
   ASSERT_TRUE(success);
 
   ActivityProfilerController controller(ConfigLoader::instance(), true);
-  controller.step();
+  controller.asyncStep();
 
   // Start an async request, step until it's active
   controller.acceptConfig(asyncCfg);
   EXPECT_FALSE(controller.isActive());
-  controller.step();
+  controller.asyncStep();
   EXPECT_FALSE(controller.isActive());
-  controller.step();
+  controller.asyncStep();
   EXPECT_TRUE(controller.isActive());
-  controller.step();
+  controller.asyncStep();
   EXPECT_TRUE(controller.isActive());
 
   // Start a sync trace, which should preempt the async request
   Config syncCfg;
   syncCfg.setClientDefaults();
   syncCfg.validate(system_clock::now());
-  controller.prepareTrace(syncCfg);
+  controller.syncPrepareTrace(syncCfg);
   EXPECT_TRUE(controller.isActive());
-  controller.startTrace();
-  auto trace = controller.stopTrace();
+  controller.syncStartTrace();
+  auto trace = controller.syncStopTrace();
   EXPECT_NE(trace, nullptr);
   EXPECT_FALSE(controller.isActive());
 
-  // Use .step() being no-op as a proxy to validate that async was cancelled
+  // Use asyncStep() being no-op as a proxy to validate that async was cancelled
   for (int i = 0; i < 10; ++i) {
-    controller.step();
+    controller.asyncStep();
     EXPECT_FALSE(controller.isActive());
   }
 


### PR DESCRIPTION
Summary:

Strightforward diff to rename methods that could be confused with each other by prefixing them with sync or async.

This can not extend up to `ActivityProfilerInterface` because these method names are exposed there as part of Kineto's public API.

Differential Revision: D108749317


