### PR TITLE
Serialize CUDA/ROCm JSON directly from typed metadata

### DIFF
--- a/libkineto/include/TypedMetadata.h
+++ b/libkineto/include/TypedMetadata.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -20,6 +21,10 @@ template <typename T>
 struct MetadataField {
   using FieldType = T;
 
+  std::string_view name;
+};
+
+struct MetadataDict {
   std::string_view name;
 };
 
@@ -57,7 +62,22 @@ class ITypedMetadataVisitor {
     visitValue(field, value);
   }
 
+  // Visits a nested dict: everything `visitChildren` visits is grouped under
+  // dict.name. Example:
+  // visitor.visit(kStats, [](auto& d) { d.visit(kCount, int64_t{1}); });
+  void visit(const MetadataDict& dict, std::invocable<ITypedMetadataVisitor&> auto&& visitChildren) {
+    beginDict(dict.name);
+    visitChildren(*this);
+    endDict();
+  }
+
  protected:
+  // beginDict/endDict bracket a nested dict and are always invoked as a
+  // pair by visit(MetadataDict, ...), with the dict's children visited in
+  // between.
+  virtual void beginDict(std::string_view name) = 0;
+  virtual void endDict() = 0;
+
   virtual void visitUnsupported(std::string_view name) = 0;
 
   template <typename T>

--- a/libkineto/include/TypedMetadataJson.h
+++ b/libkineto/include/TypedMetadataJson.h
@@ -79,22 +79,34 @@ class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
   // Emit a visible placeholder rather than silently dropping a metadata type
   // the JSON serializer doesn't handle, so the gap shows up in the trace.
   void visitUnsupported(std::string_view name) override {
-    appendKey(json_, name);
+    appendKey(name);
     appendQuoted(json_, "<unsupported metadata type>");
+  }
+
+  void beginDict(std::string_view name) override {
+    appendKey(name);
+    json_ += '{';
+    firstEntry_ = true;
+  }
+
+  void endDict() override {
+    json_ += '}';
+    firstEntry_ = false;
   }
 
   template <typename T, typename WriteValue>
   void appendField(const MetadataField<T>& field, WriteValue writeValue) {
-    appendKey(json_, field.name);
+    appendKey(field.name);
     writeValue(json_);
   }
 
-  static void appendKey(std::string& json, std::string_view key) {
-    if (!json.empty()) {
-      json += ", ";
+  void appendKey(std::string_view key) {
+    if (!firstEntry_) {
+      json_ += ", ";
     }
-    appendQuoted(json, key);
-    json += ": ";
+    firstEntry_ = false;
+    appendQuoted(json_, key);
+    json_ += ": ";
   }
 
   static void appendQuoted(std::string& json, std::string_view value) {
@@ -140,6 +152,7 @@ class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
   }
 
   std::string json_;
+  bool firstEntry_ = true;
 };
 
 } // namespace libkineto::internal

--- a/libkineto/src/CudaMetadataFields.h
+++ b/libkineto/src/CudaMetadataFields.h
@@ -15,6 +15,7 @@
 #include "TypedMetadata.h"
 
 namespace libkineto::CudaMetadataFields {
+inline constexpr MetadataDict kOccupancy{"occupancy"};
 inline constexpr MetadataField<int64_t> kActiveBlocksPerMultiprocessor{"activeBlocksPerMultiprocessor"};
 inline constexpr MetadataField<int64_t> kAllocatedRegistersPerBlock{"allocatedRegistersPerBlock"};
 inline constexpr MetadataField<int64_t> kAllocatedSharedMemPerBlock{"allocatedSharedMemPerBlock"};

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -23,6 +23,7 @@
 #include "ITraceActivity.h"
 #include "Logger.h"
 #include "ThreadUtil.h"
+#include "TypedMetadataJson.h"
 #include "cupti_strings.h"
 #include "output_base.h"
 
@@ -352,17 +353,6 @@ inline int32_t streamIdForTrace(uint32_t streamId) {
   return static_cast<int32_t>(streamId);
 }
 
-inline std::string eventSyncInfo(const CUpti_ActivitySynchronization& act, int32_t srcStream, int32_t srcCorrId) {
-  return fmt::format(
-      R"JSON(
-      "wait_on_stream": {},
-      "wait_on_cuda_event_record_corr_id": {},
-      "wait_on_cuda_event_id": {},)JSON",
-      srcStream,
-      srcCorrId,
-      act.cudaEventId);
-}
-
 inline const std::string CudaSyncActivity::name() const {
   return syncTypeString(raw().type);
 }
