### PR TITLE
kineto | clang-format xpupti plugin and init.cpp

### DIFF
--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -28,8 +28,8 @@
 #ifdef HAS_XPUPTI
 #include "plugin/xpupti/XpuptiActivityApi.h"
 #include "plugin/xpupti/XpuptiActivityProfiler.h"
-#include "plugin/xpupti/XpuptiScopeProfilerConfig.h"
 #include "plugin/xpupti/XpuptiProfilerMacros.h"
+#include "plugin/xpupti/XpuptiScopeProfilerConfig.h"
 #endif
 #include "libkineto.h"
 

--- a/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.cpp
@@ -16,18 +16,23 @@
 namespace KINETO_NAMESPACE {
 
 namespace {
-[[noreturn]] void throwXpuRuntimeError(pti_result errCode,
-                                       std::string_view message,
-                                       std::source_location source_location) {
-  const std::string function_location =
-      fmt::format("function {} located: {}:{}", source_location.function_name(),
-                  source_location.file_name(), source_location.line());
-  const std::string error_code =
-      fmt::format("Error code: {} ({})", static_cast<int>(errCode),
-                  ptiResultTypeToString(errCode));
-  const std::string error =
-      fmt::format("Kineto Profiler on XPU got error from {}. {}.",
-                  function_location, error_code);
+[[noreturn]] void throwXpuRuntimeError(
+    pti_result errCode,
+    std::string_view message,
+    std::source_location source_location) {
+  const std::string function_location = fmt::format(
+      "function {} located: {}:{}",
+      source_location.function_name(),
+      source_location.file_name(),
+      source_location.line());
+  const std::string error_code = fmt::format(
+      "Error code: {} ({})",
+      static_cast<int>(errCode),
+      ptiResultTypeToString(errCode));
+  const std::string error = fmt::format(
+      "Kineto Profiler on XPU got error from {}. {}.",
+      function_location,
+      error_code);
 
   if (message.empty())
     throw std::runtime_error(error);
@@ -39,8 +44,10 @@ namespace {
 }
 } // namespace
 
-void XPUPTI_CALL(pti_result errCode, std::string_view message,
-                 std::source_location source_location) {
+void XPUPTI_CALL(
+    pti_result errCode,
+    std::string_view message,
+    std::source_location source_location) {
   if (errCode != PTI_SUCCESS)
     throwXpuRuntimeError(errCode, message, source_location);
 }

--- a/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.h
+++ b/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.h
@@ -19,13 +19,11 @@ using namespace libkineto;
 
 // Used to enable future features in PTI before release.
 #define PTI_VERSION_AT_LEAST(MAJOR, MINOR) \
-  (PTI_VERSION_MAJOR > MAJOR ||            \
-   (PTI_VERSION_MAJOR == MAJOR && PTI_VERSION_MINOR >= MINOR))
+  (PTI_VERSION_MAJOR > MAJOR || (PTI_VERSION_MAJOR == MAJOR && PTI_VERSION_MINOR >= MINOR))
 
-void XPUPTI_CALL(
-    pti_result errCode,
-    std::string_view message = "",
-    std::source_location source_location = std::source_location::current());
+void XPUPTI_CALL(pti_result errCode,
+                 std::string_view message = "",
+                 std::source_location source_location = std::source_location::current());
 
 using DeviceIndex_t = int8_t;
 


### PR DESCRIPTION
Summary:
These files are clang-format-dirty in trunk, which makes the project-wide
`linter-update-verification_clangformat_fbsource` codemod produce changes on
unrelated `xplat` diffs (it is not scoped to the diff under test), blocking them
with a LAND_BLOCKING failure.

This applies the exact output of `tools/arcanist/lint/codemods/clangformat_fbsource`
to the affected files (pure formatting, no behavior change), so the codemod is
idempotent and the verification passes.

Split out as its own diff so it can land
independently of the LightweightVK 1.4.6 sync (D110041002) that surfaced it.

Differential Revision: D110172559


