### PR TITLE
Avoid CI OOMs by limiting parallel compile jobs

### DIFF
--- a/.github/scripts/config_cuda.sh
+++ b/.github/scripts/config_cuda.sh
@@ -26,6 +26,13 @@ KINETO_CMAKE_FLAGS=(
 export USE_CUDA=1
 export BUILD_TEST=1
 
+# Cap parallel compile jobs. PyTorch's build otherwise spawns one compile per
+# core (16 on the g5.4xlarge runner). On a cold sccache cache the heavy ATen
+# CPU kernels then compile all at once, peaking past the runner's 64 GB and
+# tripping the OOM killer (SIGKILL / exit 137). 8 jobs bounds peak memory;
+# warm cache-hit builds use little memory and stay fast regardless.
+export MAX_JOBS=8
+
 # --- PyTorch build caching ---
 # This arch's CI runner is an AWS instance, so it can reach PyTorch's shared
 # S3 sccache bucket.

--- a/.github/scripts/config_cuda.sh
+++ b/.github/scripts/config_cuda.sh
@@ -28,9 +28,11 @@ export BUILD_TEST=1
 
 # Cap parallel compile jobs. PyTorch's build otherwise spawns one compile per
 # core (16 on the g5.4xlarge runner). On a cold sccache cache the heavy ATen
-# CPU kernels then compile all at once, peaking past the runner's 64 GB and
-# tripping the OOM killer (SIGKILL / exit 137). 8 jobs bounds peak memory;
-# warm cache-hit builds use little memory and stay fast regardless.
+# CPU kernels then compile all at once, peaking past the runner's total memory
+# and tripping the OOM killer.
+#
+# Note that this is tuned to the current g5.4xlarge runner to half the available
+# cores. This should be updated if we change the default runner.
 export MAX_JOBS=8
 
 # --- PyTorch build caching ---

--- a/.github/scripts/config_rocm.sh
+++ b/.github/scripts/config_rocm.sh
@@ -30,6 +30,13 @@ export USE_ROCM=1
 export BUILD_TEST=1
 export PYTORCH_TEST_WITH_ROCM=1
 
+# Cap parallel compile jobs. PyTorch's build otherwise spawns one compile per
+# core, and ROCm never reaches the sccache bucket (see below), so every build
+# recompiles the heavy ATen kernels from scratch. Without a cap they compile
+# all at once and can exhaust runner memory, tripping the OOM killer (SIGKILL /
+# exit 137). 8 jobs bounds peak memory.
+export MAX_JOBS=8
+
 # --- PyTorch build caching ---
 # This arch's CI runner is not on AWS and cannot reach PyTorch's S3 sccache
 # bucket.

--- a/.github/scripts/config_rocm.sh
+++ b/.github/scripts/config_rocm.sh
@@ -33,8 +33,10 @@ export PYTORCH_TEST_WITH_ROCM=1
 # Cap parallel compile jobs. PyTorch's build otherwise spawns one compile per
 # core, and ROCm never reaches the sccache bucket (see below), so every build
 # recompiles the heavy ATen kernels from scratch. Without a cap they compile
-# all at once and can exhaust runner memory, tripping the OOM killer (SIGKILL /
-# exit 137). 8 jobs bounds peak memory.
+# all at once and can exhaust runner memory, tripping the OOM killer.
+#
+# Note that this is naively set the same as on the CUDA side. We can tweak this
+# if needed.
 export MAX_JOBS=8
 
 # --- PyTorch build caching ---


### PR DESCRIPTION
We're getting OOM failures on some PyTorch build jobs because they're using too much memory.