@@ -380,20 +370,9 @@ inline void CudaSyncActivity::log(ActivityLogger& logger) const {
 }
 
 inline const std::string CudaSyncActivity::metadataJson() const {
-  const CUpti_ActivitySynchronization& sync = raw();
-  // clang-format off
-  return fmt::format(R"JSON(
-      "cuda_sync_kind": "{}",{}
-      "stream": {}, "correlation": {},
-      "device": {}, "context": {})JSON",
-      syncTypeString(sync.type),
-      isEventSync(raw().type) ? eventSyncInfo(raw(), srcStream_, srcCorrId_) : "",
-      streamIdForTrace(sync.streamId),
-      sync.correlationId,
-      deviceId(),
-      sync.contextId);
-  // clang-format on
-  return "";
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 inline void CudaSyncActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
@@ -427,18 +406,9 @@ inline void CudaEventActivity::log(ActivityLogger& logger) const {
 }
 
 inline const std::string CudaEventActivity::metadataJson() const {
-  const CUpti_ActivityCudaEventType& event = raw();
-  // clang-format off
-  return fmt::format(R"JSON(
-      "event_id": {},
-      "stream": {}, "correlation": {},
-      "device": {}, "context": {})JSON",
-      event.eventId,
-      streamIdForTrace(event.streamId),
-      event.correlationId,
-      deviceId(),
-      event.contextId);
-  // clang-format on
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 inline void CudaEventActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
@@ -459,44 +429,6 @@ constexpr int64_t us(int64_t timestamp) {
   // It's important that this conversion is the same here and in the CPU trace.
   // No rounding!
   return timestamp / 1000;
-}
-
-template <class T>
-inline std::string getGraphNodeMetadata([[maybe_unused]] const T& activity) {
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
-  return fmt::format(
-      R"JSON(,
-      "graph id": {}, "graph node id": {})JSON",
-      activity.graphId,
-      activity.graphNodeId);
-#else
-  return "";
-#endif
-}
-
-template <class T>
-inline std::string getPriorityMetadata([[maybe_unused]] const T& kernel) {
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 13010
-  return fmt::format(
-      R"JSON(,
-      "priority": {})JSON",
-      kernel.priority);
-#else
-  return "";
-#endif
-}
-
-template <class T>
-inline std::string getChannelMetadata([[maybe_unused]] const T& activity) {
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
-  return fmt::format(
-      R"JSON(,
-      "channel": {}, "channel_type": {})JSON",
-      activity.channelID,
-      static_cast<uint32_t>(activity.channelType));
-#else
-  return "";
-#endif
 }
 
 template <class T>
@@ -561,61 +493,6 @@ inline std::string limitingFactorsToString(unsigned int factors) {
 }
 
 template <>
