### PR TITLE
Vendor dynolog ipcfabric headers for the OSS CMake build (#1446)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "libkineto/third_party/fmt"]
 	path = libkineto/third_party/fmt
 	url = https://github.com/fmtlib/fmt.git
-[submodule "libkineto/third_party/dynolog"]
-	path = libkineto/third_party/dynolog
-	url = https://github.com/facebookincubator/dynolog.git
 [submodule "libkineto/third_party/json"]
 	path = libkineto/third_party/json
 	url = https://github.com/nlohmann/json.git

--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -200,9 +200,11 @@ target_compile_options(kineto_base PRIVATE "${KINETO_COMPILE_OPTIONS}")
 target_compile_definitions(kineto_api PUBLIC "${KINETO_DEFINITIONS}")
 target_compile_options(kineto_api PRIVATE "${KINETO_COMPILE_OPTIONS}")
 
+# dynolog's ipcfabric is header-only and vendored under third_party/dynolog
+# (pinned in version.txt), so only its include paths are needed below -- there
+# is no library to build or link.
 set(DYNOLOG_INCLUDE_DIR "${LIBKINETO_THIRDPARTY_DIR}/dynolog/")
 set(IPCFABRIC_INCLUDE_DIR "${DYNOLOG_INCLUDE_DIR}/dynolog/src/ipcfabric/")
-add_subdirectory("${IPCFABRIC_INCLUDE_DIR}")
 
 if(NOT TARGET fmt::fmt-header-only)
   if(NOT FMT_SOURCE_DIR)
@@ -221,8 +223,6 @@ endif()
 
 message(STATUS " DYNOLOG_INCLUDE_DIR = ${DYNOLOG_INCLUDE_DIR}")
 message(STATUS " IPCFABRIC_INCLUDE_DIR = ${IPCFABRIC_INCLUDE_DIR}")
-
-target_link_libraries(kineto_base PRIVATE dynolog_ipcfabric_lib)
 
 target_include_directories(kineto_base PUBLIC
       $<BUILD_INTERFACE:${LIBKINETO_INCLUDE_DIR}>

--- a/libkineto/third_party/dynolog/LICENSE
+++ b/libkineto/third_party/dynolog/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libkineto/third_party/dynolog/dynolog/src/ipcfabric/Endpoint.h
+++ b/libkineto/third_party/dynolog/dynolog/src/ipcfabric/Endpoint.h
@@ -1,0 +1,272 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <asm/unistd.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <stdexcept>
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+// @lint-ignore-every CLANGTIDY facebook-hte-BadCall-strerror
+
+/*
+ * Design: We are using the following components:
+ * 1) Use UNIX sockets and sendmsg/rcvmsg to pass ancillary control message and
+ * payloads. see https://sarata.com/manpages/CMSG_ALIGN.3.html 2) Use abstract
+ * sockets (https://man7.org/linux/man-pages/man7/unix.7.html) to avoid choosing
+ * a path. Note that abstract sockets are indicated by pathname[0]='\0' and the
+ * actual name in the remaining characters up to struct size + null terminator.
+ * 3) Use connectionless datagram sockets
+ *    (SOCK_DGRM https://man7.org/linux/man-pages/man2/socket.2.html) - in Linux
+ *    they are guaranteed to be always reliable and don't reorder - to avoid
+ * having to mantain multiple connections. 4) Use a stateless protocol
+ * connecting based on destination socket name passed in, using scatter/gather
+ * vectors for data communication, with user input vector sizes. 5) Non-blocking
+ * send/receive. 6) Keep serialization/deserialization simple by only supporting
+ * class that are trivially copyable (i.e. std::is_trivially_copyable), like
+ * Plain Old Data (POD) classes.
+ *    (https://en.cppreference.com/w/cpp/types/is_trivially_copyable)
+ *
+ *  You can list local domain sockets using-
+ *    netstat -a -p --unix on Linux
+ */
+
+namespace dynolog {
+namespace ipcfabric {
+
+[[noreturn]] inline void terminate_with_message(const std::string& message) {
+  std::fputs(message.c_str(), stderr);
+  std::terminate();
+}
+
+// Define a type for fds to improve readibility.
+using fd_t = int;
+
+struct Payload {
+  Payload(size_t size, void* data) : size(size), data(data) {}
+  size_t size;
+  void* data;
+};
+
+template <size_t kMaxNumFds = 0>
+struct EndPointCtxt {
+  explicit EndPointCtxt(size_t n) : iov{std::vector<struct iovec>(n)} {}
+  struct sockaddr_un msg_name;
+  size_t msg_namelen;
+  struct msghdr msghdr;
+  std::vector<struct iovec> iov;
+  fd_t* ctrl_fd_ptr;
+
+  // Ancillary data buffer sized to contain kMaxNumFds in data section.
+  char ancillary_buf[CMSG_SPACE(kMaxNumFds * sizeof(fd_t))];
+};
+
+template <size_t kMaxNumFds = 0>
+class EndPoint final {
+  using TCtxt = EndPointCtxt<kMaxNumFds>;
+
+ public:
+  // Maximum defined in man unix, but minus 2 because abstract sockets, first
+  // and last are '\0'.
+  constexpr static size_t kMaxNameLen = 108 - 2;
+
+  explicit EndPoint(const std::string& address) {
+    socket_fd_ = socket(AF_UNIX, SOCK_DGRAM, 0);
+    if (socket_fd_ == -1) {
+      throw std::runtime_error(std::strerror(errno));
+    }
+    struct sockaddr_un addr;
+    size_t addrlen = setAddress_(address, addr);
+    if (addr.sun_path[0] != '\0') {
+      // delete domain socket file just in case before binding
+      unlink(addr.sun_path);
+    }
+
+    int ret = bind(socket_fd_, (const struct sockaddr*)&addr, addrlen);
+    if (ret == -1) {
+      throw std::runtime_error(std::strerror(errno));
+    }
+    if (addr.sun_path[0] != '\0') {
+      // set correct permissions for the socket. We avoid using umask because
+      // of multithreaded nature. A short window exists between bind and chmod
+      // where the permissions are wrong but it's ok for our use case.
+      chmod(addr.sun_path, 0666);
+    }
+  }
+
+  ~EndPoint() {
+    close(socket_fd_);
+  }
+
+  [[nodiscard]] auto buildSendCtxt(
+      const std::string& dest_name,
+      const std::vector<Payload>& payload,
+      const std::vector<fd_t>& fds) {
+    if (fds.size() > kMaxNumFds) {
+      throw std::invalid_argument("Requested to fill more than kMaxNumFds");
+    }
+    if (dest_name.size() == 0) {
+      throw std::invalid_argument("Cannot send to empty socket name");
+    }
+
+    auto ctxt = buildCtxt_(payload, fds.size());
+    ctxt->msghdr.msg_namelen = setAddress_(dest_name, ctxt->msg_name);
+    if (fds.size()) {
+      memcpy(ctxt->ctrl_fd_ptr, fds.data(), fds.size() * sizeof(int));
+    }
+    return ctxt;
+  }
+
+  // non-blocking. The error ECONNREFUSED may be caused by socket not being yet
+  // initialized. See man unix.
+  [[nodiscard]] bool trySendMsg(
+      TCtxt const& ctxt,
+      bool retryOnConnRefused = true) {
+    ssize_t ret = sendmsg(socket_fd_, &ctxt.msghdr, MSG_DONTWAIT);
+    if (ret > 0) { // XXX: Enforce correct number of bytes sent.
+      return true;
+    }
+    if (ret == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+      return false;
+    }
+    if (ret == -1 && retryOnConnRefused && errno == ECONNREFUSED) {
+      return false;
+    }
+    throw std::runtime_error(std::strerror(errno));
+  }
+
+  [[nodiscard]] auto buildRcvCtxt(const std::vector<Payload>& payload) {
+    return buildCtxt_(payload, kMaxNumFds);
+  }
+
+  // If false, must retry. Only enabled for bound sockets.
+  [[nodiscard]] bool tryRcvMsg(TCtxt& ctxt) noexcept {
+    ssize_t ret = recvmsg(socket_fd_, &ctxt.msghdr, MSG_DONTWAIT);
+
+    if (ret > 0) { // XXX: Enforce correct number of bytes sent.
+      return true;
+    }
+    if (ret == 0) {
+      return false; // Receiver is down.
+    }
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return false;
+    }
+
+    terminate_with_message(
+        "tryRcvMsg() got " + std::string(std::strerror(errno)));
+  }
+
+  [[nodiscard]] bool tryPeekMsg(TCtxt& ctxt) noexcept {
+    ssize_t ret = recvmsg(socket_fd_, &ctxt.msghdr, MSG_DONTWAIT | MSG_PEEK);
+    if (ret > 0) { // XXX: Enforce correct number of bytes sent.
+      return true;
+    }
+    if (ret == 0) {
+      return false; // Receiver is down.
+    }
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return false;
+    }
+    terminate_with_message(
+        "tryPeekMsg() got " + std::string(std::strerror(errno)));
+  }
+
+  const char* getName(TCtxt const& ctxt) const noexcept {
+    const char* socket_dir = getenv("KINETO_IPC_SOCKET_DIR");
+    bool is_domain_socket = socket_dir && socket_dir[0];
+    if (is_domain_socket) {
+      int socket_dirname_len = strlen(socket_dir);
+      if (strncmp(socket_dir, ctxt.msg_name.sun_path, socket_dirname_len) !=
+              0 ||
+          ctxt.msg_name.sun_path[socket_dirname_len] != '/') {
+        terminate_with_message(
+            "Unexpected socket name: " + std::string(ctxt.msg_name.sun_path) +
+            ". Expected to start with " + std::string(socket_dir));
+      }
+      return ctxt.msg_name.sun_path + socket_dirname_len + 1;
+    } else {
+      if (ctxt.msg_name.sun_path[0] != '\0') {
+        terminate_with_message(
+            "Expected abstract socket, got " +
+            std::string(ctxt.msg_name.sun_path));
+      }
+      return ctxt.msg_name.sun_path + 1;
+    }
+  }
+
+  std::vector<fd_t> getFds(const TCtxt& ctxt) const {
+    struct cmsghdr* cmsg = CMSG_FIRSTHDR(&ctxt.msghdr);
+    unsigned num_fds = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(fd_t);
+    return {ctxt.ctrl_fd_ptr, ctxt.ctrl_fd_ptr + num_fds};
+  }
+
+ protected:
+  fd_t socket_fd_;
+
+  // Initialize <dest> with address provided in <src>.
+  size_t setAddress_(const std::string& src, struct sockaddr_un& dest) {
+    if (src.size() >
+        kMaxNameLen) { // First and last bytes are used for '/0' characters.
+      throw std::invalid_argument(
+          "Abstract UNIX Socket path cannot be larger than kMaxNameLen - 2");
+    }
+    dest.sun_family = AF_UNIX;
+    const char* socket_dir = getenv("KINETO_IPC_SOCKET_DIR");
+    bool is_domain_socket = socket_dir && socket_dir[0];
+    if (is_domain_socket) {
+      std::string full_path = std::string(socket_dir) + "/" + src;
+      full_path.copy(dest.sun_path, full_path.size());
+      dest.sun_path[full_path.size()] = '\0';
+      return sizeof(sa_family_t) + full_path.size() + 1;
+    } else {
+      dest.sun_path[0] = '\0';
+      if (src.size() == 0) {
+        return sizeof(sa_family_t); // autobind socket.
+      }
+      src.copy(dest.sun_path + 1, src.size());
+      dest.sun_path[src.size() + 1] = '\0';
+      return sizeof(sa_family_t) + src.size() + 2;
+    }
+  }
+
+  auto buildCtxt_(const std::vector<Payload>& payload, unsigned num_fds) {
+    auto ctxt = std::make_unique<TCtxt>(payload.size());
+    memset(&ctxt->msghdr, 0, sizeof(decltype(ctxt->msghdr)));
+    for (int i = 0; i < payload.size(); i++) {
+      ctxt->iov[i] = {payload[i].data, payload[i].size};
+    }
+    ctxt->msghdr.msg_name = &ctxt->msg_name;
+    ctxt->msghdr.msg_namelen = sizeof(decltype(ctxt->msg_name));
+    ctxt->msghdr.msg_iov = ctxt->iov.data();
+    ctxt->msghdr.msg_iovlen = payload.size();
+    ctxt->ctrl_fd_ptr = nullptr;
+
+    if (num_fds == 0) {
+      return ctxt;
+    }
+
+    const size_t fds_size = sizeof(fd_t) * num_fds;
+    ctxt->msghdr.msg_control = ctxt->ancillary_buf;
+    ctxt->msghdr.msg_controllen = CMSG_SPACE(fds_size);
+
+    struct cmsghdr* cmsg = CMSG_FIRSTHDR(&ctxt->msghdr);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    cmsg->cmsg_len = CMSG_LEN(fds_size);
+    ctxt->ctrl_fd_ptr = (fd_t*)CMSG_DATA(cmsg);
+    return ctxt;
+  }
+};
+
+} // namespace ipcfabric
+} // namespace dynolog

