### PR TITLE
FIx build error by removing unused param

### DIFF
--- a/libkineto/test/RegisterLoggerFactoryTest.cpp
+++ b/libkineto/test/RegisterLoggerFactoryTest.cpp
@@ -179,7 +179,7 @@ TEST(RegisterLoggerFactoryTest, OverwriteProtocolWarning) {
   auto counter2 = std::make_shared<int>(0);
 
   libkineto::registerLoggerFactory(
-      "overwrite_warning_proto", [counter1](const std::string& path) {
+      "overwrite_warning_proto", [counter1](const std::string&) {
         return std::make_unique<CountingLogger>(counter1);
       });
 
@@ -187,7 +187,7 @@ TEST(RegisterLoggerFactoryTest, OverwriteProtocolWarning) {
   libkineto::Logger::addLoggerObserver(&observer);
 
   libkineto::registerLoggerFactory(
-      "overwrite_warning_proto", [counter2](const std::string& path) {
+      "overwrite_warning_proto", [counter2](const std::string&) {
         return std::make_unique<CountingLogger>(counter2);
       });
 


### PR DESCRIPTION
Summary:
Fixing:

```
/pytorch/kineto/libkineto/test/RegisterLoggerFactoryTest.cpp: In lambda function:
/pytorch/kineto/libkineto/test/RegisterLoggerFactoryTest.cpp:182:64: error: unused parameter ‘path’ [-Werror=unused-parameter]
  182 |       "overwrite_warning_proto", [counter1](const std::string& path) {
      |                                             ~~~~~~~~~~~~~~~~~~~^~~~
/pytorch/kineto/libkineto/test/RegisterLoggerFactoryTest.cpp: In lambda function:
/pytorch/kineto/libkineto/test/RegisterLoggerFactoryTest.cpp:190:64: error: unused parameter ‘path’ [-Werror=unused-parameter]
  190 |       "overwrite_warning_proto", [counter2](const std::string& path) {
      |
```

Differential Revision: D109585155