-inline const std::string GpuActivity<CUpti_ActivityKernelType>::metadataJson() const {
-  const CUpti_ActivityKernelType& kernel = raw();
-  float blocksPerSmVal = blocksPerSm(kernel);
-  float warpsPerSmVal = warpsPerSm(kernel);
-  OccupancyMetrics occMetrics = computeOccupancyMetrics(kernel);
-
-  // clang-format off
-
-  return fmt::format(R"JSON(
-      "queued": {}, "device": {}, "context": {},
-      "stream": {}, "correlation": {},
-      "registers per thread": {},
-      "shared memory": {},
-      "blocks per SM": {},
-      "warps per SM": {},
-      "grid": [{}, {}, {}],
-      "block": [{}, {}, {}],
-      "est. achieved occupancy %": {},
-      "occupancy": {{
-        "activeBlocksPerMultiprocessor": {},
-        "limitingFactors": "{}",
-        "blockLimitRegs": {},
-        "blockLimitSharedMem": {},
-        "blockLimitWarps": {},
-        "blockLimitBlocks": {},
-        "blockLimitBarriers": {},
-        "allocatedRegistersPerBlock": {},
-        "allocatedSharedMemPerBlock": {}
-      }}{}{}{})JSON",
-      kernel.queued, kernel.deviceId, kernel.contextId,
-      kernel.streamId, kernel.correlationId,
-      kernel.registersPerThread,
-      kernel.staticSharedMemory + kernel.dynamicSharedMemory,
-      std::isinf(blocksPerSmVal) ? "\"inf\"" : std::to_string(blocksPerSmVal),
-      std::isinf(warpsPerSmVal) ? "\"inf\"" : std::to_string(warpsPerSmVal),
-      kernel.gridX, kernel.gridY, kernel.gridZ,
-      kernel.blockX, kernel.blockY, kernel.blockZ,
-      static_cast<int>(std::lround(occMetrics.occupancy * 100.0)),
-      occMetrics.result.activeBlocksPerMultiprocessor,
-      limitingFactorsToString(occMetrics.result.limitingFactors),
-      occMetrics.result.blockLimitRegs,
-      occMetrics.result.blockLimitSharedMem,
-      occMetrics.result.blockLimitWarps,
-      occMetrics.result.blockLimitBlocks,
-      occMetrics.result.blockLimitBarriers,
-      occMetrics.result.allocatedRegistersPerBlock,
-      occMetrics.result.allocatedSharedMemPerBlock,
-      getGraphNodeMetadata(kernel),
-      getPriorityMetadata(kernel),
-      getChannelMetadata(kernel)
-      );
-  // clang-format on
-}
-
-template <>
 inline void GpuActivity<CUpti_ActivityKernelType>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   const CUpti_ActivityKernelType& kernel = raw();
   const float blocksPerSmVal = blocksPerSm(kernel);
@@ -661,6 +538,13 @@ inline void GpuActivity<CUpti_ActivityKernelType>::visitTypedMetadata(ITypedMeta
   addChannelTypedMetadata(visitor, kernel);
 }
 
