### PR TITLE
Finalize pending trace on async profiler teardown

### DIFF
--- a/libkineto/src/AsyncActivityProfilerHandler.cpp
+++ b/libkineto/src/AsyncActivityProfilerHandler.cpp
@@ -9,6 +9,7 @@
 #include "AsyncActivityProfilerHandler.h"
 
 #include <chrono>
+#include <exception>
 #include <string>
 
 #include "ActivityProfilerController.h"
@@ -240,7 +241,31 @@ void AsyncActivityProfilerHandler::profilerLoop() {
     }
   }
 
+  // On teardown the destructor sets stopRunloop_ and joins this thread; if
+  // collection reached ProcessTrace, finalize the pending trace before logger_
+  // is destroyed.
+  if (currentRunloopState_ == RunloopState::ProcessTrace) {
+    try {
+      completePendingTrace();
+    } catch (const std::exception& e) {
+      LOG(ERROR)
+          << "Failed to finalize pending trace on profiler loop teardown: "
+          << e.what();
+    } catch (...) {
+      LOG(ERROR)
+          << "Failed to finalize pending trace on profiler loop teardown: "
+          << "unknown exception";
+    }
+  }
+
   VLOG(0) << "Exited activity profiling loop";
+}
+
+void AsyncActivityProfilerHandler::completePendingTrace() {
+  ensureCollectTraceDone();
+  profiler_.completeTrace(*logger_);
+  currentRunloopState_ = RunloopState::WaitForRequest;
+  VLOG(0) << "ProcessTrace -> WaitForRequest";
 }
 
 void AsyncActivityProfilerHandler::memoryProfilerLoop() {
@@ -413,14 +438,9 @@ time_point<system_clock> AsyncActivityProfilerHandler::performRunLoopStep(
         return new_wakeup_time;
       }
 
-      // Before processing, we should wait for collectTrace thread to be done.
-      ensureCollectTraceDone();
-
       // FIXME: Probably want to allow interruption here
       // for quickly handling trace request via synchronous API
-      profiler_.completeTrace(*logger_);
-      currentRunloopState_ = RunloopState::WaitForRequest;
-      VLOG(0) << "ProcessTrace -> WaitForRequest";
+      completePendingTrace();
       break;
     }
   }

--- a/libkineto/src/AsyncActivityProfilerHandler.h
+++ b/libkineto/src/AsyncActivityProfilerHandler.h
@@ -70,6 +70,7 @@ class AsyncActivityProfilerHandler {
   bool shouldActivateTimestampConfig(const std::chrono::time_point<std::chrono::system_clock>& now);
   void profilerLoop();
   void memoryProfilerLoop();
+  void completePendingTrace();
   void activateConfig(std::chrono::time_point<std::chrono::system_clock> now);
 
   std::unique_ptr<Config> asyncRequestConfig_;

--- a/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
+++ b/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
@@ -365,6 +365,54 @@ TEST(AsyncActivityProfilerHandler, Cancel) {
   EXPECT_FALSE(handler.isAsyncActive());
 }
 
+TEST(AsyncActivityProfilerHandler, FinalizesPendingTraceOnTeardown) {
+  // Destroying a scheduled handler with a collected-but-unprocessed trace must
+  // let the profiler loop finalize it, not drop it.
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+
+  char filename[] = "/tmp/libkineto_testXXXXXX.json";
+  createTempTraceFile(filename);
+
+  Config cfg;
+
+  bool success = cfg.parse(
+      fmt::format(
+          R"CFG(
+    PROFILE_START_ITERATION = 1
+    ACTIVITIES_WARMUP_ITERATIONS = 0
+    ACTIVITIES_ITERATIONS = 1
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+          filename));
+  EXPECT_TRUE(success);
+
+  {
+    AsyncActivityProfilerHandler handler(profiler);
+    handler.step();
+    EXPECT_FALSE(handler.isAsyncActive());
+
+    handler.scheduleTrace(cfg);
+
+    // Activate the scheduled config and enter CollectTrace.
+    handler.step();
+    EXPECT_TRUE(handler.isAsyncActive());
+
+    // CollectTrace -> ProcessTrace asynchronously. Application step()
+    // deliberately does not finalize ProcessTrace; the loop thread should do
+    // that while exiting.
+    handler.step();
+    handler.ensureCollectTraceDone();
+    EXPECT_TRUE(handler.isAsyncActive());
+
+    // handler goes out of scope here with a collected trace still pending.
+  }
+
+  // The pending trace must have been finalized during teardown.
+  auto logFile = logUrlToPath(cfg.activitiesLogUrl());
+  checkTracefile(logFile.c_str());
+}
+
 TEST(AsyncActivityProfilerHandler, BufferSizeLimitDuringWarmup) {
   MockGpuProfiler profiler;
   AsyncActivityProfilerHandler handler(profiler);


### PR DESCRIPTION
Summary: On-demand activity profiling can silently drop a trace when the profiled process exits right after the collection window. `AsyncActivityProfilerHandler` completes collection in one run-loop tick (`RunloopState::CollectTrace` -> sets `ProcessTrace`) but defers post-processing and trace upload to a *later* tick (`ProcessTrace` -> `completeTrace`). If the process tears down in between, `~AsyncActivityProfilerHandler()` joins the loop thread without ever driving that tick, so the trace is never processed or uploaded and no error is logged.

Differential Revision: D108982576


