### PR TITLE
Escape LOG messages in output_json.cpp (#1453)

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -65,6 +65,14 @@ void sanitizeStrForJSON(std::string& value) {
   std::erase(value, '\n');
 }
 
+// Free-form log strings: drop control chars, replace backslashes and double
+// quotes
+void sanitizeLogStrForJSON(std::string& value) {
+  std::erase_if(value, [](unsigned char c) { return c < 0x20; });
+  std::ranges::replace(value, '\\', '/');
+  std::ranges::replace(value, '"', '\'');
+}
+
 std::string string2hex(const std::string& str) {
   std::string out;
   out.reserve(str.size() * 2);
@@ -1002,30 +1010,34 @@ void ChromeTraceLogger::finalizeTrace(
   }
 
 #if !USE_GOOGLE_LOG
-  std::unordered_map<std::string, std::string> preparedMetadata;
   for (const auto& kv : metadata) {
     // Skip empty log buckets, ex. skip ERROR if its empty.
-    if (!kv.second.empty()) {
-      std::string value = "[";
-      // Ex. Each metadata from logger is a list of strings, expressed in JSON
-      // as
-      //   "ERROR": ["Error 1", "Error 2"],
-      //   "WARNING": ["Warning 1", "Warning 2", "Warning 3"],
-      //   ...
-      int mdv_count = kv.second.size();
-      for (auto v : kv.second) {
-        sanitizeStrForJSON(v);
-        value.append("\"" + v + "\"");
-        if (mdv_count > 1) {
-          value.append(",");
-          mdv_count--;
-        }
-      }
-      value.append("]");
-      preparedMetadata[kv.first] = value;
+    if (kv.second.empty()) {
+      continue;
     }
+    std::string value = "[";
+    // Ex. Each metadata from logger is a list of strings, expressed in JSON
+    // as
+    //   "ERROR": ["Error 1", "Error 2"],
+    //   "WARNING": ["Warning 1", "Warning 2", "Warning 3"],
+    //   ...
+    size_t mdv_count = kv.second.size();
+    for (auto v : kv.second) {
+      sanitizeLogStrForJSON(v);
+      value.append("\"" + v + "\"");
+      if (mdv_count > 1) {
+        value.append(",");
+        mdv_count--;
+      }
+    }
+    value.append("]");
+    fmt::print(
+        traceOf_,
+        R"JSON(
+      "{}": {},)JSON",
+        kv.first,
+        value);
   }
-  metadataToJSON(preparedMetadata);
 #endif // !USE_GOOGLE_LOG
 
   // The last entry MUST NOT end with a comma.

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -128,3 +128,11 @@ target_link_libraries(PidInfoTest PRIVATE
     kineto_base kineto_api
     ${XPU_XPUPTI_LIBRARY})
 gtest_discover_tests(PidInfoTest)
+
+# OutputJsonTest
+add_executable(OutputJsonTest OutputJsonTest.cpp)
+target_link_libraries(OutputJsonTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(OutputJsonTest)

--- a/libkineto/test/OutputJsonTest.cpp
+++ b/libkineto/test/OutputJsonTest.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "include/Config.h"
+#include "src/output_json.h"
+
+#include <gtest/gtest.h>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace KINETO_NAMESPACE;
+
+namespace {
+// Emit a trace carrying a single WARNING log string and return the file text.
+std::string traceWithWarning(const std::string& warning) {
+  const std::string path =
+      ::testing::TempDir() + "kineto_output_json_test.json";
+  ChromeTraceLogger logger(path);
+  logger.handleTraceStart({}, /*device_properties=*/"");
+  std::unordered_map<std::string, std::vector<std::string>> metadata;
+  metadata["WARNING"] = {warning};
+  Config config;
+  logger.finalizeTrace(config, /*buffers=*/nullptr, /*endTime=*/1000, metadata);
+
+  std::ifstream f(path);
+  std::stringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+} // namespace
+
+TEST(OutputJsonTest, NeutralizesQuotesInLogStrings) {
+  const std::string out = traceWithWarning(R"(trace_id not hex: "abc")");
+  EXPECT_NE(out.find("trace_id not hex: 'abc'"), std::string::npos);
+}
+
+TEST(OutputJsonTest, DropsControlCharsInLogStrings) {
+  const std::string out = traceWithWarning("abc\tdef\rghi\n");
+  EXPECT_NE(out.find("abcdefghi"), std::string::npos);
+}


### PR DESCRIPTION
Summary:

This was news to me, but we write `LOG(WARNING)`/`LOG(ERROR)` messages to JSON in output_json.cpp if `USE_GOOGLE_LOG` is false/not defined. I suppose this can be used downstream but recently users were running into issues where a new LOG message emitted a double quote which we don't sanitize out, leading to invalid JSON.

Since LOG messages can be arbitrary strings, we'll add some more sanitization for them.

Differential Revision: D109399315


