### PR TITLE
Adds TypedMetadata.h to get_libkineto_public_headers

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -87,6 +87,7 @@ def get_libkineto_public_headers():
         "include/LoggingAPI.h",
         "include/TraceSpan.h",
         "include/ThreadUtil.h",
+        "include/TypedMetadata.h",
         "include/libkineto.h",
         "include/time_since_epoch.h",
         "include/output_base.h",


### PR DESCRIPTION
This change fixes the following error in bazel build:
```
In file included from third_party/libkineto/src/output_json.cpp:9:
In file included from ./third_party/libkineto/src/output_json.h:23:
In file included from ./third_party/libkineto/src/ActivityBuffers.h:14:
In file included from ./third_party/libkineto/src/CuptiActivityBuffer.h:19:
./third_party/libkineto/include/ITraceActivity.h:16:10: fatal error: 'TypedMetadata.h' file not found
   16 | #include "TypedMetadata.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```