### PR TITLE
[xpupti] Enable OVERHEAD activity

### DIFF
--- a/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
@@ -306,9 +306,9 @@ namespace {
 // overheadKindString() (see cupti_strings.cpp), so XPU and CUDA traces use the
 // same vocabulary. PTI's own ptiViewOverheadKindToString() returns raw enum
 // spellings (e.g. "BUFFER_FLUSH", "BUFFER_TIME") which do not match CUDA.
-// PTI_VIEW_OVERHEAD_KIND_TIME aggregates the time PTI spends inside the Level
-// Zero calls it injects to instrument the workload, which is the same notion as
-// CUPTI's "Instrumentation" overhead.
+// PTI_VIEW_OVERHEAD_KIND_TIME aggregates the time PTI spends inside
+// the Level Zero calls it injects to instrument the workload,
+// which is the same notion as CUPTI's "Instrumentation" overhead.
 const char* overheadKindString(pti_view_overhead_kind kind) {
   switch (kind) {
     case PTI_VIEW_OVERHEAD_KIND_UNKNOWN:
@@ -342,9 +342,13 @@ void XpuptiActivityProfilerSession::handleOverheadActivity(
   overhead_activity->threadId = activity->_overhead_thread_id;
   overhead_activity->addMetadata(
       "overhead cost", activity->_overhead_duration_ns);
-  // Guard against division by zero as PTI may emit point-like
-  // overhead records (start == end).
-  const auto occupancy = activity->_overhead_duration_ns > 0
+  // Occupancy is the share of the observation window [start, end] that was
+  // actually spent in overhead: _overhead_duration_ns is cumulative and may be
+  // smaller than the window. Guard on the divisor (duration()) directly so the
+  // check holds regardless of PTI's start/end/duration relationship -- PTI may
+  // emit point-like records (start == end), e.g. on platforms with a coarse
+  // clock.
+  const auto occupancy = overhead_activity->duration() > 0
       ? activity->_overhead_duration_ns * 100 / overhead_activity->duration()
       : 0;
   overhead_activity->addMetadataQuoted(

--- a/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
@@ -301,13 +301,39 @@ void XpuptiActivityProfilerSession::handleRuntimeKernelMemcpyMemsetActivities(
   trace_activity->log(logger);
 }
 
+namespace {
+// Map a PTI overhead kind to a human-readable name aligned with CUPTI's
+// overheadKindString() (see cupti_strings.cpp), so XPU and CUDA traces use the
+// same vocabulary. PTI's own ptiViewOverheadKindToString() returns raw enum
+// spellings (e.g. "BUFFER_FLUSH", "BUFFER_TIME") which do not match CUDA.
+// PTI_VIEW_OVERHEAD_KIND_TIME aggregates the time PTI spends inside the Level
+// Zero calls it injects to instrument the workload, which is the same notion as
+// CUPTI's "Instrumentation" overhead.
+const char* overheadKindString(pti_view_overhead_kind kind) {
+  switch (kind) {
+    case PTI_VIEW_OVERHEAD_KIND_UNKNOWN:
+      return "Unknown";
+    case PTI_VIEW_OVERHEAD_KIND_RESOURCE:
+      return "Resource";
+    case PTI_VIEW_OVERHEAD_KIND_BUFFER_FLUSH:
+      return "Buffer Flush";
+    case PTI_VIEW_OVERHEAD_KIND_DRIVER:
+      return "Driver";
+    case PTI_VIEW_OVERHEAD_KIND_TIME:
+      return "Instrumentation";
+    default:
+      return "Unknown";
+  }
+}
+} // namespace
+
 void XpuptiActivityProfilerSession::handleOverheadActivity(
     const pti_view_record_overhead* activity,
     ActivityLogger& logger) {
   traceBuffer_.emplace_activity(
       traceBuffer_.span,
       ActivityType::OVERHEAD,
-      ptiViewOverheadKindToString(activity->_overhead_kind));
+      overheadKindString(activity->_overhead_kind));
   auto& overhead_activity = traceBuffer_.activities.back();
   overhead_activity->startTime = activity->_overhead_start_timestamp_ns;
   overhead_activity->endTime = activity->_overhead_end_timestamp_ns;
@@ -316,11 +342,14 @@ void XpuptiActivityProfilerSession::handleOverheadActivity(
   overhead_activity->threadId = activity->_overhead_thread_id;
   overhead_activity->addMetadata(
       "overhead cost", activity->_overhead_duration_ns);
+  // Guard against division by zero as PTI may emit point-like
+  // overhead records (start == end).
+  const auto occupancy = activity->_overhead_duration_ns > 0
+      ? activity->_overhead_duration_ns * 100 / overhead_activity->duration()
+      : 0;
   overhead_activity->addMetadataQuoted(
       "overhead occupancy",
-      fmt::format(
-          "{}%",
-          activity->_overhead_duration_ns / overhead_activity->duration()));
+      fmt::format("{}%", occupancy));
   overhead_activity->addMetadata("overhead count", activity->_overhead_count);
 
   if (!outOfRange(overhead_activity.get())) {

--- a/libkineto/test/xpupti/XpuptiProfilerTest.cpp
+++ b/libkineto/test/xpupti/XpuptiProfilerTest.cpp
@@ -12,6 +12,8 @@
 
 #include <gtest/gtest.h>
 
+#include <unordered_set>
+
 namespace KN = KINETO_NAMESPACE;
 
 TEST(XpuptiProfilerTest, XpuDriverEvents) {
@@ -47,6 +49,56 @@ TEST(XpuptiProfilerTest, XpuDriverEvents) {
       repeatCount,
       std::move(expectedActivities),
       std::move(expectedTypes));
+}
+
+TEST(XpuptiProfilerTest, OverheadActivity) {
+  KN::Config cfg;
+
+  std::vector<std::string_view> metrics;
+
+  // Profile a normal kernel workload alongside the OVERHEAD activity so that
+  // PTI has collection work to attribute overhead to.
+  std::set<KN::ActivityType> activities{
+      KN::ActivityType::CONCURRENT_KERNEL,
+      KN::ActivityType::OVERHEAD,
+  };
+
+  std::vector<std::string_view> expectedActivities = {
+      "Run(sycl::_V1::queue, ...)"};
+  std::vector<std::string_view> expectedTypes = {"kernel"};
+
+  constexpr unsigned repeatCount = 1;
+  auto [pSession, pBuffer] = RunProfilerTest(
+      metrics,
+      activities,
+      cfg,
+      repeatCount,
+      std::move(expectedActivities),
+      std::move(expectedTypes));
+
+  // Verify the shape of every overhead record the run produced.
+  static const std::unordered_set<std::string> kExpectedNames{
+      "Unknown", "Resource", "Buffer Flush", "Driver", "Instrumentation"};
+  for (auto&& pActivity : pBuffer->activities) {
+    if (pActivity->type() != KN::ActivityType::OVERHEAD) {
+      continue;
+    }
+
+    // Overhead is host-side, not attributed to a device.
+    EXPECT_EQ(pActivity->deviceId(), -1);
+
+    const std::string name = pActivity->name();
+    EXPECT_TRUE(kExpectedNames.count(name) == 1)
+        << "unexpected overhead name: " << name;
+
+    const auto metadata = pActivity->metadataJson();
+    EXPECT_NE(metadata.find("overhead cost"), std::string::npos)
+        << "metadata = " << metadata;
+    EXPECT_NE(metadata.find("overhead count"), std::string::npos)
+        << "metadata = " << metadata;
+    EXPECT_NE(metadata.find("overhead occupancy"), std::string::npos)
+        << "metadata = " << metadata;
+  }
 }
 
 TEST(XpuptiProfilerTest, TestEvents) {

--- a/libkineto/test/xpupti/XpuptiTestUtilities.cpp
+++ b/libkineto/test/xpupti/XpuptiTestUtilities.cpp
@@ -89,8 +89,11 @@ void CheckCountsInMap(
 
   EXPECT_EQ(countsMap.size(), expMap.size());
 
-  for (auto itCountsMap = countsMap.begin(), itExpArray = expMap.begin();
-       (itCountsMap != countsMap.end()) && (itExpArray != expMap.end());
+  // Declared separately: countsMap is non-const (iterator) while expMap is
+  // const (const_iterator), so a single `auto` cannot deduce both.
+  auto itCountsMap = countsMap.begin();
+  auto itExpArray = expMap.begin();
+  for (; (itCountsMap != countsMap.end()) && (itExpArray != expMap.end());
        ++itCountsMap, ++itExpArray) {
     EXPECT_EQ(itCountsMap->first, itExpArray->first * repeatCount);
     EXPECT_EQ(itCountsMap->second, itExpArray->second);
@@ -126,6 +129,26 @@ static unsigned acceptDriverActivities(
       auto insertResult = stringStorage.insert(pActivity->name());
       expectedActivities.push_back(*insertResult.first);
       expectedTypes.push_back(driverActivity);
+      ++count;
+    }
+  }
+  return count;
+}
+
+constexpr const std::string_view overheadActivity = "overhead";
+
+static unsigned acceptOverheadActivities(
+    const std::deque<std::unique_ptr<libkineto::GenericTraceActivity>>&
+        pBufferActivities,
+    std::vector<std::string_view>& expectedActivities,
+    std::vector<std::string_view>& expectedTypes,
+    std::set<std::string>& stringStorage) {
+  unsigned count = 0;
+  for (auto&& pActivity : pBufferActivities) {
+    if (pActivity->type() == KN::ActivityType::OVERHEAD) {
+      auto insertResult = stringStorage.insert(pActivity->name());
+      expectedActivities.push_back(*insertResult.first);
+      expectedTypes.push_back(overheadActivity);
       ++count;
     }
   }
@@ -183,8 +206,10 @@ RunProfilerTest(
                           .count();
   pSession->start();
 
+  // A 16x16 GEMM is enough to exercise every activity type while keeping the
+  // simulator-based CI runtime small.
   void ComputeOnXpu(unsigned size, unsigned repeatCount);
-  ComputeOnXpu(1024, repeatCount);
+  ComputeOnXpu(16, repeatCount);
 
   pSession->stop();
   int64_t endTime = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -207,6 +232,11 @@ RunProfilerTest(
   if (activities.find(KN::ActivityType::XPU_DRIVER) != activities.end()) {
     EXPECT_EQ(repeatCount, 1);
     auto count = acceptDriverActivities(
+        pBuffer->activities, expectedActivities, expectedTypes, stringStorage);
+    EXPECT_GT(count, 0);
+  }
+  if (activities.find(KN::ActivityType::OVERHEAD) != activities.end()) {
+    auto count = acceptOverheadActivities(
         pBuffer->activities, expectedActivities, expectedTypes, stringStorage);
     EXPECT_GT(count, 0);
   }


### PR DESCRIPTION
The xpupti plugin already wires PTI_VIEW_COLLECTION_OVERHEAD through handleOverheadActivity(), but two issues remained:

- The overhead kind name came straight from PTI's ptiViewOverheadKindToString(), whose spelling does not match the vocabulary the CUDA/CUPTI backend uses. Add a local overheadKindString() that maps PTI kinds to CUPTI spelling (Resource, Buffer Flush, Driver, Unknown) so XPU and CUDA traces are consistent. PTI_VIEW_OVERHEAD_KIND_TIME (the only kind PTI currently emits) aggregates the cost of the Level Zero calls PTI injects to instrument the workload, which matches CUPTI's "Instrumentation" overhead.

- "overhead occupancy" divided by duration() without guarding against a zero-length span; PTI can emit point-like records (start == end). Compute the percentage only when there is a non-zero overhead duration.

Add a unit test (XpuptiProfilerTest.OverheadActivity) that profiles a tiny GEMM with the OVERHEAD activity enabled and asserts the shape of the emitted records (host-side deviceId == -1, CUPTI-style name, overhead cost/count/occupancy metadata). Overhead records are folded into RunProfilerTest's activity-count check via acceptOverheadActivities(), mirroring the existing driver-activity handling, and the run is expected to produce at least one.