### PR TITLE
Make TypedMetadata a visitor interface instead

### DIFF
--- a/libkineto/include/ITraceActivity.h
+++ b/libkineto/include/ITraceActivity.h
@@ -51,9 +51,8 @@ struct ITraceActivity {
   // Return json formatted metadata
   // FIXME: Return iterator to dynamic type map here instead
   [[nodiscard]] virtual const std::string metadataJson() const = 0;
-  [[nodiscard]] virtual TypedMetadata typedMetadata() const {
-    return {};
-  }
+  // Write structured metadata to a consumer.
+  virtual void visitTypedMetadata([[maybe_unused]] ITypedMetadataVisitor& visitor) const {}
   // Return the metadata value in string format with key
   // @lint-ignore CLANGTIDY: clang-diagnostic-unused-parameter
   [[nodiscard]] virtual const std::string getMetadataValue([[maybe_unused]] const std::string& key) const {

--- a/libkineto/include/TypedMetadata.h
+++ b/libkineto/include/TypedMetadata.h
@@ -9,18 +9,12 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
-#include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
-#include <utility>
-#include <variant>
 #include <vector>
 
 namespace libkineto {
-
-using TypedValue = std::variant<int64_t, double, bool, std::string, std::vector<int64_t>, std::vector<std::string>>;
 
 template <typename T>
 struct MetadataField {
@@ -30,66 +24,63 @@ struct MetadataField {
 };
 
 /*
- * TypedMetadata is a per-activity map for structured metadata with
+ * ITypedMetadataVisitor is a per-activity visitor for structured metadata with
  * field-level type checking.
  *
  * Usage:
- *   // Declare each field once. FieldType is int64_t here, and set/get enforce
+ *   // Declare each field once. FieldType is int64_t here, and visit() enforces
  *   // that declared type.
  *   inline constexpr MetadataField<int64_t> kCorrelation{"correlation"};
  *
- *   // Producer: populate metadata from ITraceActivity::typedMetadata().
- *   TypedMetadata metadata;
- *   metadata.set(kCorrelation, int64_t{activity.correlationId});
+ *   // Producer: emit metadata from ITraceActivity::visitTypedMetadata().
+ *   void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override {
+ *     visitor.visit(kCorrelation, int64_t{activity.correlationId});
+ *   }
  *
- *   // Consumer: read a known field with its declared type.
- *   std::optional<int64_t> correlation = metadata.get(kCorrelation);
- *
- *   // Consumer: iterate over all fields for generic output conversion.
- *   metadata.visit([](std::string_view name, const TypedValue& value) {
+ *   // Consumer: implement visitValue() overloads for handled field types.
+ *   class MyVisitor : public ITypedMetadataVisitor {
  *     ...
- *   });
+ *   };
+ *
+ *   // Consumer: pass the visitor to an activity for generic output conversion.
+ *   MyVisitor visitor;
+ *   activity.visitTypedMetadata(visitor);
  */
-class TypedMetadata {
+class ITypedMetadataVisitor {
  public:
+  virtual ~ITypedMetadataVisitor() = default;
+
   template <typename T, typename V>
-  void set(const MetadataField<T>& field, V&& value) {
+  void visit(const MetadataField<T>& field, const V& value) {
     using FieldType = typename MetadataField<T>::FieldType;
     static_assert(std::is_same_v<FieldType, std::decay_t<V>>, "value type must match field's declared type");
-    entries_.insert_or_assign(std::string{field.name}, TypedValue{std::forward<V>(value)});
+    visitValue(field, value);
   }
 
-  [[nodiscard]] std::optional<TypedValue> get(std::string_view key) const {
-    auto it = entries_.find(key);
-    if (it == entries_.end()) {
-      return std::nullopt;
-    }
-    return it->second;
-  }
+ protected:
+  virtual void visitUnsupported(std::string_view name) = 0;
 
   template <typename T>
-  [[nodiscard]] std::optional<typename MetadataField<T>::FieldType> get(const MetadataField<T>& field) const {
-    using FieldType = typename MetadataField<T>::FieldType;
-    auto it = entries_.find(field.name);
-    if (it == entries_.end()) {
-      return std::nullopt;
-    }
-    return std::get<FieldType>(it->second);
+  void visitValue(const MetadataField<T>& field, const T& /*value*/) {
+    visitUnsupported(field.name);
   }
 
-  template <typename Fn>
-  void visit(Fn&& fn) const {
-    for (const auto& [name, value] : entries_) {
-      fn(std::string_view{name}, value);
-    }
+  void visitValue(const MetadataField<std::string>& field, const std::string& value) {
+    visitValue(field, std::string_view{value});
   }
 
-  [[nodiscard]] bool empty() const {
-    return entries_.empty();
-  }
+  virtual void visitValue(const MetadataField<int64_t>& field, int64_t value) = 0;
 
- private:
-  std::map<std::string, TypedValue, std::less<>> entries_;
+  virtual void visitValue(const MetadataField<double>& field, double value) = 0;
+
+  virtual void visitValue(const MetadataField<bool>& field, bool value) = 0;
+
+  virtual void visitValue(const MetadataField<std::string>& field, std::string_view value) = 0;
+
+  virtual void visitValue(const MetadataField<std::vector<int64_t>>& field, const std::vector<int64_t>& value) = 0;
+
+  virtual void visitValue(const MetadataField<std::vector<std::string>>& field,
+                          const std::vector<std::string>& value) = 0;
 };
 
 } // namespace libkineto

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -123,7 +123,7 @@ struct RuntimeActivity : public CuptiActivity<CUpti_ActivityAPI> {
   }
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
-  TypedMetadata typedMetadata() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
 
  private:
   const int32_t threadId_;
@@ -149,7 +149,7 @@ struct DriverActivity : public CuptiActivity<CUpti_ActivityAPI> {
   const std::string name() const override;
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
-  TypedMetadata typedMetadata() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
 
  private:
   const int32_t threadId_;
@@ -200,7 +200,7 @@ struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
   }
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
-  TypedMetadata typedMetadata() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
 
  private:
   const int32_t threadId_;
@@ -227,7 +227,7 @@ struct CudaSyncActivity : public CuptiActivity<CUpti_ActivitySynchronization> {
   const std::string name() const override;
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
-  TypedMetadata typedMetadata() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
   const CUpti_ActivitySynchronization& raw() const {
     return CuptiActivity<CUpti_ActivitySynchronization>::raw();
   }
@@ -288,7 +288,7 @@ struct CudaEventActivity : public CuptiActivity<CUpti_ActivityCudaEventType> {
   const std::string name() const override;
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
-  TypedMetadata typedMetadata() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
   const CUpti_ActivityCudaEventType& raw() const {
     return CuptiActivity<CUpti_ActivityCudaEventType>::raw();
   }
@@ -315,7 +315,7 @@ struct GpuActivity : public CuptiActivity<T> {
   const std::string name() const override;
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
-  TypedMetadata typedMetadata() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
   const T& raw() const {
     return CuptiActivity<T>::raw();
   }
@@ -396,20 +396,18 @@ inline const std::string CudaSyncActivity::metadataJson() const {
   return "";
 }
 
-inline TypedMetadata CudaSyncActivity::typedMetadata() const {
+inline void CudaSyncActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   const CUpti_ActivitySynchronization& sync = raw();
-  TypedMetadata metadata;
-  metadata.set(CudaMetadataFields::kCudaSyncKind, std::string{syncTypeString(sync.type)});
+  visitor.visit(CudaMetadataFields::kCudaSyncKind, std::string{syncTypeString(sync.type)});
   if (isEventSync(sync.type)) {
-    metadata.set(CudaMetadataFields::kWaitOnStream, static_cast<int64_t>(srcStream_));
-    metadata.set(CudaMetadataFields::kWaitOnCudaEventRecordCorrId, static_cast<int64_t>(srcCorrId_));
-    metadata.set(CudaMetadataFields::kWaitOnCudaEventId, static_cast<int64_t>(sync.cudaEventId));
+    visitor.visit(CudaMetadataFields::kWaitOnStream, static_cast<int64_t>(srcStream_));
+    visitor.visit(CudaMetadataFields::kWaitOnCudaEventRecordCorrId, static_cast<int64_t>(srcCorrId_));
+    visitor.visit(CudaMetadataFields::kWaitOnCudaEventId, static_cast<int64_t>(sync.cudaEventId));
   }
-  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(streamIdForTrace(sync.streamId)));
-  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(sync.correlationId));
-  metadata.set(CudaMetadataFields::kDevice, deviceId());
-  metadata.set(CudaMetadataFields::kContext, static_cast<int64_t>(sync.contextId));
-  return metadata;
+  visitor.visit(CudaMetadataFields::kStream, static_cast<int64_t>(streamIdForTrace(sync.streamId)));
+  visitor.visit(CudaMetadataFields::kCorrelation, static_cast<int64_t>(sync.correlationId));
+  visitor.visit(CudaMetadataFields::kDevice, deviceId());
+  visitor.visit(CudaMetadataFields::kContext, static_cast<int64_t>(sync.contextId));
 }
 
 inline const std::string CudaEventActivity::name() const {
@@ -443,15 +441,13 @@ inline const std::string CudaEventActivity::metadataJson() const {
   // clang-format on
 }
 
-inline TypedMetadata CudaEventActivity::typedMetadata() const {
+inline void CudaEventActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   const CUpti_ActivityCudaEventType& event = raw();
-  TypedMetadata metadata;
-  metadata.set(CudaMetadataFields::kEventId, static_cast<int64_t>(event.eventId));
-  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(streamIdForTrace(event.streamId)));
-  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(event.correlationId));
-  metadata.set(CudaMetadataFields::kDevice, deviceId());
-  metadata.set(CudaMetadataFields::kContext, static_cast<int64_t>(event.contextId));
-  return metadata;
+  visitor.visit(CudaMetadataFields::kEventId, static_cast<int64_t>(event.eventId));
+  visitor.visit(CudaMetadataFields::kStream, static_cast<int64_t>(streamIdForTrace(event.streamId)));
+  visitor.visit(CudaMetadataFields::kCorrelation, static_cast<int64_t>(event.correlationId));
+  visitor.visit(CudaMetadataFields::kDevice, deviceId());
+  visitor.visit(CudaMetadataFields::kContext, static_cast<int64_t>(event.contextId));
 }
 
 template <class T>
@@ -504,33 +500,38 @@ inline std::string getChannelMetadata([[maybe_unused]] const T& activity) {
 }
 
 template <class T>
-inline void addGraphNodeTypedMetadata([[maybe_unused]] TypedMetadata& metadata, [[maybe_unused]] const T& activity) {
+inline void addGraphNodeTypedMetadata([[maybe_unused]] ITypedMetadataVisitor& visitor,
+                                      [[maybe_unused]] const T& activity) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
-  metadata.set(CudaMetadataFields::kGraphId, static_cast<int64_t>(activity.graphId));
-  metadata.set(CudaMetadataFields::kGraphNodeId, static_cast<int64_t>(activity.graphNodeId));
+  visitor.visit(CudaMetadataFields::kGraphId, static_cast<int64_t>(activity.graphId));
+  visitor.visit(CudaMetadataFields::kGraphNodeId, static_cast<int64_t>(activity.graphNodeId));
 #endif
 }
 
 template <class T>
-inline void addPriorityTypedMetadata([[maybe_unused]] TypedMetadata& metadata, [[maybe_unused]] const T& kernel) {
+inline void addPriorityTypedMetadata([[maybe_unused]] ITypedMetadataVisitor& visitor,
+                                     [[maybe_unused]] const T& kernel) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 13010
-  metadata.set(CudaMetadataFields::kPriority, static_cast<int64_t>(kernel.priority));
+  visitor.visit(CudaMetadataFields::kPriority, static_cast<int64_t>(kernel.priority));
 #endif
 }
 
 template <class T>
-inline void addChannelTypedMetadata([[maybe_unused]] TypedMetadata& metadata, [[maybe_unused]] const T& activity) {
+inline void addChannelTypedMetadata([[maybe_unused]] ITypedMetadataVisitor& visitor,
+                                    [[maybe_unused]] const T& activity) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
-  metadata.set(CudaMetadataFields::kChannel, static_cast<int64_t>(activity.channelID));
-  metadata.set(CudaMetadataFields::kChannelType, static_cast<int64_t>(activity.channelType));
+  visitor.visit(CudaMetadataFields::kChannel, static_cast<int64_t>(activity.channelID));
+  visitor.visit(CudaMetadataFields::kChannelType, static_cast<int64_t>(activity.channelType));
 #endif
 }
 
-inline void addBandwidthTypedMetadata([[maybe_unused]] TypedMetadata& metadata, uint64_t bytes, int64_t duration) {
+inline void addBandwidthTypedMetadata([[maybe_unused]] ITypedMetadataVisitor& visitor,
+                                      uint64_t bytes,
+                                      int64_t duration) {
   if (duration == 0) {
     return;
   }
-  metadata.set(CudaMetadataFields::kMemoryBandwidthGbps, static_cast<double>(bytes) / static_cast<double>(duration));
+  visitor.visit(CudaMetadataFields::kMemoryBandwidthGbps, static_cast<double>(bytes) / static_cast<double>(duration));
 }
 
 // Convert limitingFactors bitmask to human-readable string
@@ -615,49 +616,47 @@ inline const std::string GpuActivity<CUpti_ActivityKernelType>::metadataJson() c
 }
 
 template <>
-inline TypedMetadata GpuActivity<CUpti_ActivityKernelType>::typedMetadata() const {
+inline void GpuActivity<CUpti_ActivityKernelType>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   const CUpti_ActivityKernelType& kernel = raw();
   const float blocksPerSmVal = blocksPerSm(kernel);
   const float warpsPerSmVal = warpsPerSm(kernel);
   const OccupancyMetrics occMetrics = computeOccupancyMetrics(kernel);
 
-  TypedMetadata metadata;
-  metadata.set(CudaMetadataFields::kQueued, static_cast<int64_t>(kernel.queued));
-  metadata.set(CudaMetadataFields::kDevice, static_cast<int64_t>(kernel.deviceId));
-  metadata.set(CudaMetadataFields::kContext, static_cast<int64_t>(kernel.contextId));
-  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(kernel.streamId));
-  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(kernel.correlationId));
-  metadata.set(CudaMetadataFields::kRegistersPerThread, static_cast<int64_t>(kernel.registersPerThread));
-  metadata.set(CudaMetadataFields::kSharedMemory,
-               static_cast<int64_t>(kernel.staticSharedMemory + kernel.dynamicSharedMemory));
-  metadata.set(CudaMetadataFields::kBlocksPerSm, static_cast<double>(blocksPerSmVal));
-  metadata.set(CudaMetadataFields::kWarpsPerSm, static_cast<double>(warpsPerSmVal));
-  metadata.set(
+  visitor.visit(CudaMetadataFields::kQueued, static_cast<int64_t>(kernel.queued));
+  visitor.visit(CudaMetadataFields::kDevice, static_cast<int64_t>(kernel.deviceId));
+  visitor.visit(CudaMetadataFields::kContext, static_cast<int64_t>(kernel.contextId));
+  visitor.visit(CudaMetadataFields::kStream, static_cast<int64_t>(kernel.streamId));
+  visitor.visit(CudaMetadataFields::kCorrelation, static_cast<int64_t>(kernel.correlationId));
+  visitor.visit(CudaMetadataFields::kRegistersPerThread, static_cast<int64_t>(kernel.registersPerThread));
+  visitor.visit(CudaMetadataFields::kSharedMemory,
+                static_cast<int64_t>(kernel.staticSharedMemory + kernel.dynamicSharedMemory));
+  visitor.visit(CudaMetadataFields::kBlocksPerSm, static_cast<double>(blocksPerSmVal));
+  visitor.visit(CudaMetadataFields::kWarpsPerSm, static_cast<double>(warpsPerSmVal));
+  visitor.visit(
       CudaMetadataFields::kGrid,
       std::vector<int64_t>{
           static_cast<int64_t>(kernel.gridX), static_cast<int64_t>(kernel.gridY), static_cast<int64_t>(kernel.gridZ)});
-  metadata.set(CudaMetadataFields::kBlock,
-               std::vector<int64_t>{static_cast<int64_t>(kernel.blockX),
-                                    static_cast<int64_t>(kernel.blockY),
-                                    static_cast<int64_t>(kernel.blockZ)});
-  metadata.set(CudaMetadataFields::kEstAchievedOccupancyPercent,
-               static_cast<int64_t>(std::lround(occMetrics.occupancy * 100.0)));
-  metadata.set(CudaMetadataFields::kActiveBlocksPerMultiprocessor,
-               static_cast<int64_t>(occMetrics.result.activeBlocksPerMultiprocessor));
-  metadata.set(CudaMetadataFields::kLimitingFactors, limitingFactorsToString(occMetrics.result.limitingFactors));
-  metadata.set(CudaMetadataFields::kBlockLimitRegs, static_cast<int64_t>(occMetrics.result.blockLimitRegs));
-  metadata.set(CudaMetadataFields::kBlockLimitSharedMem, static_cast<int64_t>(occMetrics.result.blockLimitSharedMem));
-  metadata.set(CudaMetadataFields::kBlockLimitWarps, static_cast<int64_t>(occMetrics.result.blockLimitWarps));
-  metadata.set(CudaMetadataFields::kBlockLimitBlocks, static_cast<int64_t>(occMetrics.result.blockLimitBlocks));
-  metadata.set(CudaMetadataFields::kBlockLimitBarriers, static_cast<int64_t>(occMetrics.result.blockLimitBarriers));
-  metadata.set(CudaMetadataFields::kAllocatedRegistersPerBlock,
-               static_cast<int64_t>(occMetrics.result.allocatedRegistersPerBlock));
-  metadata.set(CudaMetadataFields::kAllocatedSharedMemPerBlock,
-               static_cast<int64_t>(occMetrics.result.allocatedSharedMemPerBlock));
-  addGraphNodeTypedMetadata(metadata, kernel);
-  addPriorityTypedMetadata(metadata, kernel);
-  addChannelTypedMetadata(metadata, kernel);
-  return metadata;
+  visitor.visit(CudaMetadataFields::kBlock,
+                std::vector<int64_t>{static_cast<int64_t>(kernel.blockX),
+                                     static_cast<int64_t>(kernel.blockY),
+                                     static_cast<int64_t>(kernel.blockZ)});
+  visitor.visit(CudaMetadataFields::kEstAchievedOccupancyPercent,
+                static_cast<int64_t>(std::lround(occMetrics.occupancy * 100.0)));
+  visitor.visit(CudaMetadataFields::kActiveBlocksPerMultiprocessor,
+                static_cast<int64_t>(occMetrics.result.activeBlocksPerMultiprocessor));
+  visitor.visit(CudaMetadataFields::kLimitingFactors, limitingFactorsToString(occMetrics.result.limitingFactors));
+  visitor.visit(CudaMetadataFields::kBlockLimitRegs, static_cast<int64_t>(occMetrics.result.blockLimitRegs));
+  visitor.visit(CudaMetadataFields::kBlockLimitSharedMem, static_cast<int64_t>(occMetrics.result.blockLimitSharedMem));
+  visitor.visit(CudaMetadataFields::kBlockLimitWarps, static_cast<int64_t>(occMetrics.result.blockLimitWarps));
+  visitor.visit(CudaMetadataFields::kBlockLimitBlocks, static_cast<int64_t>(occMetrics.result.blockLimitBlocks));
+  visitor.visit(CudaMetadataFields::kBlockLimitBarriers, static_cast<int64_t>(occMetrics.result.blockLimitBarriers));
+  visitor.visit(CudaMetadataFields::kAllocatedRegistersPerBlock,
+                static_cast<int64_t>(occMetrics.result.allocatedRegistersPerBlock));
+  visitor.visit(CudaMetadataFields::kAllocatedSharedMemPerBlock,
+                static_cast<int64_t>(occMetrics.result.allocatedSharedMemPerBlock));
+  addGraphNodeTypedMetadata(visitor, kernel);
+  addPriorityTypedMetadata(visitor, kernel);
+  addChannelTypedMetadata(visitor, kernel);
 }
 
 inline std::string memcpyName(uint8_t kind, uint8_t src, uint8_t dst) {
@@ -698,18 +697,16 @@ inline const std::string GpuActivity<CUpti_ActivityMemcpyType>::metadataJson() c
 }
 
 template <>
-inline TypedMetadata GpuActivity<CUpti_ActivityMemcpyType>::typedMetadata() const {
+inline void GpuActivity<CUpti_ActivityMemcpyType>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   const CUpti_ActivityMemcpyType& memcpy = raw();
-  TypedMetadata metadata;
-  metadata.set(CudaMetadataFields::kDevice, static_cast<int64_t>(memcpy.deviceId));
-  metadata.set(CudaMetadataFields::kContext, static_cast<int64_t>(memcpy.contextId));
-  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(memcpy.streamId));
-  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(memcpy.correlationId));
-  metadata.set(CudaMetadataFields::kBytes, static_cast<int64_t>(memcpy.bytes));
-  addBandwidthTypedMetadata(metadata, memcpy.bytes, duration());
-  addGraphNodeTypedMetadata(metadata, memcpy);
-  addChannelTypedMetadata(metadata, memcpy);
-  return metadata;
+  visitor.visit(CudaMetadataFields::kDevice, static_cast<int64_t>(memcpy.deviceId));
+  visitor.visit(CudaMetadataFields::kContext, static_cast<int64_t>(memcpy.contextId));
+  visitor.visit(CudaMetadataFields::kStream, static_cast<int64_t>(memcpy.streamId));
+  visitor.visit(CudaMetadataFields::kCorrelation, static_cast<int64_t>(memcpy.correlationId));
+  visitor.visit(CudaMetadataFields::kBytes, static_cast<int64_t>(memcpy.bytes));
+  addBandwidthTypedMetadata(visitor, memcpy.bytes, duration());
+  addGraphNodeTypedMetadata(visitor, memcpy);
+  addChannelTypedMetadata(visitor, memcpy);
 }
 
 template <>
@@ -741,22 +738,20 @@ inline const std::string GpuActivity<CUpti_ActivityMemcpyPtoPType>::metadataJson
 }
 
 template <>
-inline TypedMetadata GpuActivity<CUpti_ActivityMemcpyPtoPType>::typedMetadata() const {
+inline void GpuActivity<CUpti_ActivityMemcpyPtoPType>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   const CUpti_ActivityMemcpyPtoPType& memcpy = raw();
-  TypedMetadata metadata;
-  metadata.set(CudaMetadataFields::kFromDevice, static_cast<int64_t>(memcpy.srcDeviceId));
-  metadata.set(CudaMetadataFields::kInDevice, static_cast<int64_t>(memcpy.deviceId));
-  metadata.set(CudaMetadataFields::kToDevice, static_cast<int64_t>(memcpy.dstDeviceId));
-  metadata.set(CudaMetadataFields::kFromContext, static_cast<int64_t>(memcpy.srcContextId));
-  metadata.set(CudaMetadataFields::kInContext, static_cast<int64_t>(memcpy.contextId));
-  metadata.set(CudaMetadataFields::kToContext, static_cast<int64_t>(memcpy.dstContextId));
-  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(memcpy.streamId));
-  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(memcpy.correlationId));
-  metadata.set(CudaMetadataFields::kBytes, static_cast<int64_t>(memcpy.bytes));
-  addBandwidthTypedMetadata(metadata, memcpy.bytes, duration());
-  addGraphNodeTypedMetadata(metadata, memcpy);
-  addChannelTypedMetadata(metadata, memcpy);
-  return metadata;
+  visitor.visit(CudaMetadataFields::kFromDevice, static_cast<int64_t>(memcpy.srcDeviceId));
+  visitor.visit(CudaMetadataFields::kInDevice, static_cast<int64_t>(memcpy.deviceId));
+  visitor.visit(CudaMetadataFields::kToDevice, static_cast<int64_t>(memcpy.dstDeviceId));
+  visitor.visit(CudaMetadataFields::kFromContext, static_cast<int64_t>(memcpy.srcContextId));
+  visitor.visit(CudaMetadataFields::kInContext, static_cast<int64_t>(memcpy.contextId));
+  visitor.visit(CudaMetadataFields::kToContext, static_cast<int64_t>(memcpy.dstContextId));
+  visitor.visit(CudaMetadataFields::kStream, static_cast<int64_t>(memcpy.streamId));
+  visitor.visit(CudaMetadataFields::kCorrelation, static_cast<int64_t>(memcpy.correlationId));
+  visitor.visit(CudaMetadataFields::kBytes, static_cast<int64_t>(memcpy.bytes));
+  addBandwidthTypedMetadata(visitor, memcpy.bytes, duration());
+  addGraphNodeTypedMetadata(visitor, memcpy);
+  addChannelTypedMetadata(visitor, memcpy);
 }
 
 template <>
@@ -787,18 +782,16 @@ inline const std::string GpuActivity<CUpti_ActivityMemsetType>::metadataJson() c
 }
 
 template <>