+template <>
+inline const std::string GpuActivity<CUpti_ActivityKernelType>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
 inline std::string memcpyName(uint8_t kind, uint8_t src, uint8_t dst) {
   return fmt::format("Memcpy {} ({} -> {})",
                      memcpyKindString((CUpti_ActivityMemcpyKind)kind),
@@ -678,26 +562,6 @@ inline const std::string GpuActivity<CUpti_ActivityMemcpyType>::name() const {
   return memcpyName(raw().copyKind, raw().srcKind, raw().dstKind);
 }
 
-inline std::string bandwidth(uint64_t bytes, uint64_t duration) {
-  return duration == 0 ? "\"N/A\"" : fmt::format("{}", bytes * 1.0 / duration);
-}
-
-template <>
-inline const std::string GpuActivity<CUpti_ActivityMemcpyType>::metadataJson() const {
-  const CUpti_ActivityMemcpyType& memcpy = raw();
-  // clang-format off
-  return fmt::format(R"JSON(
-      "device": {}, "context": {},
-      "stream": {}, "correlation": {},
-      "bytes": {}, "memory bandwidth (GB/s)": {}{}{})JSON",
-      memcpy.deviceId, memcpy.contextId,
-      memcpy.streamId, memcpy.correlationId,
-      memcpy.bytes, bandwidth(memcpy.bytes, duration()),
-      getGraphNodeMetadata(memcpy),
-      getChannelMetadata(memcpy));
-  // clang-format on
-}
-
 template <>
 inline void GpuActivity<CUpti_ActivityMemcpyType>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   const CUpti_ActivityMemcpyType& memcpy = raw();
@@ -712,6 +576,13 @@ inline void GpuActivity<CUpti_ActivityMemcpyType>::visitTypedMetadata(ITypedMeta
 }
 
 template <>
+inline const std::string GpuActivity<CUpti_ActivityMemcpyType>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+template <>
 inline ActivityType GpuActivity<CUpti_ActivityMemcpyPtoPType>::type() const {
   return ActivityType::GPU_MEMCPY;
 }
@@ -719,24 +590,6 @@ inline ActivityType GpuActivity<CUpti_ActivityMemcpyPtoPType>::type() const {
 template <>
 inline const std::string GpuActivity<CUpti_ActivityMemcpyPtoPType>::name() const {
   return memcpyName(raw().copyKind, raw().srcKind, raw().dstKind);
-}
-
-template <>
-inline const std::string GpuActivity<CUpti_ActivityMemcpyPtoPType>::metadataJson() const {
-  const CUpti_ActivityMemcpyPtoPType& memcpy = raw();
-  // clang-format off
-  return fmt::format(R"JSON(
-      "fromDevice": {}, "inDevice": {}, "toDevice": {},
-      "fromContext": {}, "inContext": {}, "toContext": {},
-      "stream": {}, "correlation": {},
-      "bytes": {}, "memory bandwidth (GB/s)": {}{}{})JSON",
-      memcpy.srcDeviceId, memcpy.deviceId, memcpy.dstDeviceId,
-      memcpy.srcContextId, memcpy.contextId, memcpy.dstContextId,
-      memcpy.streamId, memcpy.correlationId,
-      memcpy.bytes, bandwidth(memcpy.bytes, duration()),
-      getGraphNodeMetadata(memcpy),
-      getChannelMetadata(memcpy));
-  // clang-format on
 }
 
 template <>
@@ -757,6 +610,13 @@ inline void GpuActivity<CUpti_ActivityMemcpyPtoPType>::visitTypedMetadata(ITyped
 }
 
 template <>
+inline const std::string GpuActivity<CUpti_ActivityMemcpyPtoPType>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
+template <>
 inline const std::string GpuActivity<CUpti_ActivityMemsetType>::name() const {
   const char* memory_kind = memoryKindString((CUpti_ActivityMemoryKind)raw().memoryKind);
   return fmt::format("Memset ({})", memory_kind);
@@ -765,22 +625,6 @@ inline const std::string GpuActivity<CUpti_ActivityMemsetType>::name() const {
 template <>
 inline ActivityType GpuActivity<CUpti_ActivityMemsetType>::type() const {
   return ActivityType::GPU_MEMSET;
-}
-
-template <>
-inline const std::string GpuActivity<CUpti_ActivityMemsetType>::metadataJson() const {
-  const CUpti_ActivityMemsetType& memset = raw();
-  // clang-format off
-  return fmt::format(R"JSON(
-      "device": {}, "context": {},
-      "stream": {}, "correlation": {},
-      "bytes": {}, "memory bandwidth (GB/s)": {}{}{})JSON",
-      memset.deviceId, memset.contextId,
-      memset.streamId, memset.correlationId,
-      memset.bytes, bandwidth(memset.bytes, duration()),
-      getGraphNodeMetadata(memset),
-      getChannelMetadata(memset));
-  // clang-format on
 }
 
 template <>
@@ -794,6 +638,13 @@ inline void GpuActivity<CUpti_ActivityMemsetType>::visitTypedMetadata(ITypedMeta
   addBandwidthTypedMetadata(visitor, memset.bytes, duration());
   addGraphNodeTypedMetadata(visitor, memset);
   addChannelTypedMetadata(visitor, memset);
+}
+
+template <>
+inline const std::string GpuActivity<CUpti_ActivityMemsetType>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 inline void RuntimeActivity::log(ActivityLogger& logger) const {
@@ -813,7 +664,9 @@ inline bool OverheadActivity::flowStart() const {
 }
 
 inline const std::string OverheadActivity::metadataJson() const {
-  return "";
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 inline void OverheadActivity::visitTypedMetadata([[maybe_unused]] ITypedMetadataVisitor& visitor) const {}
@@ -823,11 +676,9 @@ inline bool RuntimeActivity::flowStart() const {
 }
 
 inline const std::string RuntimeActivity::metadataJson() const {
-  return fmt::format(
-      R"JSON(
-      "cbid": {}, "correlation": {})JSON",
-      activity_.cbid,
-      activity_.correlationId);
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 inline void RuntimeActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
@@ -844,11 +695,9 @@ inline bool DriverActivity::flowStart() const {
 }
 
 inline const std::string DriverActivity::metadataJson() const {
-  return fmt::format(
-      R"JSON(
-      "cbid": {}, "correlation": {})JSON",
-      activity_.cbid,
-      activity_.correlationId);
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 inline void DriverActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
@@ -862,7 +711,9 @@ inline const std::string DriverActivity::name() const {
 
 template <class T>
 inline const std::string GpuActivity<T>::metadataJson() const {
-  return "";
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 template <class T>

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -642,18 +642,20 @@ inline void GpuActivity<CUpti_ActivityKernelType>::visitTypedMetadata(ITypedMeta
                                      static_cast<int64_t>(kernel.blockZ)});
   visitor.visit(CudaMetadataFields::kEstAchievedOccupancyPercent,
                 static_cast<int64_t>(std::lround(occMetrics.occupancy * 100.0)));
-  visitor.visit(CudaMetadataFields::kActiveBlocksPerMultiprocessor,
-                static_cast<int64_t>(occMetrics.result.activeBlocksPerMultiprocessor));
-  visitor.visit(CudaMetadataFields::kLimitingFactors, limitingFactorsToString(occMetrics.result.limitingFactors));
-  visitor.visit(CudaMetadataFields::kBlockLimitRegs, static_cast<int64_t>(occMetrics.result.blockLimitRegs));
-  visitor.visit(CudaMetadataFields::kBlockLimitSharedMem, static_cast<int64_t>(occMetrics.result.blockLimitSharedMem));
-  visitor.visit(CudaMetadataFields::kBlockLimitWarps, static_cast<int64_t>(occMetrics.result.blockLimitWarps));
-  visitor.visit(CudaMetadataFields::kBlockLimitBlocks, static_cast<int64_t>(occMetrics.result.blockLimitBlocks));
-  visitor.visit(CudaMetadataFields::kBlockLimitBarriers, static_cast<int64_t>(occMetrics.result.blockLimitBarriers));
-  visitor.visit(CudaMetadataFields::kAllocatedRegistersPerBlock,
-                static_cast<int64_t>(occMetrics.result.allocatedRegistersPerBlock));
-  visitor.visit(CudaMetadataFields::kAllocatedSharedMemPerBlock,
-                static_cast<int64_t>(occMetrics.result.allocatedSharedMemPerBlock));
+  visitor.visit(CudaMetadataFields::kOccupancy, [&](auto& d) {
+    d.visit(CudaMetadataFields::kActiveBlocksPerMultiprocessor,
+            static_cast<int64_t>(occMetrics.result.activeBlocksPerMultiprocessor));
+    d.visit(CudaMetadataFields::kLimitingFactors, limitingFactorsToString(occMetrics.result.limitingFactors));
+    d.visit(CudaMetadataFields::kBlockLimitRegs, static_cast<int64_t>(occMetrics.result.blockLimitRegs));
+    d.visit(CudaMetadataFields::kBlockLimitSharedMem, static_cast<int64_t>(occMetrics.result.blockLimitSharedMem));
+    d.visit(CudaMetadataFields::kBlockLimitWarps, static_cast<int64_t>(occMetrics.result.blockLimitWarps));
+    d.visit(CudaMetadataFields::kBlockLimitBlocks, static_cast<int64_t>(occMetrics.result.blockLimitBlocks));
+    d.visit(CudaMetadataFields::kBlockLimitBarriers, static_cast<int64_t>(occMetrics.result.blockLimitBarriers));
+    d.visit(CudaMetadataFields::kAllocatedRegistersPerBlock,
+            static_cast<int64_t>(occMetrics.result.allocatedRegistersPerBlock));
+    d.visit(CudaMetadataFields::kAllocatedSharedMemPerBlock,
+            static_cast<int64_t>(occMetrics.result.allocatedSharedMemPerBlock));
+  });
   addGraphNodeTypedMetadata(visitor, kernel);
   addPriorityTypedMetadata(visitor, kernel);
   addChannelTypedMetadata(visitor, kernel);

--- a/libkineto/src/RocprofActivity_inl.h
+++ b/libkineto/src/RocprofActivity_inl.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "Demangle.h"
+#include "TypedMetadataJson.h"
 #include "output_base.h"
 
 namespace KINETO_NAMESPACE {
@@ -39,9 +40,6 @@ inline std::vector<int64_t> rocprofKernelBlock(const rocprofKernelRow& activity)
           static_cast<int64_t>(activity.workgroupZ)};
 }
 
-inline std::string vectorToJsonArray(const std::vector<int64_t>& values) {
-  return fmt::format("[{}, {}, {}]", values[0], values[1], values[2]);
-}
 } // namespace
 
 inline const char* getGpuActivityKindString(uint32_t domain, uint32_t op) {
@@ -113,10 +111,6 @@ inline void GpuActivity::log(ActivityLogger& logger) const {
   logger.handleActivity(*this);
 }
 
-static inline std::string bandwidth(size_t bytes, uint64_t duration) {
-  return duration == 0 ? "\"N/A\"" : fmt::format("{}", bytes * 1.0 / duration);
-}
-
 static inline void addBandwidthTypedMetadata(ITypedMetadataVisitor& visitor, size_t bytes, uint64_t duration) {
   if (duration == 0) {
     return;
@@ -125,43 +119,9 @@ static inline void addBandwidthTypedMetadata(ITypedMetadataVisitor& visitor, siz
 }
 
 inline const std::string GpuActivity::metadataJson() const {
-  const auto& gpuActivity = raw();
-  // clang-format off
-
-  // if memcpy or memset, add size
-  auto sizeIt = correlationToSize.find(gpuActivity.id);
-  if (sizeIt != correlationToSize.end()) {
-    size_t size = sizeIt->second;
-    std::string bandwidth_gib = (bandwidth(size, gpuActivity.end - gpuActivity.begin));
-    return fmt::format(R"JSON(
-      "device": {}, "stream": {}, "hsa_queue": {},
-      "correlation": {}, "kind": "{}",
-      "bytes": {}, "memory bandwidth (GB/s)": {})JSON",
-      gpuActivity.device, resourceId(), gpuActivity.queue,
-      gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op),
-      size, bandwidth_gib);
-  }
-
-  auto gridIt = correlationToGrid.find(gpuActivity.id);
-  auto blockIt = correlationToBlock.find(gpuActivity.id);
-
-  // if compute kernel, add grid and block
-  if (gridIt != correlationToGrid.end() && blockIt != correlationToBlock.end()) {
-    return fmt::format(R"JSON(
-      "device": {}, "stream": {}, "hsa_queue": {},
-      "correlation": {}, "kind": "{}",
-      "grid": {}, "block": {})JSON",
-      gpuActivity.device, resourceId(), gpuActivity.queue,
-      gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op),
-      vectorToJsonArray(gridIt->second), vectorToJsonArray(blockIt->second));
-  } else {
-    return fmt::format(R"JSON(
-      "device": {}, "stream": {}, "hsa_queue": {},
-      "correlation": {}, "kind": "{}")JSON",
-      gpuActivity.device, resourceId(), gpuActivity.queue,
-      gpuActivity.id, getGpuActivityKindString(gpuActivity.domain, gpuActivity.op));
-  }
-  // clang-format on
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 inline void GpuActivity::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
@@ -213,42 +173,6 @@ inline void RuntimeActivity<T>::log(ActivityLogger& logger) const {
 }
 
 template <>
-inline const std::string RuntimeActivity<rocprofKernelRow>::metadataJson() const {
-  std::string kernel = "";
-  if ((raw().functionAddr != nullptr)) {
-    kernel = fmt::format(
-        R"JSON(
-    "kernel": "{}", )JSON",
-        demangle(hipKernelNameRefByPtr(raw().functionAddr, raw().stream)));
-  } else if ((raw().function != nullptr)) {
-    kernel = fmt::format(
-        R"JSON(
-    "kernel": "{}", )JSON",
-        demangle(hipKernelNameRef(raw().function)));
-  }
-  // cache grid and block so we can pass it into async activity (GPU track)
-  correlationToGrid[raw().id] = rocprofKernelGrid(raw());
-  correlationToBlock[raw().id] = rocprofKernelBlock(raw());
-
-  return fmt::format(
-      R"JSON(
-      {}"cid": {}, "correlation": {},
-      "grid": [{}, {}, {}],
-      "block": [{}, {}, {}],
-      "shared memory": {})JSON",
-      kernel,
-      raw().cid,
-      raw().id,
-      raw().gridX,
-      raw().gridY,
-      raw().gridZ,
-      raw().workgroupX,
-      raw().workgroupY,
-      raw().workgroupZ,
-      raw().groupSegmentSize);
-}
-
-template <>
 inline void RuntimeActivity<rocprofKernelRow>::visitTypedMetadata(ITypedMetadataVisitor& visitor) const {
   if ((raw().functionAddr != nullptr)) {
     visitor.visit(RocmMetadataFields::kKernel, demangle(hipKernelNameRefByPtr(raw().functionAddr, raw().stream)));
@@ -268,17 +192,10 @@ inline void RuntimeActivity<rocprofKernelRow>::visitTypedMetadata(ITypedMetadata
 }
 
 template <>
-inline const std::string RuntimeActivity<rocprofCopyRow>::metadataJson() const {
-  correlationToSize[raw().id] = raw().size;
-  return fmt::format(
-      R"JSON(
-      "cid": {}, "correlation": {}, "src": "{}", "dst": "{}", "bytes": "{}", "kind": "{}")JSON",
-      raw().cid,
-      raw().id,
-      raw().src,
-      raw().dst,
-      raw().size,
-      fmt::underlying(raw().kind));
+inline const std::string RuntimeActivity<rocprofKernelRow>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 template <>
@@ -293,22 +210,10 @@ inline void RuntimeActivity<rocprofCopyRow>::visitTypedMetadata(ITypedMetadataVi
 }
 
 template <>
-inline const std::string RuntimeActivity<rocprofMallocRow>::metadataJson() const {
-  correlationToSize[raw().id] = raw().size;
-  std::string size = "";
-  if (raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMalloc) {
-    size = fmt::format(
-        R"JSON(
-      "bytes": {}, )JSON",
-        raw().size);
-  }
-  return fmt::format(
-      R"JSON(
-      {}"cid": {}, "correlation": {}, "ptr": "{}")JSON",
-      size,
-      raw().cid,
-      raw().id,
-      raw().ptr);
+inline const std::string RuntimeActivity<rocprofCopyRow>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 template <>
@@ -322,13 +227,18 @@ inline void RuntimeActivity<rocprofMallocRow>::visitTypedMetadata(ITypedMetadata
   visitor.visit(RocmMetadataFields::kPtr, fmt::format("{}", raw().ptr));
 }
 
+template <>
+inline const std::string RuntimeActivity<rocprofMallocRow>::metadataJson() const {
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
 template <class T>
 inline const std::string RuntimeActivity<T>::metadataJson() const {
-  return fmt::format(
-      R"JSON(
-      "cid": {}, "correlation": {})JSON",
-      raw().cid,
-      raw().id);
+  libkineto::internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
 }
 
 template <class T>

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -141,6 +141,9 @@ class RecordingTypedMetadataVisitor final : public ITypedMetadataVisitor {
 
   void visitUnsupported(std::string_view /*name*/) override {}
 
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
+
   std::map<std::string, RecordedMetadataValue> values_;
 };
 } // namespace

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -116,6 +116,9 @@ struct RocmStreamTypedMetadataVisitor final : public ITypedMetadataVisitor {
 
   void visitUnsupported(std::string_view /*name*/) override {}
 
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
+
   std::optional<int64_t> stream;
   std::optional<int64_t> hsaQueue;
 };

