### PR TITLE
[CI] Deselect XPU-failing TestProfilerDevice CPU tests

### DIFF
--- a/.github/scripts/config_xpu.sh
+++ b/.github/scripts/config_xpu.sh
@@ -56,4 +56,19 @@ KINETO_USE_SCCACHE=0
 # shellcheck disable=SC2034
 DESELECTED_TESTS=(
   test/profiler/test_profiler.py::TestExperimentalUtils::test_fuzz_symbolize
+
+  # https://github.com/pytorch/kineto/issues/1429
+  # Moved into the device-parametrized TestProfilerDevice by pytorch/pytorch#182434.
+  # fork-after-init: re-initializing XPU in a forked subprocess raises
+  # "Cannot re-initialize XPU in forked subprocess". Independent of runtime XPU
+  # availability and already deselected for CUDA and ROCm.
+  test/profiler/test_profiler.py::TestProfilerDeviceCPU::test_forked_process_cpu
+
+  # https://github.com/pytorch/kineto/issues/1429
+  # _validate_basic_json indexes traceEvents[-4] expecting the "PyTorch Profiler (0)"
+  # event, but a USE_XPU=1 build appends a second "__xpu_profiler__ (0)" instance to
+  # the trace, shifting that fixed offset. Caused by XPU being built (not by runtime
+  # availability), so it fails on this runner like the CPU-variant does here.
+  # Tracked for an upstream fix that locates the events by name instead of by offset.
+  test/profiler/test_profiler.py::TestProfilerDeviceCPU::test_basic_chrome_trace_cpu
 )


### PR DESCRIPTION
## Problem

`linux_xpu_pytorch.yml` has been red on `main`. The job builds PyTorch (`USE_XPU=1`) and runs `test/profiler/`. Two CPU-variant tests from the device-parametrized `TestProfilerDevice` (added in pytorch/pytorch#182434) fail and were never deselected for XPU, unlike CUDA/ROCm (#1429).

## What fails and why (verified on PVC with an XPU device present)

- **`test_forked_process_cpu`** — `RuntimeError: Cannot re-initialize XPU in forked subprocess`. Independent of runtime XPU availability (it also fails with an XPU device present); already deselected on CUDA and ROCm.
- **`test_basic_chrome_trace_cpu`** — `_validate_basic_json` indexes `traceEvents[-4]` expecting the `"PyTorch Profiler (0)"` event, but a `USE_XPU=1` build appends a second `"__xpu_profiler__ (0)"` instance to the trace, shifting that fixed offset. Caused by XPU being *built*, not by runtime availability. An upstream fix to locate the events by name instead of by offset is tracked separately; deselecting until it lands.

## Relationship to #1450

Orthogonal. #1450 fixes runtime XPU visibility (`umf`/`tcm` env sourcing); this PR fixes the two build-dependent test failures. Both are needed for the workflow to go green.

Note: `test_kineto_profiler_with_environment_variable_cpu` is intentionally **not** deselected here — it passes once XPU is available at runtime (covered by #1450).