--- a/libkineto/third_party/dynolog/dynolog/src/ipcfabric/FabricManager.h
+++ b/libkineto/third_party/dynolog/dynolog/src/ipcfabric/FabricManager.h
@@ -1,0 +1,224 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <exception>
+#include <mutex>
+#include "dynolog/src/ipcfabric/Endpoint.h"
+#include "dynolog/src/ipcfabric/Utils.h"
+
+// If building inside Kineto, use its logger, otherwise use glog
+#if defined(KINETO_NAMESPACE) && defined(ENABLE_IPC_FABRIC)
+// We need to include the Logger header here for LOG() macros.
+// However this can alias with other files that include this and
+// also use glog. TODO(T131440833). Thus, the user should also set
+#include "Logger.h" // @manual
+// set error to use kineto version
+#define ERROR libkineto::ERROR
+
+#else // KINETO_NAMESPACE && ENABLE_IPC_FABRIC
+#include <glog/logging.h>
+#endif // KINETO_NAMESPACE && ENABLE_IPC_FABRIC
+
+namespace dynolog::ipcfabric {
+
+constexpr int TYPE_SIZE = 32;
+
+struct Metadata {
+  size_t size = 0;
+  char type[TYPE_SIZE] = "";
+};
+
+struct Message {
+  template <class T>
+  static std::unique_ptr<Message> constructMessage(
+      const T& data,
+      const std::string& type) {
+    std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
+    memcpy(msg->metadata.type, type.c_str(), type.size() + 1);
+    // TODO CXX 17 - https://github.com/pytorch/kineto/issues/650
+    // if constexpr (std::is_same_v<std::string, T>) {
+    // Without constexpr following is not possible
+#if __cplusplus >= 201703L
+    if constexpr (std::is_same<std::string, T>::value == true) {
+      msg->metadata.size = data.size();
+      msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
+      memcpy(msg->buf.get(), data.c_str(), msg->metadata.size);
+    } else {
+#endif
+      // ensure memcpy works on T
+      // TODO CXX 17 - https://github.com/pytorch/kineto/issues/650
+      // static_assert(std::is_trivially_copyable_v<T>);
+      static_assert(std::is_trivially_copyable<T>::value);
+      msg->metadata.size = sizeof(data);
+      msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
+      memcpy(msg->buf.get(), &data, msg->metadata.size);
+#if __cplusplus >= 201703L
+    }
+#endif
+    return msg;
+  }
+
+  // Construct message where T is a trivially copyable struct with
+  // a flexible array at the end. The items in the flexible array are
+  // of (trivially copyable) type U and there are n of them.
+  template <class T, class U>
+  static std::unique_ptr<Message>
+  constructMessage(const T& data, const std::string& type, int n) {
+    std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
+    memcpy(msg->metadata.type, type.c_str(), type.size() + 1);
+    // ensure memcpy works on T and U
+    // TODO CXX 17 - https://github.com/pytorch/kineto/issues/650
+    // static_assert(std::is_trivially_copyable_v<T>);
+    // static_assert(std::is_trivially_copyable_v<U>);
+    static_assert(std::is_trivially_copyable<T>::value);
+    static_assert(std::is_trivially_copyable<U>::value);
+    msg->metadata.size = sizeof(data) + sizeof(U) * n;
+    msg->buf = std::make_unique<unsigned char[]>(msg->metadata.size);
+    memcpy(msg->buf.get(), &data, msg->metadata.size);
+    return msg;
+  }
+
+  Metadata metadata;
+  std::unique_ptr<unsigned char[]> buf;
+  // endpoint name of the sender
+  std::string src;
+};
+
+class FabricManager {
+ public:
+  FabricManager(const FabricManager&) = delete;
+  FabricManager& operator=(const FabricManager&) = delete;
+
+  static std::unique_ptr<FabricManager> factory(
+      std::string endpoint_name = "") {
+    try {
+      return std::unique_ptr<FabricManager>(new FabricManager(endpoint_name));
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Error when initializing FabricManager: " << e.what();
+    }
+    return nullptr;
+  }
+
+  // warning: this will block for user passed in time with exponential increase
+  // if send keeps failing
+  bool sync_send(
+      const Message& msg,
+      const std::string& dest_name,
+      int num_retries = 10,
+      int sleep_time_us = 10000) {
+    if (dest_name.size() == 0) {
+      LOG(ERROR) << "Cannot send to empty socket name";
+      return false;
+    }
+
+    std::vector<Payload> payload{
+        Payload(sizeof(struct Metadata), (void*)&msg.metadata),
+        Payload(msg.metadata.size, msg.buf.get())};
+    int i = 0;
+    try {
+      auto ctxt = ep_.buildSendCtxt(dest_name, payload, std::vector<int>());
+      while (!ep_.trySendMsg(*ctxt) && i < num_retries) {
+        i++;
+        /* sleep override */
+        usleep(sleep_time_us);
+        sleep_time_us *= 2;
+      }
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Error when sync_send(): " << e.what();
+      return false;
+    }
+    return i < num_retries;
+  }
+
+  bool recv() {
+    try {
+      Metadata receive_metadata;
+      std::vector<Payload> peek_payload{
+          Payload(sizeof(struct Metadata), &receive_metadata)};
+      auto peek_ctxt = ep_.buildRcvCtxt(peek_payload);
+      // unix socket only fills the data for the iov that have a non NULL
+      // buffer. Leverage that to read metadata to find buffer size by:
+      //   1) FabricManager assumes metadata in first iov, data in second
+      //   2) peek with only metadata buffer in iov
+      //   3) read metadata
+      //   4) use metadata to find the desired size for the buffer to allocate.
+      //   5) read metadata + data with allocated buffer
+      bool success;
+      try {
+        success = ep_.tryPeekMsg(*peek_ctxt);
+      } catch (std::exception& e) {
+        LOG(ERROR) << "Error when tryPeekMsg(): " << e.what();
+        return false;
+      }
+      if (success) {
+        std::unique_ptr<Message> msg = std::make_unique<Message>(Message());
+        msg->metadata = receive_metadata;
+        // new unsigned char[N] guarantees the maximum alignment to hold any
+        // object thus we don't need to worry about memory alignment here see
+        // https://stackoverflow.com/questions/10587879/does-new-char-actually-guarantee-aligned-memory-for-a-class-type
+        // and
+        // https://stackoverflow.com/questions/39668561/allocate-n-bytes-by-new-and-fill-it-with-any-type
+        msg->buf = std::unique_ptr<unsigned char[]>(
+            new unsigned char[receive_metadata.size]);
+        msg->src = std::string(ep_.getName(*peek_ctxt));
+        std::vector<Payload> payload{
+            Payload(sizeof(struct Metadata), (void*)&msg->metadata),
+            Payload(receive_metadata.size, msg->buf.get())};
+        auto recv_ctxt = ep_.buildRcvCtxt(payload);
+
+        // the deque can potentially grow very large
+        try {
+          success = ep_.tryRcvMsg(*recv_ctxt);
+        } catch (std::exception& e) {
+          LOG(ERROR) << "Error when tryRcvMsg(): " << e.what();
+          return false;
+        }
+        if (success) {
+          std::lock_guard<std::mutex> wguard(dequeLock_);
+          message_deque_.push_back(std::move(msg));
+          return true;
+        }
+      }
+    } catch (std::exception& e) {
+      LOG(ERROR) << "Error in recv(): " << e.what();
+      return false;
+    }
+    return false;
+  }
+
+  std::unique_ptr<Message> retrieve_msg() {
+    std::lock_guard<std::mutex> wguard(dequeLock_);
+    if (message_deque_.empty()) {
+      return nullptr;
+    }
+    std::unique_ptr<Message> msg = std::move(message_deque_.front());
+    message_deque_.pop_front();
+    return msg;
+  }
+
+  std::unique_ptr<Message> poll_recv(int max_retries, int sleep_time_us) {
+    for (int i = 0; i < max_retries; i++) {
+      if (recv()) {
+        return retrieve_msg();
+      }
+      /* sleep override */
+      usleep(sleep_time_us);
+    }
+    return nullptr;
+  }
+
+ private:
+  explicit FabricManager(std::string endpoint_name = "") : ep_{endpoint_name} {}
+  // message LIFO deque with oldest message at front
+  std::deque<std::unique_ptr<Message>> message_deque_;
+  EndPoint<0> ep_;
+  std::mutex dequeLock_;
+};
+
+} // namespace dynolog::ipcfabric