--- a/libkineto/test/TypedMetadataTest.cpp
+++ b/libkineto/test/TypedMetadataTest.cpp
@@ -29,6 +29,12 @@ constexpr MetadataField<bool> kEnabled{"enabled"};
 constexpr MetadataField<std::vector<std::string>> kNames{"names"};
 constexpr MetadataField<std::pair<int64_t, int64_t>> kPair{"pair"};
 constexpr MetadataField<std::string> kSpecialChars{"special"};
+constexpr MetadataDict kNested{"nested"};
+constexpr MetadataField<int64_t> kNestedCount{"nested_count"};
+constexpr MetadataField<int64_t> kNestedOther{"nested_other"};
+constexpr MetadataField<int64_t> kAfterNested{"after_nested"};
+constexpr MetadataDict kOuter{"outer"};
+constexpr MetadataDict kInner{"inner"};
 
 using RecordedValue = std::variant<
     int64_t,
@@ -71,6 +77,9 @@ class RecordingTypedMetadataVisitor : public ITypedMetadataVisitor {
   }
 
   void visitUnsupported(std::string_view /*name*/) override {}
+
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
 
   std::map<std::string, RecordedValue> values;
 
@@ -128,6 +137,11 @@ TEST(TypedMetadataVisitorTest, SerializesVisitedFieldsToJson) {
   visitor.visit(kEnabled, true);
   visitor.visit(kNames, std::vector<std::string>{"a", "b"});
   visitor.visit(kSpecialChars, std::string{"quote \" slash \\ newline\n"});
+  visitor.visit(kNested, [&](auto& d) {
+    d.visit(kNestedCount, int64_t{7});
+    d.visit(kNestedOther, int64_t{8});
+  });
+  visitor.visit(kAfterNested, int64_t{9});
 
   const auto json = std::move(jsonVisitor).json();
 
@@ -142,6 +156,32 @@ TEST(TypedMetadataVisitorTest, SerializesVisitedFieldsToJson) {
   EXPECT_NE(
       json.find("\"special\": \"quote \" slash \\ newline\n\""),
       std::string::npos);
+  EXPECT_NE(
+      json.find("\"nested\": {\"nested_count\": 7, \"nested_other\": 8}"),
+      std::string::npos);
+  EXPECT_NE(json.find("\"after_nested\": 9"), std::string::npos);
+}
+
+TEST(TypedMetadataVisitorTest, SerializesNestedDictsToJson) {
+  internal::JsonTypedMetadataVisitor jsonVisitor;
+  ITypedMetadataVisitor& visitor = jsonVisitor;
+
+  visitor.visit(kOuter, [&](auto& outer) {
+    outer.visit(kCount, int64_t{1});
+    outer.visit(kInner, [&](auto& inner) { inner.visit(kEnabled, true); });
+    outer.visit(kRatio, 2.5);
+  });
+  visitor.visit(kAfterNested, int64_t{9});
+
+  const auto json = std::move(jsonVisitor).json();
+
+  // A dict nested inside another dict, with sibling fields before and after the
+  // inner dict, then a field back at the top level.
+  EXPECT_NE(
+      json.find(
+          "\"outer\": {\"count\": 1, \"inner\": {\"enabled\": true}, \"ratio\": 2.5}"),
+      std::string::npos);
+  EXPECT_NE(json.find("\"after_nested\": 9"), std::string::npos);
 }
 
 TEST(TypedMetadataVisitorTest, FallsBackToVisitUnsupported) {


### PR DESCRIPTION
Summary:
Replace all CUDA/ROCm `metadataJson` instances with versions that serialize directly from `typedMetadata` using the JSON serializer we introduced in a previous diff.

There's a couple minor changes to the output:
1. ROCm `bytes` now reports a number instead of a quoted string.
2. `memory bandwidth (GB/s)` is omitted when duration == 0 instead of emitting "N/A", because we can't have mixed types.
3. Key order is mixed up. In particular, occupancy metrics go at the end of the metadata json now.

These *should* all be minor but to be determined if they break any tests.

Differential Revision: D109175060