-inline TypedMetadata GpuActivity<CUpti_ActivityMemsetType>::typedMetadata() const {
+inline void GpuActivity<CUpti_ActivityMemsetType>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   const CUpti_ActivityMemsetType& memset = raw();
-  TypedMetadata metadata;
-  metadata.set(CudaMetadataFields::kDevice, static_cast<int64_t>(memset.deviceId));
-  metadata.set(CudaMetadataFields::kContext, static_cast<int64_t>(memset.contextId));
-  metadata.set(CudaMetadataFields::kStream, static_cast<int64_t>(memset.streamId));
-  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(memset.correlationId));
-  metadata.set(CudaMetadataFields::kBytes, static_cast<int64_t>(memset.bytes));
-  addBandwidthTypedMetadata(metadata, memset.bytes, duration());
-  addGraphNodeTypedMetadata(metadata, memset);
-  addChannelTypedMetadata(metadata, memset);
-  return metadata;
+  visitor.visit(CudaMetadataFields::kDevice, static_cast<int64_t>(memset.deviceId));
+  visitor.visit(CudaMetadataFields::kContext, static_cast<int64_t>(memset.contextId));
+  visitor.visit(CudaMetadataFields::kStream, static_cast<int64_t>(memset.streamId));
+  visitor.visit(CudaMetadataFields::kCorrelation, static_cast<int64_t>(memset.correlationId));
+  visitor.visit(CudaMetadataFields::kBytes, static_cast<int64_t>(memset.bytes));
+  addBandwidthTypedMetadata(visitor, memset.bytes, duration());
+  addGraphNodeTypedMetadata(visitor, memset);
+  addChannelTypedMetadata(visitor, memset);
 }
 
 inline void RuntimeActivity::log(ActivityLogger& logger) const {
@@ -821,9 +814,7 @@ inline const std::string OverheadActivity::metadataJson() const {
   return "";
 }
 
-inline TypedMetadata OverheadActivity::typedMetadata() const {
-  return {};
-}
+inline void OverheadActivity::visitTypedMetadata([[maybe_unused]] ITypedMetadataVisitor& visitor) const {}
 
 inline bool RuntimeActivity::flowStart() const {
   return CuptiCbidRegistry::instance().requiresFlowCorrelation(CallbackDomain::RUNTIME, activity_.cbid);
@@ -837,11 +828,9 @@ inline const std::string RuntimeActivity::metadataJson() const {
       activity_.correlationId);
 }
 
-inline TypedMetadata RuntimeActivity::typedMetadata() const {
-  TypedMetadata metadata;
-  metadata.set(CudaMetadataFields::kCbid, static_cast<int64_t>(activity_.cbid));
-  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(activity_.correlationId));
-  return metadata;
+inline void RuntimeActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
+  visitor.visit(CudaMetadataFields::kCbid, static_cast<int64_t>(activity_.cbid));
+  visitor.visit(CudaMetadataFields::kCorrelation, static_cast<int64_t>(activity_.correlationId));
 }
 
 inline bool isTrackedDriverCbid(const CUpti_ActivityAPI& activity_) {
@@ -860,11 +849,9 @@ inline const std::string DriverActivity::metadataJson() const {
       activity_.correlationId);
 }
 
