### PR TITLE
Add MetadataDict for nested metadata fields (#1454)

### DIFF
--- a/libkineto/include/TypedMetadata.h
+++ b/libkineto/include/TypedMetadata.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -20,6 +21,10 @@ template <typename T>
 struct MetadataField {
   using FieldType = T;
 
+  std::string_view name;
+};
+
+struct MetadataDict {
   std::string_view name;
 };
 
@@ -57,7 +62,22 @@ class ITypedMetadataVisitor {
     visitValue(field, value);
   }
 
+  // Visits a nested dict: everything `visitChildren` visits is grouped under
+  // dict.name. Example:
+  // visitor.visit(kStats, [](auto& d) { d.visit(kCount, int64_t{1}); });
+  void visit(const MetadataDict& dict, std::invocable<ITypedMetadataVisitor&> auto&& visitChildren) {
+    beginDict(dict.name);
+    visitChildren(*this);
+    endDict();
+  }
+
  protected:
+  // beginDict/endDict bracket a nested dict and are always invoked as a
+  // pair by visit(MetadataDict, ...), with the dict's children visited in
+  // between.
+  virtual void beginDict(std::string_view name) = 0;
+  virtual void endDict() = 0;
+
   virtual void visitUnsupported(std::string_view name) = 0;
 
   template <typename T>

--- a/libkineto/include/TypedMetadataJson.h
+++ b/libkineto/include/TypedMetadataJson.h
@@ -79,22 +79,34 @@ class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
   // Emit a visible placeholder rather than silently dropping a metadata type
   // the JSON serializer doesn't handle, so the gap shows up in the trace.
   void visitUnsupported(std::string_view name) override {
-    appendKey(json_, name);
+    appendKey(name);
     appendQuoted(json_, "<unsupported metadata type>");
+  }
+
+  void beginDict(std::string_view name) override {
+    appendKey(name);
+    json_ += '{';
+    firstEntry_ = true;
+  }
+
+  void endDict() override {
+    json_ += '}';
+    firstEntry_ = false;
   }
 
   template <typename T, typename WriteValue>
   void appendField(const MetadataField<T>& field, WriteValue writeValue) {
-    appendKey(json_, field.name);
+    appendKey(field.name);
     writeValue(json_);
   }
 
-  static void appendKey(std::string& json, std::string_view key) {
-    if (!json.empty()) {
-      json += ", ";
+  void appendKey(std::string_view key) {
+    if (!firstEntry_) {
+      json_ += ", ";
     }
-    appendQuoted(json, key);
-    json += ": ";
+    firstEntry_ = false;
+    appendQuoted(json_, key);
+    json_ += ": ";
   }
 
   static void appendQuoted(std::string& json, std::string_view value) {
@@ -140,6 +152,7 @@ class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
   }
 
   std::string json_;
+  bool firstEntry_ = true;
 };
 
 } // namespace libkineto::internal

--- a/libkineto/src/CudaMetadataFields.h
+++ b/libkineto/src/CudaMetadataFields.h
@@ -15,6 +15,7 @@
 #include "TypedMetadata.h"
 
 namespace libkineto::CudaMetadataFields {
+inline constexpr MetadataDict kOccupancy{"occupancy"};
 inline constexpr MetadataField<int64_t> kActiveBlocksPerMultiprocessor{"activeBlocksPerMultiprocessor"};
 inline constexpr MetadataField<int64_t> kAllocatedRegistersPerBlock{"allocatedRegistersPerBlock"};
 inline constexpr MetadataField<int64_t> kAllocatedSharedMemPerBlock{"allocatedSharedMemPerBlock"};

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -642,18 +642,20 @@ inline void GpuActivity<CUpti_ActivityKernelType>::visitTypedMetadata(ITypedMeta
                                      static_cast<int64_t>(kernel.blockZ)});
   visitor.visit(CudaMetadataFields::kEstAchievedOccupancyPercent,
                 static_cast<int64_t>(std::lround(occMetrics.occupancy * 100.0)));
-  visitor.visit(CudaMetadataFields::kActiveBlocksPerMultiprocessor,
-                static_cast<int64_t>(occMetrics.result.activeBlocksPerMultiprocessor));
-  visitor.visit(CudaMetadataFields::kLimitingFactors, limitingFactorsToString(occMetrics.result.limitingFactors));
-  visitor.visit(CudaMetadataFields::kBlockLimitRegs, static_cast<int64_t>(occMetrics.result.blockLimitRegs));
-  visitor.visit(CudaMetadataFields::kBlockLimitSharedMem, static_cast<int64_t>(occMetrics.result.blockLimitSharedMem));
-  visitor.visit(CudaMetadataFields::kBlockLimitWarps, static_cast<int64_t>(occMetrics.result.blockLimitWarps));
-  visitor.visit(CudaMetadataFields::kBlockLimitBlocks, static_cast<int64_t>(occMetrics.result.blockLimitBlocks));
-  visitor.visit(CudaMetadataFields::kBlockLimitBarriers, static_cast<int64_t>(occMetrics.result.blockLimitBarriers));
-  visitor.visit(CudaMetadataFields::kAllocatedRegistersPerBlock,
-                static_cast<int64_t>(occMetrics.result.allocatedRegistersPerBlock));
-  visitor.visit(CudaMetadataFields::kAllocatedSharedMemPerBlock,
-                static_cast<int64_t>(occMetrics.result.allocatedSharedMemPerBlock));
+  visitor.visit(CudaMetadataFields::kOccupancy, [&](auto& d) {
+    d.visit(CudaMetadataFields::kActiveBlocksPerMultiprocessor,
+            static_cast<int64_t>(occMetrics.result.activeBlocksPerMultiprocessor));
+    d.visit(CudaMetadataFields::kLimitingFactors, limitingFactorsToString(occMetrics.result.limitingFactors));
+    d.visit(CudaMetadataFields::kBlockLimitRegs, static_cast<int64_t>(occMetrics.result.blockLimitRegs));
+    d.visit(CudaMetadataFields::kBlockLimitSharedMem, static_cast<int64_t>(occMetrics.result.blockLimitSharedMem));
+    d.visit(CudaMetadataFields::kBlockLimitWarps, static_cast<int64_t>(occMetrics.result.blockLimitWarps));
+    d.visit(CudaMetadataFields::kBlockLimitBlocks, static_cast<int64_t>(occMetrics.result.blockLimitBlocks));
+    d.visit(CudaMetadataFields::kBlockLimitBarriers, static_cast<int64_t>(occMetrics.result.blockLimitBarriers));
+    d.visit(CudaMetadataFields::kAllocatedRegistersPerBlock,
+            static_cast<int64_t>(occMetrics.result.allocatedRegistersPerBlock));
+    d.visit(CudaMetadataFields::kAllocatedSharedMemPerBlock,
+            static_cast<int64_t>(occMetrics.result.allocatedSharedMemPerBlock));
+  });
   addGraphNodeTypedMetadata(visitor, kernel);
   addPriorityTypedMetadata(visitor, kernel);
   addChannelTypedMetadata(visitor, kernel);

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -141,6 +141,9 @@ class RecordingTypedMetadataVisitor final : public ITypedMetadataVisitor {
 
   void visitUnsupported(std::string_view /*name*/) override {}
 
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
+
   std::map<std::string, RecordedMetadataValue> values_;
 };
 } // namespace

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -116,6 +116,9 @@ struct RocmStreamTypedMetadataVisitor final : public ITypedMetadataVisitor {
 
   void visitUnsupported(std::string_view /*name*/) override {}
 
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
+
   std::optional<int64_t> stream;
   std::optional<int64_t> hsaQueue;
 };

