### PR TITLE
Fix incorrect enum usage preventing CUPTI early-init

### DIFF
--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -75,15 +75,15 @@ void CuptiCallbackApi::__callback_switchboard(
     case CUPTI_CB_DOMAIN_RUNTIME_API:
       switch (cbid) {
         case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000:
-          cblist =
-              &callbacks_
-                   .runtime[CUDA_LAUNCH_KERNEL - __RUNTIME_CB_DOMAIN_START];
+          cblist = &callbacks_.runtime[domainIndex(
+              CuptiCallBackID::CUDA_LAUNCH_KERNEL,
+              CuptiCallBackID::__RUNTIME_CB_DOMAIN_START)];
           break;
 #if defined(CUDA_VERSION) && (CUDA_VERSION >= 11080)
         case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060:
-          cblist =
-              &callbacks_
-                   .runtime[CUDA_LAUNCH_KERNEL_EXC - __RUNTIME_CB_DOMAIN_START];
+          cblist = &callbacks_.runtime[domainIndex(
+              CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC,
+              CuptiCallBackID::__RUNTIME_CB_DOMAIN_START)];
           break;
 #endif
         default:
@@ -109,13 +109,14 @@ void CuptiCallbackApi::__callback_switchboard(
     case CUPTI_CB_DOMAIN_RESOURCE:
       switch (cbid) {
         case CUPTI_CBID_RESOURCE_CONTEXT_CREATED:
-          cblist = &callbacks_.resource
-                        [RESOURCE_CONTEXT_CREATED - __RESOURCE_CB_DOMAIN_START];
+          cblist = &callbacks_.resource[domainIndex(
+              CuptiCallBackID::RESOURCE_CONTEXT_CREATED,
+              CuptiCallBackID::__RESOURCE_CB_DOMAIN_START)];
           break;
         case CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING:
-          cblist =
-              &callbacks_.resource
-                   [RESOURCE_CONTEXT_DESTROYED - __RESOURCE_CB_DOMAIN_START];
+          cblist = &callbacks_.resource[domainIndex(
+              CuptiCallBackID::RESOURCE_CONTEXT_DESTROYED,
+              CuptiCallBackID::__RESOURCE_CB_DOMAIN_START)];
           break;
         default:
           break;
@@ -180,15 +181,15 @@ CuptiCallbackApi::CallbackList* CuptiCallbackApi::CallbackTable::lookup(
 
   switch (domain) {
     case CUPTI_CB_DOMAIN_RESOURCE:
-      assert(cbid >= __RESOURCE_CB_DOMAIN_START);
-      assert(cbid < __RESOURCE_CB_DOMAIN_END);
-      idx = cbid - __RESOURCE_CB_DOMAIN_START;
+      assert(cbid >= CuptiCallBackID::__RESOURCE_CB_DOMAIN_START);
+      assert(cbid < CuptiCallBackID::__RESOURCE_CB_DOMAIN_END);
+      idx = domainIndex(cbid, CuptiCallBackID::__RESOURCE_CB_DOMAIN_START);
       return &resource.at(idx);
 
     case CUPTI_CB_DOMAIN_RUNTIME_API:
-      assert(cbid >= __RUNTIME_CB_DOMAIN_START);
-      assert(cbid < __RUNTIME_CB_DOMAIN_END);
-      idx = cbid - __RUNTIME_CB_DOMAIN_START;
+      assert(cbid >= CuptiCallBackID::__RUNTIME_CB_DOMAIN_START);
+      assert(cbid < CuptiCallBackID::__RUNTIME_CB_DOMAIN_END);
+      idx = domainIndex(cbid, CuptiCallBackID::__RUNTIME_CB_DOMAIN_START);
       return &runtime.at(idx);
 
     default:
@@ -205,7 +206,7 @@ bool CuptiCallbackApi::registerCallback(
 
   if (!cblist) {
     LOG(WARNING) << "Could not register callback -- domain = " << domain
-                 << " callback id = " << cbid;
+                 << " callback id = " << static_cast<int>(cbid);
     return false;
   }
 
@@ -213,13 +214,13 @@ bool CuptiCallbackApi::registerCallback(
   auto it = std::ranges::find(*cblist, cbfn);
   if (it != cblist->end()) {
     LOG(WARNING) << "Adding duplicate callback -- domain = " << domain
-                 << " callback id = " << cbid;
+                 << " callback id = " << static_cast<int>(cbid);
     return true;
   }
 
   if (cblist->size() == MAX_CB_FNS_PER_CB) {
     LOG(WARNING) << "Already registered max callback -- domain = " << domain
-                 << " callback id = " << cbid;
+                 << " callback id = " << static_cast<int>(cbid);
   }
 
   WriteLockGuard wl(callbackLock_);
@@ -234,7 +235,7 @@ bool CuptiCallbackApi::deleteCallback(
   CallbackList* cblist = callbacks_.lookup(domain, cbid);
   if (!cblist) {
     LOG(WARNING) << "Attempting to remove unsupported callback -- domain = "
-                 << domain << " callback id = " << cbid;
+                 << domain << " callback id = " << static_cast<int>(cbid);
     return false;
   }
 
@@ -245,7 +246,7 @@ bool CuptiCallbackApi::deleteCallback(
   auto it = std::ranges::find(*cblist, cbfn);
   if (it == cblist->end()) {
     LOG(WARNING) << "Could not find callback to remove -- domain = " << domain
-                 << " callback id = " << cbid;
+                 << " callback id = " << static_cast<int>(cbid);
     return false;
   }
 

--- a/libkineto/src/CuptiCallbackApi.h
+++ b/libkineto/src/CuptiCallbackApi.h
@@ -39,7 +39,7 @@ class CuptiCallbackApi {
  public:
   /* Global list of supported callback ids
    *  use the class namespace to avoid confusing with CUPTI enums*/
-  enum CuptiCallBackID {
+  enum class CuptiCallBackID : int {
     CUDA_LAUNCH_KERNEL = 0,
     // can possibly support more callback ids per domain
     //
@@ -98,10 +98,19 @@ class CuptiCallbackApi {
   // For callback table design overview see the .cpp file
   using CallbackList = std::list<CuptiCallbackFn>;
 
-  // level 2 tables sizes are known at compile time
-  constexpr static size_t RUNTIME_CB_DOMAIN_SIZE = (__RUNTIME_CB_DOMAIN_END - __RUNTIME_CB_DOMAIN_START);
+  // Computing the slot of the callback id within its domain's table.
+  static constexpr size_t domainIndex(CuptiCallBackID cbid, CuptiCallBackID domainStart) {
+    return static_cast<size_t>(cbid) - static_cast<size_t>(domainStart);
+  }
 
-  constexpr static size_t RESOURCE_CB_DOMAIN_SIZE = (__RESOURCE_CB_DOMAIN_END - __RESOURCE_CB_DOMAIN_START);
+  // level 2 tables sizes are known at compile time. Computed inline rather than
+  // via domainIndex(): an inline member function isn't yet usable in a constexpr
+  // member initializer within the same class definition.
+  constexpr static size_t RUNTIME_CB_DOMAIN_SIZE = static_cast<size_t>(CuptiCallBackID::__RUNTIME_CB_DOMAIN_END) -
+      static_cast<size_t>(CuptiCallBackID::__RUNTIME_CB_DOMAIN_START);
+
+  constexpr static size_t RESOURCE_CB_DOMAIN_SIZE = static_cast<size_t>(CuptiCallBackID::__RESOURCE_CB_DOMAIN_END) -
+      static_cast<size_t>(CuptiCallBackID::__RESOURCE_CB_DOMAIN_START);
 
   // level 1 table is a struct
   struct CallbackTable {

--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -102,11 +102,11 @@ bool setupCuptiInitCallback(bool logOnError) {
     const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RESOURCE;
     status = cbapi.registerCallback(
         domain,
-        CuptiCallbackApi::RESOURCE_CONTEXT_CREATED,
+        CuptiCallbackApi::CuptiCallBackID::RESOURCE_CONTEXT_CREATED,
         initProfilersCallback);
     if (status) {
-      status = cbapi.enableCallback(
-          domain, CuptiCallbackApi::RESOURCE_CONTEXT_CREATED);
+      status =
+          cbapi.enableCallback(domain, CUPTI_CBID_RESOURCE_CONTEXT_CREATED);
     }
   }
 

--- a/libkineto/test/CuptiCallbackApiTest.cpp
+++ b/libkineto/test/CuptiCallbackApiTest.cpp
@@ -112,28 +112,28 @@ TEST(CuptiCallbackApiTest, SimpleTest) {
 
   bool ret = api.deleteCallback(
       CUPTI_CB_DOMAIN_RUNTIME_API,
-      CuptiCallbackApi::CUDA_LAUNCH_KERNEL,
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL,
       &simple_cudaLaunchKernel_cb);
 
   EXPECT_TRUE(ret) << "Failed to remove callback";
 
   ret = api.deleteCallback(
       CUPTI_CB_DOMAIN_RUNTIME_API,
-      CuptiCallbackApi::CUDA_LAUNCH_KERNEL_EXC,
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC,
       &simple_cudaLaunchKernelExC_cb);
 
   EXPECT_TRUE(ret) << "Failed to remove callback";
 
   ret = api.deleteCallback(
       CUPTI_CB_DOMAIN_RUNTIME_API,
-      CuptiCallbackApi::CUDA_LAUNCH_KERNEL,
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL,
       &atomic_cb);
 
   EXPECT_FALSE(ret) << "oops! deleted a callback that was never added";
 
   ret = api.deleteCallback(
       CUPTI_CB_DOMAIN_RUNTIME_API,
-      CuptiCallbackApi::CUDA_LAUNCH_KERNEL_EXC,
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC,
       &atomic_cb);
 
   EXPECT_FALSE(ret) << "oops! deleted a callback that was never added";
@@ -166,25 +166,25 @@ TEST(CuptiCallbackApiTest, AllCallbacks) {
   EXPECT_TRUE(testCallback(
       CUPTI_CB_DOMAIN_RESOURCE,
       CUPTI_CBID_RESOURCE_CONTEXT_CREATED,
-      CuptiCallbackApi::RESOURCE_CONTEXT_CREATED))
+      CuptiCallbackApi::CuptiCallBackID::RESOURCE_CONTEXT_CREATED))
       << "Failed to run callback for RESOURCE_CONTEXT_CREATED";
 
   EXPECT_TRUE(testCallback(
       CUPTI_CB_DOMAIN_RESOURCE,
       CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING,
-      CuptiCallbackApi::RESOURCE_CONTEXT_DESTROYED))
+      CuptiCallbackApi::CuptiCallBackID::RESOURCE_CONTEXT_DESTROYED))
       << "Failed to run callback for RESOURCE_CONTEXT_DESTROYED";
 
   EXPECT_TRUE(testCallback(
       CUPTI_CB_DOMAIN_RUNTIME_API,
       CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,
-      CuptiCallbackApi::CUDA_LAUNCH_KERNEL))
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL))
       << "Failed to run callback for CUDA_LAUNCH_KERNEL";
 
   EXPECT_TRUE(testCallback(
       CUPTI_CB_DOMAIN_RUNTIME_API,
       CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,
-      CuptiCallbackApi::CUDA_LAUNCH_KERNEL_EXC))
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL_EXC))
       << "Failed to run callback for CUDA_LAUNCH_KERNEL_EXC";
 }
 
@@ -193,7 +193,7 @@ TEST(CuptiCallbackApiTest, ContentionTest) {
   const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RUNTIME_API;
   const CUpti_CallbackId cbid = CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000;
   const CuptiCallbackApi::CuptiCallBackID kineto_cbid =
-      CuptiCallbackApi::CUDA_LAUNCH_KERNEL;
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL;
 
   bool ret = api.registerCallback(domain, kineto_cbid, empty_cb);
   EXPECT_TRUE(ret) << "Failed to add callback";
@@ -242,7 +242,7 @@ TEST(CuptiCallbackApiTest, Bechmark) {
   const CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_RUNTIME_API;
   const CUpti_CallbackId cbid = CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000;
   const CuptiCallbackApi::CuptiCallBackID kineto_cbid =
-      CuptiCallbackApi::CUDA_LAUNCH_KERNEL;
+      CuptiCallbackApi::CuptiCallBackID::CUDA_LAUNCH_KERNEL;
 
   LOG(INFO) << "Iteration count = " << iters;
 


### PR DESCRIPTION
Summary:
During init, `setupCuptiInitCallback` installs a callback using `CuptiCallbackApi` so that whenever the CUDA context is created, CUPTI is also early initialized. It does this by first calling `registerCallback`, then `enableCallback` on the `RESOURCE_CONTEXT_CREATED` enum in `CuptiCallbackApi`.

[Code ref](https://github.com/pytorch/kineto/blob/main/libkineto/src/init.cpp#L103-L110)

HOWEVER `registerCallback` and `enableCallback` [do not take the same enum](https://github.com/pytorch/kineto/blob/main/libkineto/src/CuptiCallbackApi.h#L79-L85). `registerCallback` is a `CuptiCallbackApi`-side concept, where the enum set is pruned down for performance reasons. `enableCallback` on the other hand is a thin wrapper over the CUPTI API which takes CUPTI enums. You can see the difference in their definitions; `registerCallback` takes `CuptiCallBackID` (Kineto enum), while `enableCallback` takes `CUpti_CallbackId` (CUPTI enum). Currently we're passing the wrong enum type to `enableCallback`, so we're actually enabling a callback for a completely different event.

This manifested itself in a profiler prepare call duration regression (~10ms -> ~70ms based on internal integration tests) when the range profiler was removed a few weeks back. The range profiler originally had a second `enableCallback` call which ran during init and used the proper enum, which meant that this bug was covered up. Note that this was always present on CUDA > 12.6, because the range profiler init was gated on CUDA version.

This diff fixes the regression by using the proper enum in `enableCallback`, and it attempts to harden this logic by making  `CuptiCallBackID` a proper enum class, so that using the class improperly leads to a compile error. You can see in the code comment "use the class namespace to avoid confusing with CUPTI enums" that this was always a possibility, but we should guard on this more forcefully.

Differential Revision: D110200328