--- a/libkineto/third_party/dynolog/dynolog/src/ipcfabric/Utils.h
+++ b/libkineto/third_party/dynolog/dynolog/src/ipcfabric/Utils.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <sys/types.h>
+#include <cstdint>
+
+namespace dynolog {
+namespace ipcfabric {
+
+// struct to register libkineto process
+struct LibkinetoContext {
+  // gpu id of the process running on
+  int32_t gpu;
+  // pid to register to dynolog
+  pid_t pid;
+  // job id of the process
+  int64_t jobid;
+};
+
+// struct to request libkineto ondemand config
+struct LibkinetoRequest {
+  // type of libkineto config
+  int type;
+  // size of pids
+  int n;
+  // job id of the libkineto process
+  int64_t jobid;
+  // pids of the process and its ancestors
+  int32_t pids[];
+};
+
+constexpr char dynolog_endpoint[] = "dynolog";
+constexpr char kLibkinetoRequest[] = "req";
+constexpr char kLibkinetoContext[] = "ctxt";
+} // namespace ipcfabric
+} // namespace dynolog

--- a/libkineto/third_party/dynolog/version.txt
+++ b/libkineto/third_party/dynolog/version.txt
@@ -1,0 +1,2 @@
+https://github.com/facebookincubator/dynolog.git
+d2ffe0a4e3acace628db49974246b66fc3e85fb1