--- a/libkineto/test/TypedMetadataTest.cpp
+++ b/libkineto/test/TypedMetadataTest.cpp
@@ -29,6 +29,12 @@ constexpr MetadataField<bool> kEnabled{"enabled"};
 constexpr MetadataField<std::vector<std::string>> kNames{"names"};
 constexpr MetadataField<std::pair<int64_t, int64_t>> kPair{"pair"};
 constexpr MetadataField<std::string> kSpecialChars{"special"};
+constexpr MetadataDict kNested{"nested"};
+constexpr MetadataField<int64_t> kNestedCount{"nested_count"};
+constexpr MetadataField<int64_t> kNestedOther{"nested_other"};
+constexpr MetadataField<int64_t> kAfterNested{"after_nested"};
+constexpr MetadataDict kOuter{"outer"};
+constexpr MetadataDict kInner{"inner"};
 
 using RecordedValue = std::variant<
     int64_t,
@@ -71,6 +77,9 @@ class RecordingTypedMetadataVisitor : public ITypedMetadataVisitor {
   }
 
   void visitUnsupported(std::string_view /*name*/) override {}
+
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
 
   std::map<std::string, RecordedValue> values;
 
@@ -128,6 +137,11 @@ TEST(TypedMetadataVisitorTest, SerializesVisitedFieldsToJson) {
   visitor.visit(kEnabled, true);
   visitor.visit(kNames, std::vector<std::string>{"a", "b"});
   visitor.visit(kSpecialChars, std::string{"quote \" slash \\ newline\n"});
+  visitor.visit(kNested, [&](auto& d) {
+    d.visit(kNestedCount, int64_t{7});
+    d.visit(kNestedOther, int64_t{8});
+  });
+  visitor.visit(kAfterNested, int64_t{9});
 
   const auto json = std::move(jsonVisitor).json();
 
@@ -142,6 +156,32 @@ TEST(TypedMetadataVisitorTest, SerializesVisitedFieldsToJson) {
   EXPECT_NE(
       json.find("\"special\": \"quote \" slash \\ newline\n\""),
       std::string::npos);
+  EXPECT_NE(
+      json.find("\"nested\": {\"nested_count\": 7, \"nested_other\": 8}"),
+      std::string::npos);
+  EXPECT_NE(json.find("\"after_nested\": 9"), std::string::npos);
+}
+
+TEST(TypedMetadataVisitorTest, SerializesNestedDictsToJson) {
+  internal::JsonTypedMetadataVisitor jsonVisitor;
+  ITypedMetadataVisitor& visitor = jsonVisitor;
+
+  visitor.visit(kOuter, [&](auto& outer) {
+    outer.visit(kCount, int64_t{1});
+    outer.visit(kInner, [&](auto& inner) { inner.visit(kEnabled, true); });
+    outer.visit(kRatio, 2.5);
+  });
+  visitor.visit(kAfterNested, int64_t{9});
+
+  const auto json = std::move(jsonVisitor).json();
+
+  // A dict nested inside another dict, with sibling fields before and after the
+  // inner dict, then a field back at the top level.
+  EXPECT_NE(
+      json.find(
+          "\"outer\": {\"count\": 1, \"inner\": {\"enabled\": true}, \"ratio\": 2.5}"),
+      std::string::npos);
+  EXPECT_NE(json.find("\"after_nested\": 9"), std::string::npos);
 }
 
 TEST(TypedMetadataVisitorTest, FallsBackToVisitUnsupported) {


### PR DESCRIPTION
Summary:

CUDA `occupancy` metrics are nested, but we don't currently have a way to represent this. This diff introduces a `MetadataDict` struct, which we implement a new `visit` method for in `ITypedMetadataVisitor`.

The new `visit` method takes `MetadataDict` + a lambda which visits the `MetadataField` objects the `MetadataDict` is meant to contain.

Reviewed By: scotts

Differential Revision: D109229000


