### PR TITLE
Fix: JSON-escape double quotes in chrome-trace event names

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -65,6 +65,18 @@ void sanitizeStrForJSON(std::string& value) {
   std::erase(value, '\n');
 }
 
+// Escape bare double quotes so an event name can be safely embedded in a JSON
+// string value ("name": "<value>"). Names can contain `"` (e.g. dynamo-generated
+// co_filenames like {"device": "cpu"} surfaced with with_stack=True); an
+// unescaped `"` corrupts the whole trace. Run after sanitizeStrForJSON() so the
+// inserted backslashes aren't rewritten. See pytorch/pytorch#146900.
+void escapeQuotesForJSON(std::string& value) {
+  for (size_t pos = value.find('"'); pos != std::string::npos;
+       pos = value.find('"', pos + 2)) {
+    value.insert(pos, 1, '\\');
+  }
+}
+
 std::string string2hex(const std::string& str) {
   std::string out;
   out.reserve(str.size() * 2);
@@ -880,6 +892,7 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
   std::string op_name = op.name() == "kernel" ? "Kernel" : op.name();
   sanitizeStrForJSON(op_name);
   sanitizeForNonReadableChars(op_name);
+  escapeQuotesForJSON(op_name);
 
   ts = transToRelativeTime(ts);
   writeCompleteEvent(

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -153,3 +153,16 @@ target_include_directories(GenericTraceActivityMetadataTest PRIVATE
     "${LIBKINETO_DIR}/include"
     "${LIBKINETO_DIR}/src")
 gtest_discover_tests(GenericTraceActivityMetadataTest)
+
+# OutputJsonTest
+add_executable(OutputJsonTest OutputJsonTest.cpp)
+target_link_libraries(OutputJsonTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    nlohmann_json::nlohmann_json
+    ${XPU_XPUPTI_LIBRARY})
+target_include_directories(OutputJsonTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src")
+gtest_discover_tests(OutputJsonTest)

--- a/libkineto/test/OutputJsonTest.cpp
+++ b/libkineto/test/OutputJsonTest.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#include "include/GenericTraceActivity.h"
+#include "include/TraceSpan.h"
+#include "src/output_json.h"
+
+using namespace KINETO_NAMESPACE;
+using namespace libkineto;
+
+namespace {
+
+// Exposes the protected finalizeTrace(endTime) overload so the test can flush a
+// trace without constructing a Config / ActivityBuffers.
+class TestableChromeTraceLogger : public ChromeTraceLogger {
+ public:
+  explicit TestableChromeTraceLogger(const std::string& file)
+      : ChromeTraceLogger(file) {}
+  using ChromeTraceLogger::finalizeTrace;
+};
+
+std::string readFile(const std::string& path) {
+  std::ifstream f(path);
+  return std::string(
+      (std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+}
+
+// Write a trace containing a single CPU-op event with the given name, parse it
+// back, and assert the trace is valid JSON and the name round-trips exactly.
+void expectEventNameRoundTrips(const std::string& eventName) {
+  const std::string filename = ::testing::TempDir() + "kineto_output_json.json";
+
+  TraceSpan span(0, 0, "test_span");
+  GenericTraceActivity act(span, ActivityType::CPU_OP, eventName);
+  act.startTime = 100;
+  act.endTime = 200;
+  act.device = 0;
+  act.resource = 0;
+
+  TestableChromeTraceLogger logger(filename);
+  logger.handleTraceStart({}, "");
+  logger.handleGenericActivity(act);
+  logger.finalizeTrace(/*endTime=*/300);
+
+  nlohmann::json data;
+  ASSERT_NO_THROW(data = nlohmann::json::parse(readFile(filename)));
+
+  bool found = false;
+  for (const auto& event : data["traceEvents"]) {
+    if (event.contains("ph") && event["ph"] == "X" && event.contains("name") &&
+        event["name"].get<std::string>() == eventName) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "event name did not round-trip: " << eventName;
+
+  std::remove(filename.c_str());
+}
+
+} // namespace
+
+// Reproduces pytorch/pytorch#146900: with with_stack=True an event name can
+// contain `"` (e.g. dynamo co_filenames like {"device": "cpu"}). The writer
+// must JSON-escape those quotes so the trace stays valid JSON.
+TEST(OutputJsonTest, EventNameWithQuotesProducesValidJson) {
+  expectEventNameRoundTrips(R"({"device": "cpu", "dtype": "float32"}(12): run)");
+}
+
+TEST(OutputJsonTest, PlainEventNameIsUnchanged) {
+  expectEventNameRoundTrips("aten::addmm");
+}


### PR DESCRIPTION
# Fix: JSON-escape double quotes in chrome-trace event names

Fixes pytorch/pytorch#146900

## Summary

`ChromeTraceLogger` writes each event `name` as a bare JSON string value
(`"name": "<value>"`) but does not escape embedded double quotes. When an event
name contains a `"`, the JSON string terminates early and the **entire exported
`trace.json` becomes invalid** — `json.load()` raises
`JSONDecodeError: Expecting ',' delimiter`, and any downstream consumer
(TensorBoard, Perfetto, Chrome `chrome://tracing`, custom analyzers) fails to
load the whole trace, not just the offending event.

## How it happens

With `with_stack=True`, the profiler builds each Python-frame event name as
`"<co_filename>(<lineno>): <funcname>"`. The `co_filename` is attacker-free but
not quote-free:

- **`torch.compile` / dynamo** compile generated code whose `co_filename` is a
  dict-like string, e.g. `nn.Linear.__init__`'s
  `factory_kwargs = {"device": device, "dtype": dtype}` surfaces a "filename"
  like `{"device": "cpu", "dtype": "float32"}`.
- More generally, any frame whose source text (e.g. a `<module>` frame's line)
  contains a `"` — including ordinary module docstrings — produces the same
  corruption.

The result in the trace file:

```
"name": "{"device": "cpu", "dtype": "float32"}(12): run"
```

The unescaped `"` after `{` ends the JSON string, and the document no longer
parses.

This is the same class of bug as the previously-fixed #98432, which only
escaped backslashes (Windows paths) — quotes still slipped through.

## The fix

Add a small `escapeQuotesForJSON()` helper and apply it to the event name in
`ChromeTraceLogger::handleActivity()`, **after** the existing
`sanitizeStrForJSON()` / `sanitizeForNonReadableChars()` steps so the inserted
escape characters are not rewritten by the `\` → `/` substitution.

The helper is deliberately scoped to **bare string values** (the event name).
It is **not** applied to pre-formatted JSON fragments such as
`ITraceActivity::metadataJson()`, whose quotes are structural — escaping those
would corrupt valid metadata.

### Why quote-only escaping is sufficient here

By the time `escapeQuotesForJSON()` runs, the name has already been through:
- `sanitizeStrForJSON()` — replaces every `\` with `/` and strips `\n`, so no
  backslashes remain to double-escape, and
- `sanitizeForNonReadableChars()` — replaces the whole string with `"unknown"`
  if it contains any non-printable byte, so control characters cannot survive.

After that chain, `"` is the only JSON-special character that can remain, so
escaping it is enough to guarantee a valid JSON string value.

## Test

Adds `OutputJsonTest` (CPU-only):
- `EventNameWithQuotesProducesValidJson` — an event name containing quotes now
  produces valid JSON and the name round-trips exactly.
- `PlainEventNameIsUnchanged` — a normal name (e.g. `aten::addmm`) is untouched.

## Reproducer (from the issue)

```python
import json, torch
from torch.profiler import profile, ProfilerActivity
torch.set_num_threads(1)
g = {}
exec(compile("def run(a, b): return a @ b", '{"device": "cpu"}', "exec"), g)
x = torch.randn(8, 8)
with profile(activities=[ProfilerActivity.CPU], with_stack=True) as p:
    g["run"](x, x)
p.export_chrome_trace("/tmp/trace.json")
json.load(open("/tmp/trace.json"))   # before: JSONDecodeError; after: OK
```

Before this change the script raises `JSONDecodeError`; after it, the trace
loads and the quoted event name round-trips correctly.