-inline TypedMetadata DriverActivity::typedMetadata() const {
-  TypedMetadata metadata;
-  metadata.set(CudaMetadataFields::kCbid, static_cast<int64_t>(activity_.cbid));
-  metadata.set(CudaMetadataFields::kCorrelation, static_cast<int64_t>(activity_.correlationId));
-  return metadata;
+inline void DriverActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
+  visitor.visit(CudaMetadataFields::kCbid, static_cast<int64_t>(activity_.cbid));
+  visitor.visit(CudaMetadataFields::kCorrelation, static_cast<int64_t>(activity_.correlationId));
 }
 
 inline const std::string DriverActivity::name() const {
@@ -877,8 +864,6 @@ inline const std::string GpuActivity<T>::metadataJson() const {
 }
 
 template <class T>
-inline TypedMetadata GpuActivity<T>::typedMetadata() const {
-  return {};
-}
+inline void GpuActivity<T>::visitTypedMetadata([[maybe_unused]] ITypedMetadataVisitor& visitor) const {}
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/RocprofActivity.h
+++ b/libkineto/src/RocprofActivity.h
@@ -111,7 +111,7 @@ struct GpuActivity : public RocprofActivity<rocprofAsyncRow> {
   const std::string name() const override;
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
-  TypedMetadata typedMetadata() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
 
   // Add small buffer to fix visual error created by
   // https://github.com/ROCm/rocprof/issues/105 Once this is resolved we can
@@ -150,7 +150,7 @@ struct RuntimeActivity : public RocprofActivity<T> {
   }
   void log(ActivityLogger& logger) const override;
   const std::string metadataJson() const override;
-  TypedMetadata typedMetadata() const override;
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override;
   const T& raw() const {
     return RocprofActivity<T>::raw();
   }

--- a/libkineto/src/RocprofActivity_inl.h
+++ b/libkineto/src/RocprofActivity_inl.h
@@ -117,11 +117,11 @@ static inline std::string bandwidth(size_t bytes, uint64_t duration) {
   return duration == 0 ? "\"N/A\"" : fmt::format("{}", bytes * 1.0 / duration);
 }
 
-static inline void addBandwidthTypedMetadata(TypedMetadata& metadata, size_t bytes, uint64_t duration) {
+static inline void addBandwidthTypedMetadata(ITypedMetadataVisitor& visitor, size_t bytes, uint64_t duration) {
   if (duration == 0) {
     return;
   }
-  metadata.set(RocmMetadataFields::kMemoryBandwidthGbps, static_cast<double>(bytes) / static_cast<double>(duration));
+  visitor.visit(RocmMetadataFields::kMemoryBandwidthGbps, static_cast<double>(bytes) / static_cast<double>(duration));
 }
 
 inline const std::string GpuActivity::metadataJson() const {
@@ -164,32 +164,29 @@ inline const std::string GpuActivity::metadataJson() const {
   // clang-format on
 }
 
-inline TypedMetadata GpuActivity::typedMetadata() const {
+inline void GpuActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   const auto& gpuActivity = raw();
-  TypedMetadata metadata;
-  metadata.set(RocmMetadataFields::kDevice, static_cast<int64_t>(gpuActivity.device));
-  metadata.set(RocmMetadataFields::kStream, resourceId());
-  metadata.set(RocmMetadataFields::kHsaQueue, static_cast<int64_t>(gpuActivity.queue));
-  metadata.set(RocmMetadataFields::kCorrelation, static_cast<int64_t>(gpuActivity.id));
-  metadata.set(RocmMetadataFields::kKind, std::string{getGpuActivityKindString(gpuActivity.domain, gpuActivity.op)});
+  visitor.visit(RocmMetadataFields::kDevice, static_cast<int64_t>(gpuActivity.device));
+  visitor.visit(RocmMetadataFields::kStream, resourceId());
+  visitor.visit(RocmMetadataFields::kHsaQueue, static_cast<int64_t>(gpuActivity.queue));
+  visitor.visit(RocmMetadataFields::kCorrelation, static_cast<int64_t>(gpuActivity.id));
+  visitor.visit(RocmMetadataFields::kKind, std::string{getGpuActivityKindString(gpuActivity.domain, gpuActivity.op)});
 
   // if memcpy or memset, add size
   auto sizeIt = correlationToSize.find(gpuActivity.id);
   if (sizeIt != correlationToSize.end()) {
-    metadata.set(RocmMetadataFields::kBytes, static_cast<int64_t>(sizeIt->second));
-    addBandwidthTypedMetadata(metadata, sizeIt->second, gpuActivity.end - gpuActivity.begin);
-    return metadata;
+    visitor.visit(RocmMetadataFields::kBytes, static_cast<int64_t>(sizeIt->second));
+    addBandwidthTypedMetadata(visitor, sizeIt->second, gpuActivity.end - gpuActivity.begin);
+    return;
   }
 
   // if compute kernel, add grid and block
   auto gridIt = correlationToGrid.find(gpuActivity.id);
   auto blockIt = correlationToBlock.find(gpuActivity.id);
   if (gridIt != correlationToGrid.end() && blockIt != correlationToBlock.end()) {
-    metadata.set(RocmMetadataFields::kGrid, gridIt->second);
-    metadata.set(RocmMetadataFields::kBlock, blockIt->second);
+    visitor.visit(RocmMetadataFields::kGrid, gridIt->second);
+    visitor.visit(RocmMetadataFields::kBlock, blockIt->second);
   }
-
-  return metadata;
 }
 
 // Runtime Activities
@@ -252,24 +249,22 @@ inline const std::string RuntimeActivity<rocprofKernelRow>::metadataJson() const
 }
 
 template <>
-inline TypedMetadata RuntimeActivity<rocprofKernelRow>::typedMetadata() const {
-  TypedMetadata metadata;
+inline void RuntimeActivity<rocprofKernelRow>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   if ((raw().functionAddr != nullptr)) {
-    metadata.set(RocmMetadataFields::kKernel, demangle(hipKernelNameRefByPtr(raw().functionAddr, raw().stream)));
+    visitor.visit(RocmMetadataFields::kKernel, demangle(hipKernelNameRefByPtr(raw().functionAddr, raw().stream)));
   } else if ((raw().function != nullptr)) {
-    metadata.set(RocmMetadataFields::kKernel, demangle(hipKernelNameRef(raw().function)));
+    visitor.visit(RocmMetadataFields::kKernel, demangle(hipKernelNameRef(raw().function)));
   }
 
   // cache grid and block so we can pass it into async activity (GPU track)
   correlationToGrid[raw().id] = rocprofKernelGrid(raw());
   correlationToBlock[raw().id] = rocprofKernelBlock(raw());
 
-  metadata.set(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
-  metadata.set(RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
-  metadata.set(RocmMetadataFields::kGrid, correlationToGrid[raw().id]);
-  metadata.set(RocmMetadataFields::kBlock, correlationToBlock[raw().id]);
-  metadata.set(RocmMetadataFields::kSharedMemory, static_cast<int64_t>(raw().groupSegmentSize));
-  return metadata;
+  visitor.visit(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
+  visitor.visit(RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
+  visitor.visit(RocmMetadataFields::kGrid, correlationToGrid[raw().id]);
+  visitor.visit(RocmMetadataFields::kBlock, correlationToBlock[raw().id]);
+  visitor.visit(RocmMetadataFields::kSharedMemory, static_cast<int64_t>(raw().groupSegmentSize));
 }
 
 template <>
@@ -287,16 +282,14 @@ inline const std::string RuntimeActivity<rocprofCopyRow>::metadataJson() const {
 }
 
 template <>
-inline TypedMetadata RuntimeActivity<rocprofCopyRow>::typedMetadata() const {
-  TypedMetadata metadata;
+inline void RuntimeActivity<rocprofCopyRow>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   correlationToSize[raw().id] = raw().size;
-  metadata.set(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
-  metadata.set(RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
-  metadata.set(RocmMetadataFields::kSrc, fmt::format("{}", raw().src));
-  metadata.set(RocmMetadataFields::kDst, fmt::format("{}", raw().dst));
-  metadata.set(RocmMetadataFields::kBytes, static_cast<int64_t>(raw().size));
-  metadata.set(RocmMetadataFields::kKind, fmt::format("{}", fmt::underlying(raw().kind)));
-  return metadata;
+  visitor.visit(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
+  visitor.visit(RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
+  visitor.visit(RocmMetadataFields::kSrc, fmt::format("{}", raw().src));
+  visitor.visit(RocmMetadataFields::kDst, fmt::format("{}", raw().dst));
+  visitor.visit(RocmMetadataFields::kBytes, static_cast<int64_t>(raw().size));
+  visitor.visit(RocmMetadataFields::kKind, fmt::format("{}", fmt::underlying(raw().kind)));
 }
 
 template <>
@@ -319,16 +312,14 @@ inline const std::string RuntimeActivity<rocprofMallocRow>::metadataJson() const
 }
 
 template <>
-inline TypedMetadata RuntimeActivity<rocprofMallocRow>::typedMetadata() const {
-  TypedMetadata metadata;
+inline void RuntimeActivity<rocprofMallocRow>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   correlationToSize[raw().id] = raw().size;
   if (raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMalloc) {
-    metadata.set(RocmMetadataFields::kBytes, static_cast<int64_t>(raw().size));
+    visitor.visit(RocmMetadataFields::kBytes, static_cast<int64_t>(raw().size));
   }
-  metadata.set(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
-  metadata.set(RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
-  metadata.set(RocmMetadataFields::kPtr, fmt::format("{}", raw().ptr));
-  return metadata;
+  visitor.visit(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
+  visitor.visit(RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
+  visitor.visit(RocmMetadataFields::kPtr, fmt::format("{}", raw().ptr));
 }
 
 template <class T>
@@ -341,11 +332,9 @@ inline const std::string RuntimeActivity<T>::metadataJson() const {
 }
 
 template <class T>
-inline TypedMetadata RuntimeActivity<T>::typedMetadata() const {
-  TypedMetadata metadata;
-  metadata.set(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
-  metadata.set(RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
-  return metadata;
+inline void RuntimeActivity<T>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
+  visitor.visit(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
+  visitor.visit(RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -17,6 +17,9 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <map>
+#include <optional>
+#include <variant>
 
 #include <unistd.h>
 
@@ -83,6 +86,63 @@ void createTempTraceFile(char* filename) {
   ASSERT_GE(fd, 0) << "mkstemps failed for " << filename;
   close(fd);
 }
+
+using RecordedMetadataValue = std::variant<
+    int64_t,
+    double,
+    bool,
+    std::string,
+    std::vector<int64_t>,
+    std::vector<std::string>>;
+
+class RecordingTypedMetadataVisitor final : public ITypedMetadataVisitor {
+ public:
+  template <typename T>
+  [[nodiscard]]
+  std::optional<typename MetadataField<T>::FieldType> get(
+      const MetadataField<T>& field) const {
+    auto it = values_.find(std::string{field.name});
+    if (it == values_.end()) {
+      return std::nullopt;
+    }
+    return std::get<typename MetadataField<T>::FieldType>(it->second);
+  }
+
+ private:
+  void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitValue(const MetadataField<double>& field, double value) override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitValue(const MetadataField<bool>& field, bool value) override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitValue(
+      const MetadataField<std::string>& field,
+      std::string_view value) override {
+    values_[std::string{field.name}] = std::string{value};
+  }
+
+  void visitValue(
+      const MetadataField<std::vector<int64_t>>& field,
+      const std::vector<int64_t>& value) override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitValue(
+      const MetadataField<std::vector<std::string>>& field,
+      const std::vector<std::string>& value) override {
+    values_[std::string{field.name}] = value;
+  }
+
+  void visitUnsupported(std::string_view /*name*/) override {}
+
+  std::map<std::string, RecordedMetadataValue> values_;
+};
 } // namespace
 
 // Provides ability to easily create a few test CPU-side ops
@@ -591,7 +651,8 @@ TEST_F(CuptiActivityProfilerTest, SyncEventCorrIdOutOfOrder) {
           << "Stream Wait Event corr_id should be populated despite out-of-order records";
       EXPECT_EQ(json["wait_on_stream"], kEventStreamId)
           << "Stream Wait Event should reference stream the event was recorded on";
-      const auto typedMetadata = activity->typedMetadata();
+      RecordingTypedMetadataVisitor typedMetadata;
+      activity->visitTypedMetadata(typedMetadata);
       EXPECT_EQ(
           typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventId),
           static_cast<int64_t>(kEventId));
@@ -611,7 +672,8 @@ TEST_F(CuptiActivityProfilerTest, SyncEventCorrIdOutOfOrder) {
           << "Event Sync corr_id should be populated despite out-of-order records";
       EXPECT_EQ(json["wait_on_stream"], kEventStreamId)
           << "Event Sync should reference stream the event was recorded on";
-      const auto typedMetadata = activity->typedMetadata();
+      RecordingTypedMetadataVisitor typedMetadata;
+      activity->visitTypedMetadata(typedMetadata);
       EXPECT_EQ(
           typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventId),
           static_cast<int64_t>(kEventId));

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iterator>
+#include <optional>
 
 #include <unistd.h>
 
@@ -87,6 +88,37 @@ bool isAsyncCopy(const rocprofAsyncRow& async) {
 bool isAsyncKernel(const rocprofAsyncRow& async) {
   return async.domain == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH;
 }
+
+struct RocmStreamTypedMetadataVisitor final : public ITypedMetadataVisitor {
+  void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
+    if (field.name == RocmMetadataFields::kStream.name) {
+      stream = value;
+    } else if (field.name == RocmMetadataFields::kHsaQueue.name) {
+      hsaQueue = value;
+    }
+  }
+
+  void visitValue(
+      [[maybe_unused]] const MetadataField<double>& field,
+      [[maybe_unused]] double value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<bool>& field,
+      [[maybe_unused]] bool value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<std::string>& field,
+      [[maybe_unused]] std::string_view value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<std::vector<int64_t>>& field,
+      [[maybe_unused]] const std::vector<int64_t>& value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<std::vector<std::string>>& field,
+      [[maybe_unused]] const std::vector<std::string>& value) override {}
+
+  void visitUnsupported(std::string_view /*name*/) override {}
+
+  std::optional<int64_t> stream;
+  std::optional<int64_t> hsaQueue;
+};
 } // namespace
 
 // Provides ability to easily create a test CPU-side ops
@@ -462,15 +494,12 @@ TEST_F(RocmActivityProfilerTest, GpuTypedMetadataMatchesLegacyStreamMetadata) {
   ASSERT_NE(memcpyActivity, nullptr);
   EXPECT_EQ(memcpyActivity->resourceId(), 42);
 
-  const auto typedMetadata = memcpyActivity->typedMetadata();
+  RocmStreamTypedMetadataVisitor typedMetadata;
+  memcpyActivity->visitTypedMetadata(typedMetadata);
   const auto jsonMetadata =
       nlohmann::json::parse("{" + memcpyActivity->metadataJson() + "}");
-  EXPECT_EQ(
-      typedMetadata.get(RocmMetadataFields::kStream),
-      jsonMetadata["stream"].get<int64_t>());
-  EXPECT_EQ(
-      typedMetadata.get(RocmMetadataFields::kHsaQueue),
-      jsonMetadata["hsa_queue"].get<int64_t>());
+  EXPECT_EQ(typedMetadata.stream, jsonMetadata["stream"].get<int64_t>());
+  EXPECT_EQ(typedMetadata.hsaQueue, jsonMetadata["hsa_queue"].get<int64_t>());
 }
 
 TEST_F(

--- a/libkineto/test/TypedMetadataTest.cpp
+++ b/libkineto/test/TypedMetadataTest.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -20,56 +21,107 @@ using namespace libkineto;
 namespace {
 
 constexpr MetadataField<int64_t> kCount{"count"};
-constexpr MetadataField<int64_t> kMissing{"missing"};
 constexpr MetadataField<std::vector<int64_t>> kIds{"ids"};
 constexpr MetadataField<std::string> kLabel{"label"};
 constexpr MetadataField<double> kRatio{"ratio"};
 constexpr MetadataField<bool> kEnabled{"enabled"};
 constexpr MetadataField<std::vector<std::string>> kNames{"names"};
+constexpr MetadataField<std::pair<int64_t, int64_t>> kPair{"pair"};
+
+using RecordedValue = std::variant<
+    int64_t,
+    double,
+    bool,
+    std::string,
+    std::vector<int64_t>,
+    std::vector<std::string>>;
+
+class RecordingTypedMetadataVisitor : public ITypedMetadataVisitor {
+ public:
+  void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
+    record(field, value);
+  }
+
+  void visitValue(const MetadataField<double>& field, double value) override {
+    record(field, value);
+  }
+
+  void visitValue(const MetadataField<bool>& field, bool value) override {
+    record(field, value);
+  }
+
+  void visitValue(
+      const MetadataField<std::string>& field,
+      std::string_view value) override {
+    record(field, std::string{value});
+  }
+
+  void visitValue(
+      const MetadataField<std::vector<int64_t>>& field,
+      const std::vector<int64_t>& value) override {
+    record(field, value);
+  }
+
+  void visitValue(
+      const MetadataField<std::vector<std::string>>& field,
+      const std::vector<std::string>& value) override {
+    record(field, value);
+  }
+
+  void visitUnsupported(std::string_view /*name*/) override {}
+
+  std::map<std::string, RecordedValue> values;
+
+ private:
+  template <typename T>
+  void record(const MetadataField<T>& field, RecordedValue value) {
+    values[std::string{field.name}] = std::move(value);
+  }
+};
+
+class UnsupportedRecordingTypedMetadataVisitor final
+    : public RecordingTypedMetadataVisitor {
+ public:
+  void visitUnsupported(std::string_view name) override {
+    unsupportedFields.emplace_back(name);
+  }
+
+  std::vector<std::string> unsupportedFields;
+};
 
 } // namespace
 
-TEST(TypedMetadataTest, StoresAndRetrievesTypedValues) {
-  TypedMetadata metadata;
-  metadata.set(kCount, int64_t{5});
-  metadata.set(kIds, std::vector<int64_t>{1, 2});
-  metadata.set(kLabel, std::string{"label"});
-  metadata.set(kRatio, 1.5);
-  metadata.set(kEnabled, true);
-  metadata.set(kNames, std::vector<std::string>{"a", "b"});
+TEST(TypedMetadataVisitorTest, VisitsTypedFields) {
+  RecordingTypedMetadataVisitor recorder;
+  ITypedMetadataVisitor& visitor = recorder;
 
-  EXPECT_FALSE(metadata.empty());
-  EXPECT_EQ(metadata.get(kCount), int64_t{5});
-  EXPECT_EQ(metadata.get(kIds), std::vector<int64_t>({1, 2}));
-  EXPECT_EQ(metadata.get(kLabel), std::string{"label"});
-  EXPECT_EQ(metadata.get(kRatio), 1.5);
-  EXPECT_EQ(metadata.get(kEnabled), true);
-  EXPECT_EQ(metadata.get(kNames), std::vector<std::string>({"a", "b"}));
-  EXPECT_FALSE(metadata.get(kMissing).has_value());
+  visitor.visit(kCount, int64_t{5});
+  visitor.visit(kIds, std::vector<int64_t>{1, 2});
+  visitor.visit(kLabel, std::string{"label"});
+  visitor.visit(kRatio, 1.5);
+  visitor.visit(kEnabled, true);
+  visitor.visit(kNames, std::vector<std::string>{"a", "b"});
 
-  auto raw = metadata.get("count");
-  ASSERT_TRUE(raw.has_value());
-  EXPECT_EQ(std::get<int64_t>(*raw), int64_t{5});
+  EXPECT_EQ(std::get<int64_t>(recorder.values.at("count")), int64_t{5});
+  EXPECT_EQ(
+      std::get<std::vector<int64_t>>(recorder.values.at("ids")),
+      std::vector<int64_t>({1, 2}));
+  EXPECT_EQ(
+      std::get<std::string>(recorder.values.at("label")), std::string{"label"});
+  EXPECT_EQ(std::get<double>(recorder.values.at("ratio")), 1.5);
+  EXPECT_EQ(std::get<bool>(recorder.values.at("enabled")), true);
+  EXPECT_EQ(
+      std::get<std::vector<std::string>>(recorder.values.at("names")),
+      std::vector<std::string>({"a", "b"}));
 }
 
-TEST(TypedMetadataTest, VisitsStoredValuesByName) {
-  TypedMetadata metadata;
-  metadata.set(kCount, int64_t{5});
-  metadata.set(kLabel, std::string{"label"});
+TEST(TypedMetadataVisitorTest, FallsBackToVisitUnsupported) {
+  UnsupportedRecordingTypedMetadataVisitor recorder;
+  ITypedMetadataVisitor& visitor = recorder;
 
-  std::map<std::string, TypedValue> values;
-  metadata.visit([&](std::string_view name, const TypedValue& value) {
-    values.emplace(std::string{name}, value);
-  });
+  visitor.visit(kCount, int64_t{5});
+  visitor.visit(kPair, std::pair<int64_t, int64_t>{1, 2});
 
-  EXPECT_EQ(std::get<int64_t>(values.at("count")), int64_t{5});
-  EXPECT_EQ(std::get<std::string>(values.at("label")), std::string{"label"});
-}
-
-TEST(TypedMetadataTest, OverwritesDuplicateFields) {
-  TypedMetadata metadata;
-  metadata.set(kCount, int64_t{5});
-  metadata.set(kCount, int64_t{6});
-
-  EXPECT_EQ(metadata.get(kCount), int64_t{6});
+  EXPECT_EQ(std::get<int64_t>(recorder.values.at("count")), int64_t{5});
+  EXPECT_EQ(recorder.unsupportedFields, std::vector<std::string>({"pair"}));
 }


### PR DESCRIPTION
Summary:
I was implementing JSON serialization from TypedMetadata to make progress towards our target of being able to add a new `MetadataField` to Kineto and have it reflect in all of our outputs. However when I benchmarked the results, I found that the JSON took ~1.5x longer to write that before, and the primary contributor to this was building the `TypedMetadata` struct on every `metadataJson()` call.

Realistically there's no reason why we need to build a new struct every time we call `typedMetadata()`, and to be honest we probably don't even need to materialize it ever. One option is to make `typedMetadata` a visitor method instead.

===============

The general idea is:

On `ITraceActivity.h`, replacing `typedMetadata()`
```
virtual void visitTypedMetadata(ITypedMetadataVisitor& visitor)
```

`ITypedMetadataVisitor` is an interface containing `visitValue` methods.

```
class  {
 public:
  virtual ~ITypedMetadataVisitor() = default;

  template <typename T, typename V>
  void visit(const MetadataField<T>& field, V&& value) {
    using FieldType = typename MetadataField<T>::FieldType;
    static_assert(std::is_same_v<FieldType, std::decay_t<V>>, "value type must match field's declared type");
    visitValue(field, value);
  }

 protected:
  // Overridable fallback for logging if someone introduces a new type
  virtual void visitUnsupported(std::string_view /*name*/) {}

  template <typename T>
  void visitValue(const MetadataField<T>& field, const T& /*value*/) {
    visitUnsupported(field.name);
  }

  void visitValue(const MetadataField<std::string>& field, const std::string& value) {
    visitValue(field, std::string_view{value});
  }

  virtual void visitValue(const MetadataField<int64_t>& field, int64_t value) = 0;

  // For each supported type
  ...
};
```

For each output type (JSON, Protobuf, .events), they implement a new `ITypedMetadataVisitor` class which handles their specific case. For JSON, this means that each `visitValue` would handle serialization for that type to a JSON string and appending it to the `metadataJson` output.

`visitTypedMetadata` is implemented by calling .visit on each `MetadataField` + Value pair.

```
inline void CudaEventActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
  const CUpti_ActivityCudaEventType& event = raw();
  visitor.visit(CudaMetadataFields::kEventId, static_cast<int64_t>(event.eventId));
  visitor.visit(CudaMetadataFields::kStream, static_cast<int64_t>(streamIdForTrace(event.streamId)));
  visitor.visit(CudaMetadataFields::kCorrelation, static_cast<int64_t>(event.correlationId));
  visitor.visit(CudaMetadataFields::kDevice, deviceId());
  visitor.visit(CudaMetadataFields::kContext, static_cast<int64_t>(event.contextId));
}
```

So there is no longer any materialization.

Reviewed By: scotts

Differential Revision: D109168373


