### PR TITLE
Enrich MTIA hccl:: rows with collective metadata

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -652,9 +652,8 @@ void ChromeTraceLogger::handleCounterEvent(
       /*args=*/args);
 }
 
-void ChromeTraceLogger::appendNcclCollectiveMetadata(
+void ChromeTraceLogger::appendCollectiveArgs(
     ArgsBuilder& args,
-    [[maybe_unused]] const ITraceActivity& gpuOp,
     const ITraceActivity& collectiveRecord) {
   const auto& collectiveName =
       collectiveRecord.getMetadataValue(std::string(kCollectiveName));
@@ -733,6 +732,22 @@ void ChromeTraceLogger::appendNcclCollectiveMetadata(
   if (!commsId.empty()) {
     args.addRaw(kCommsId, commsId);
   }
+}
+
+void ChromeTraceLogger::appendNcclCollectiveMetadata(
+    ArgsBuilder& args,
+    [[maybe_unused]] const ITraceActivity& gpuOp,
+    const ITraceActivity& collectiveRecord) {
+  appendCollectiveArgs(args, collectiveRecord);
+
+  const auto& groupSize =
+      collectiveRecord.getMetadataValue(std::string(kGroupSize));
+  const auto& processGroupName =
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupName));
+  const auto& processGroupDesc =
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupDesc));
+  const auto& groupRanks =
+      collectiveRecord.getMetadataValue(std::string(kGroupRanks));
 
   if (distInfo_.backend.empty() && processGroupDesc == "\"default_pg\"") {
     distInfo_.backend = "nccl";
@@ -745,6 +760,40 @@ void ChromeTraceLogger::appendNcclCollectiveMetadata(
   pg_config.pg_name = processGroupName;
   pg_config.pg_desc = processGroupDesc;
   pg_config.backend_config = "cuda:nccl";
+  pg_config.pg_size = groupSize;
+  pg_config.ranks = groupRanks;
+  pgMap_.insert({processGroupName, pg_config});
+}
+
+void ChromeTraceLogger::appendMtiaCollectiveMetadata(
+    ArgsBuilder& args,
+    const ITraceActivity& collectiveRecord) {
+  // Reuse the exact NCCL arg shape so HTA/Durin consume MTIA hccl:: rows like
+  // NCCL collectives (seq, pg, dtype, msg sizes).
+  appendCollectiveArgs(args, collectiveRecord);
+
+  const auto& groupSize =
+      collectiveRecord.getMetadataValue(std::string(kGroupSize));
+  const auto& processGroupName =
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupName));
+  const auto& processGroupDesc =
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupDesc));
+  const auto& groupRanks =
+      collectiveRecord.getMetadataValue(std::string(kGroupRanks));
+
+  if (distInfo_.backend.empty() && processGroupDesc == "\"default_pg\"") {
+    distInfo_.backend = "hccl";
+    distInfo_.rank = collectiveRecord.getMetadataValue(std::string(kRank));
+    distInfo_.world_size = groupSize;
+    // Intentionally no version: DistributedInfo carries only nccl_version and
+    // there is no HCCL version source here, so leave it empty rather than
+    // mislabel MTIA traffic as NCCL.
+  }
+
+  auto pg_config = pgConfig();
+  pg_config.pg_name = processGroupName;
+  pg_config.pg_desc = processGroupDesc;
+  pg_config.backend_config = "mtia:hccl";
   pg_config.pg_size = groupSize;
   pg_config.ranks = groupRanks;
   pgMap_.insert({processGroupName, pg_config});
@@ -810,10 +859,22 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
   sanitizeStrForJSON(op_metadata);
   args.appendFragment(op_metadata);
 
-  // Populate NCCL collective metadata from CPU to GPU
-  if (op.type() == ActivityType::CONCURRENT_KERNEL && op.linkedActivity() &&
-      op.linkedActivity()->name() == kParamCommsCallName) {
-    appendNcclCollectiveMetadata(args, op, *op.linkedActivity());
+  // Populate collective metadata from the linked record_param_comms CPU op.
+  // CUDA kernels take the NCCL path. MTIA reuses the same arg shape via the
+  // HCCL path (MTIA backend labels, no version), but only for parent hccl::
+  // collective rows: the generic MTIA linkedActivity mechanism links every
+  // device-correlated activity (DMA, runFunction, event wait/record, ...) to
+  // its launching CPU op, so a non-collective MTIA row that happens to launch
+  // under the collective CPU scope must not be mislabeled as a collective.
+  const auto* linkedOp = op.linkedActivity();
+  if (linkedOp != nullptr && linkedOp->name() == kParamCommsCallName) {
+    if (op.type() == ActivityType::CONCURRENT_KERNEL) {
+      appendNcclCollectiveMetadata(args, op, *linkedOp);
+    } else if (
+        op.type() == ActivityType::MTIA_CCP_EVENTS &&
+        op.name().starts_with("hccl::")) {
+      appendMtiaCollectiveMetadata(args, *linkedOp);
+    }
   }
 
   int64_t device = op.deviceId();

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -192,9 +192,20 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
                       std::string_view cat,
                       std::string_view name);
 
+  // Shared arg-copy: writes the NCCL-shaped collective args (seq, pg, dtype,
+  // msg sizes, ...) read from the linked record_param_comms op into args.
+  // Backend-agnostic -- reused by both the NCCL and MTIA/HCCL paths.
+  void appendCollectiveArgs(ArgsBuilder& args, const ITraceActivity& collectiveRecord);
+
   void appendNcclCollectiveMetadata(ArgsBuilder& args,
                                     const ITraceActivity& gpuOp,
                                     const ITraceActivity& collectiveRecord);
+
+  // MTIA/HCCL counterpart of appendNcclCollectiveMetadata: same arg shape via
+  // appendCollectiveArgs, but with MTIA backend labels and no version field
+  // (the schema carries only nccl_version, and there is no HCCL version source
+  // on this path).
+  void appendMtiaCollectiveMetadata(ArgsBuilder& args, const ITraceActivity& collectiveRecord);
 
   std::string fileName_;
   std::string tempFileName_;


### PR DESCRIPTION
Summary:
MTIA collective rows (`hccl::*`) in Kineto's Chrome-JSON output didn't carry the collective metadata that GPU NCCL rows do -- sequence number, process group, dtype, message sizes -- so HTA and Durin couldn't analyze MTIA collectives the way they analyze GPU ones.

This teaches the JSON exporter to attach that same metadata to MTIA collective rows, reusing the existing NCCL collective-metadata path so the two stay consistent. A device row recognized as an MTIA collective is enriched with the args of the `record_param_comms` op that launched it (the link established earlier in this stack) and labeled with the MTIA/HCCL backend. The CUDA NCCL path is unchanged, and only true collective rows are enriched -- ordinary MTIA rows and the visual-only execution children are left alone.

Differential Revision: D108807190


