### PR TITLE
Add a visitor class for JSON serialization

### DIFF
--- a/libkineto/include/TypedMetadataJson.h
+++ b/libkineto/include/TypedMetadataJson.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "TypedMetadata.h"
+
+#include <fmt/format.h>
+
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// Migration-only typed metadata -> metadataJson compatibility helpers.
+//
+// These helpers preserve legacy metadataJson formatting while Kineto producers
+// are migrated to typed metadata. Eventually, we want to decouple metadataJson
+// from ITraceActivity and rely only on typed metadata as the canonical Kineto
+// metadata output. We use these helpers to reduce the risk of drift during
+// migration.
+//
+// IMPORTANT: This file may change or go away once metadataJson is no longer
+// needed as an ITraceActivity output.
+
+namespace libkineto::internal {
+
+class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
+ public:
+  JsonTypedMetadataVisitor() {
+    json_.reserve(kInitialJsonCapacity);
+  }
+
+  [[nodiscard]] std::string json() && {
+    return std::move(json_);
+  }
+
+ private:
+  // Sized to hold the largest common CUDA activity (kernels) in one allocation, with some buffer
+  static constexpr size_t kInitialJsonCapacity = 1024;
+
+  // Widest int64_t is "-9223372036854775808" (20 chars)
+  static constexpr size_t kMaxInt64Chars = 20;
+
+  void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
+    appendField(field, [&](std::string& json) { appendIntValue(json, value); });
+  }
+
+  void visitValue(const MetadataField<double>& field, double value) override {
+    appendField(field, [&](std::string& json) { appendDoubleValue(json, value); });
+  }
+
+  void visitValue(const MetadataField<bool>& field, bool value) override {
+    appendField(field, [&](std::string& json) { json += value ? "true" : "false"; });
+  }
+
+  void visitValue(const MetadataField<std::string>& field, std::string_view value) override {
+    appendField(field, [&](std::string& json) { appendQuoted(json, value); });
+  }
+
+  void visitValue(const MetadataField<std::vector<int64_t>>& field, const std::vector<int64_t>& value) override {
+    appendField(field, [&](std::string& json) { appendArray(json, value); });
+  }
+
+  void visitValue(const MetadataField<std::vector<std::string>>& field,
+                  const std::vector<std::string>& value) override {
+    appendField(field, [&](std::string& json) { appendArray(json, value); });
+  }
+
+  // Emit a visible placeholder rather than silently dropping a metadata type
+  // the JSON serializer doesn't handle, so the gap shows up in the trace.
+  void visitUnsupported(std::string_view name) override {
+    appendKey(json_, name);
+    appendQuoted(json_, "<unsupported metadata type>");
+  }
+
+  template <typename T, typename WriteValue>
+  void appendField(const MetadataField<T>& field, WriteValue writeValue) {
+    appendKey(json_, field.name);
+    writeValue(json_);
+  }
+
+  static void appendKey(std::string& json, std::string_view key) {
+    if (!json.empty()) {
+      json += ", ";
+    }
+    appendQuoted(json, key);
+    json += ": ";
+  }
+
+  static void appendQuoted(std::string& json, std::string_view value) {
+    json += '"';
+    json += value;
+    json += '"';
+  }
+
+  static void appendIntValue(std::string& json, int64_t value) {
+    char buf[kMaxInt64Chars];
+    const auto result = std::to_chars(buf, buf + sizeof(buf), value);
+    json.append(buf, static_cast<size_t>(result.ptr - buf));
+  }
+
+  static void appendDoubleValue(std::string& json, double value) {
+    if (std::isfinite(value)) {
+      fmt::format_to(std::back_inserter(json), "{}", value);
+      return;
+    }
+    appendQuoted(json, fmt::format("{}", value));
+  }
+
+  template <typename T>
+  static void appendArray(std::string& json, const std::vector<T>& values) {
+    json += '[';
+    bool first = true;
+    for (const auto& value : values) {
+      if (!first) {
+        json += ", ";
+      }
+      appendArrayValue(json, value);
+      first = false;
+    }
+    json += ']';
+  }
+
+  static void appendArrayValue(std::string& json, int64_t value) {
+    appendIntValue(json, value);
+  }
+
+  static void appendArrayValue(std::string& json, const std::string& value) {
+    appendQuoted(json, value);
+  }
+
+  std::string json_;
+};
+
+} // namespace libkineto::internal

--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -88,6 +88,7 @@ def get_libkineto_public_headers():
         "include/TraceSpan.h",
         "include/ThreadUtil.h",
         "include/TypedMetadata.h",
+        "include/TypedMetadataJson.h",
         "include/libkineto.h",
         "include/time_since_epoch.h",
         "include/output_base.h",

--- a/libkineto/test/TypedMetadataTest.cpp
+++ b/libkineto/test/TypedMetadataTest.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "include/TypedMetadata.h"
+#include "include/TypedMetadataJson.h"
 
 #include <gtest/gtest.h>
 #include <map>
@@ -27,6 +28,7 @@ constexpr MetadataField<double> kRatio{"ratio"};
 constexpr MetadataField<bool> kEnabled{"enabled"};
 constexpr MetadataField<std::vector<std::string>> kNames{"names"};
 constexpr MetadataField<std::pair<int64_t, int64_t>> kPair{"pair"};
+constexpr MetadataField<std::string> kSpecialChars{"special"};
 
 using RecordedValue = std::variant<
     int64_t,
@@ -113,6 +115,33 @@ TEST(TypedMetadataVisitorTest, VisitsTypedFields) {
   EXPECT_EQ(
       std::get<std::vector<std::string>>(recorder.values.at("names")),
       std::vector<std::string>({"a", "b"}));
+}
+
+TEST(TypedMetadataVisitorTest, SerializesVisitedFieldsToJson) {
+  internal::JsonTypedMetadataVisitor jsonVisitor;
+  ITypedMetadataVisitor& visitor = jsonVisitor;
+
+  visitor.visit(kCount, int64_t{5});
+  visitor.visit(kIds, std::vector<int64_t>{1, 2});
+  visitor.visit(kLabel, std::string{"label"});
+  visitor.visit(kRatio, 1.5);
+  visitor.visit(kEnabled, true);
+  visitor.visit(kNames, std::vector<std::string>{"a", "b"});
+  visitor.visit(kSpecialChars, std::string{"quote \" slash \\ newline\n"});
+
+  const auto json = std::move(jsonVisitor).json();
+
+  EXPECT_NE(json.find("\"count\": 5"), std::string::npos);
+  EXPECT_NE(json.find("\"ids\": [1, 2]"), std::string::npos);
+  EXPECT_NE(json.find("\"label\": \"label\""), std::string::npos);
+  EXPECT_NE(json.find("\"ratio\": 1.5"), std::string::npos);
+  EXPECT_NE(json.find("\"enabled\": true"), std::string::npos);
+  EXPECT_NE(json.find("\"names\": [\"a\", \"b\"]"), std::string::npos);
+  // String values pass through verbatim; output_json.cpp sanitizes the full
+  // metadata fragment before appending it to the Chrome trace.
+  EXPECT_NE(
+      json.find("\"special\": \"quote \" slash \\ newline\n\""),
+      std::string::npos);
 }
 
 TEST(TypedMetadataVisitorTest, FallsBackToVisitUnsupported) {


### PR DESCRIPTION
Summary:
As titled, this will enable us to use the visitor class to create `metadataJson` without custom string handling for every `ITraceActivity`. This is in the `include` directory because I need to use it in `GenericTraceActivity.h`.

Each override handles a different data type -> JSON string case.

Reviewed By: scotts

Differential Revision: D109171413


