### PR TITLE
Guard GenericActivityProfiler teardown against null traceBuffers_

### DIFF
--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -109,7 +109,12 @@ void GenericActivityProfiler::transferCpuTrace(
     std::unique_ptr<libkineto::CpuTraceBuffer> cpuTrace) {
   std::lock_guard<std::recursive_mutex> guard(mutex_);
   const string& trace_name = cpuTrace->span.name;
-  if (!acceptCpuTraces_) {
+  // acceptCpuTraces_ stays true after the synchronous processTrace() path moves
+  // traceBuffers_ out via finalizeTrace() (only completeTrace()/resetInternal()
+  // clears it), so a late span can arrive with traceBuffers_ already null.
+  // Treat either condition as "not collecting" and discard instead of
+  // dereferencing.
+  if (!acceptCpuTraces_ || traceBuffers_ == nullptr) {
     VLOG(0) << "Trace collection not in progress - discarding span "
             << trace_name;
     return;
@@ -135,6 +140,13 @@ const std::unordered_set<std::string>& getLoggerMedataAllowList() {
 
 void GenericActivityProfiler::processTraceInternal(ActivityLogger& logger) {
   UST_LOGGER_STAGE_SCOPE(kPostProcessingStage);
+  // A previous processTraceInternal() moved traceBuffers_ out via
+  // finalizeTrace(); a redundant process call can reach here with it already
+  // null. Bail out instead of dereferencing null.
+  if (traceBuffers_ == nullptr) {
+    LOG(WARNING) << "No trace buffers to process - skipping";
+    return;
+  }
   LOG(INFO) << "Processing " << traceBuffers_->cpu.size() << " CPU buffers";
   VLOG(0) << "Profile time range: " << captureWindowStartTime_ << " - "
           << captureWindowEndTime_;

--- a/libkineto/test/GenericActivityProfilerTeardownTest.cpp
+++ b/libkineto/test/GenericActivityProfilerTeardownTest.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <chrono>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "include/Config.h"
+#include "src/GenericActivityProfiler.h"
+#include "src/output_membuf.h"
+
+using namespace KINETO_NAMESPACE;
+using namespace std::chrono;
+
+namespace {
+
+// Run one full synchronous trace and leave the profiler in the post-teardown
+// state the guards protect: processTrace() -> finalizeTrace() std::move()s
+// traceBuffers_ out (now null). The bare processTrace() does not call
+// resetInternal(), so acceptCpuTraces_ stays true. Net: acceptCpuTraces_ ==
+// true and traceBuffers_ == nullptr -- the state a late transferCpuTrace() or a
+// redundant processTrace() can hit.
+void runSyncTraceLeavingStaleState(
+    GenericActivityProfiler& profiler,
+    const Config& cfg) {
+  const auto now = system_clock::now();
+  profiler.configure(cfg, now);
+  profiler.startTrace(now);
+  profiler.stopTrace(now);
+  MemoryTraceLogger logger(cfg);
+  profiler.processTrace(logger);
+}
+
+} // namespace
+
+class GenericActivityProfilerTeardownTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    cfg_ = std::make_unique<Config>();
+    cfg_->validate(system_clock::now());
+  }
+  std::unique_ptr<Config> cfg_;
+};
+
+// A span arriving after teardown must be discarded, not dereferenced.
+// acceptCpuTraces_ is still true here, so the acceptCpuTraces_ gate alone is
+// not enough -- transferCpuTrace() must also null-check traceBuffers_. Before
+// the fix it ran cpu.push_back() on the null traceBuffers_ and crashed.
+TEST_F(GenericActivityProfilerTeardownTest, LateTransferCpuTraceIsDiscarded) {
+  GenericActivityProfiler profiler(/*cpuOnly=*/true);
+  runSyncTraceLeavingStaleState(profiler, *cfg_);
+
+  auto lateSpan = std::make_unique<CpuTraceBuffer>();
+  lateSpan->span = TraceSpan(0, 0, "late span");
+  lateSpan->gpuOpCount = 0;
+  profiler.transferCpuTrace(std::move(lateSpan)); // must not crash
+}
+
+// A redundant processTrace() after teardown must be a no-op. Unlike
+// transferCpuTrace(), processTraceInternal() has no acceptCpuTraces_ gate, so
+// without the null guard it dereferences the moved-out traceBuffers_
+// (cpu.size()).
+TEST_F(GenericActivityProfilerTeardownTest, RedundantProcessTraceIsNoOp) {
+  GenericActivityProfiler profiler(/*cpuOnly=*/true);
+  runSyncTraceLeavingStaleState(profiler, *cfg_);
+
+  MemoryTraceLogger logger(*cfg_);
+  profiler.processTrace(logger); // must not crash
+}


### PR DESCRIPTION
Summary:
`GenericActivityProfiler` can dereference a null `traceBuffers_` during trace teardown and crash (SEGV / ASAN `DEADLYSIGNAL`) in `transferCpuTrace()` (`traceBuffers_->cpu.push_back`) or `processTraceInternal()` (`traceBuffers_->cpu.size()`).

Root cause: the synchronous `processTrace()` path runs `processTraceInternal() -> finalizeTrace()`, which `std::move()`s `traceBuffers_` out (leaving it null) but does not call `resetInternal()` -- only `completeTrace()`/`cancelTrace()` reset. So `acceptCpuTraces_` stays true while `traceBuffers_` is null, and a late `transferCpuTrace()` (which gates only on `acceptCpuTraces_`) or a redundant `processTrace()` (which gates on nothing) then dereferences null. This is reachable when a profiling session is torn down and restarted in quick succession with global RecordFunction callbacks active on many threads (e.g. `torch.profiler` with `profile_all_threads=true`).

Fix: both `traceBuffers_` entry points treat a null `traceBuffers_` as "not collecting" and bail out under the existing `mutex_` -- `transferCpuTrace()` discards the late span (same semantics as the existing `acceptCpuTraces_` discard) and `processTraceInternal()` becomes a no-op instead of a null dereference.

Reviewed By: haoyuz

Differential Revision: D108379307