--- a/libkineto/third_party/vendor_dynolog.sh
+++ b/libkineto/third_party/vendor_dynolog.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Re-vendor the dynolog ipcfabric headers used by libkineto's open-source CMake
+# build. Kineto's CMake build consumes these three header-only files directly.
+#
+# Usage:
+#   vendor_dynolog.sh <commit> [--from <dynolog-checkout>]
+#
+#   <commit>            dynolog commit to vendor (required).
+#   --from <checkout>   Copy headers from an existing dynolog checkout rooted at
+#                       <checkout> instead of cloning from GitHub. Use this where
+#                       GitHub is unreachable. The caller must ensure the
+#                       checkout is at <commit>.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dest_dir="${script_dir}/dynolog"
+version_file="${dest_dir}/version.txt"
+repo_url="https://github.com/facebookincubator/dynolog.git"
+rel_headers="dynolog/src/ipcfabric"
+headers=(FabricManager.h Endpoint.h Utils.h)
+
+commit=""
+from_dir=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from)
+      from_dir="${2:?--from requires a path}"
+      shift 2
+      ;;
+    *)
+      commit="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${commit}" ]]; then
+  echo "error: a dynolog commit hash is required" >&2
+  echo "usage: vendor_dynolog.sh <commit> [--from <dynolog-checkout>]" >&2
+  exit 1
+fi
+
+tmp_dir=""
+cleanup() {
+  if [[ -n "${tmp_dir}" ]]; then
+    rm -rf "${tmp_dir}"
+  fi
+}
+trap cleanup EXIT
+
+if [[ -n "${from_dir}" ]]; then
+  src_dir="${from_dir}"
+else
+  tmp_dir="$(mktemp -d)"
+  git clone --filter=blob:none --no-checkout "${repo_url}" "${tmp_dir}"
+  git -C "${tmp_dir}" checkout "${commit}"
+  src_dir="${tmp_dir}"
+fi
+
+mkdir -p "${dest_dir}/${rel_headers}"
+for h in "${headers[@]}"; do
+  cp "${src_dir}/${rel_headers}/${h}" "${dest_dir}/${rel_headers}/${h}"
+done
+
+# The headers are MIT-licensed; carry dynolog's LICENSE alongside them so the
+# vendored copy satisfies the MIT notice requirement and the headers' reference
+# to the LICENSE in the root of this source tree resolves.
+cp "${src_dir}/LICENSE" "${dest_dir}/LICENSE"
+
+printf '%s\n%s\n' "${repo_url}" "${commit}" >"${version_file}"
+
+echo "Vendored ${headers[*]} + LICENSE from dynolog ${commit}"
+echo "  source: ${src_dir}/${rel_headers}"
+echo "  dest:   ${dest_dir}/${rel_headers}"
+echo "  wrote:  ${version_file}"


### PR DESCRIPTION
Summary:

**Problem** — Kineto's open-source CMake build pulls dynolog in as a git submodule (`libkineto/third_party/dynolog`) only to obtain three header-only files from its ipcfabric IPC layer. The recursive clone, the `.gitmodules` entry, and the submodule machinery are heavyweight for about 540 lines of headers. On a fresh clone, the dynolog repo is about 40 MB with about 475,000 lines of source code (almost 65,000 unique, the rest generated).

**Fix** — Vendor the three ipcfabric headers (`FabricManager.h`, `Endpoint.h`, `Utils.h`) directly under `libkineto/third_party/dynolog/`, pinned to the previously-referenced commit `d2ffe0a4`, and drop the submodule. `version.txt` records the upstream URL and commit; `vendor_dynolog.sh` re-vendors the headers from a given commit. CMake consumes the headers through the existing include directories.

Differential Revision: D109617574
