### PR TITLE
Add additional types to TypedMetadata.h and visitor classes

### DIFF
--- a/libkineto/include/TypedMetadata.h
+++ b/libkineto/include/TypedMetadata.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <variant>
 #include <vector>
 
 namespace libkineto {
@@ -27,6 +28,19 @@ struct MetadataField {
 struct MetadataDict {
   std::string_view name;
 };
+
+// Used to identify JSON fields from normal strings.
+struct RawJson {
+  std::string value;
+};
+
+// For a TensorList op argument: the per-dimension shape of each tensor in the
+// list.
+using TensorListShapes = std::vector<std::vector<int64_t>>;
+
+// "Input Dims" / "Input Strides" payload: one entry per op argument, each either
+// a single tensor's shape or, for a TensorList argument, a list of tensor shapes.
+using InputShapes = std::vector<std::variant<std::vector<int64_t>, TensorListShapes>>;
 
 /*
  * ITypedMetadataVisitor is a per-activity visitor for structured metadata with
@@ -101,6 +115,12 @@ class ITypedMetadataVisitor {
 
   virtual void visitValue(const MetadataField<std::vector<std::string>>& field,
                           const std::vector<std::string>& value) = 0;
+
+  virtual void visitValue(const MetadataField<RawJson>& field, const RawJson& value) = 0;
+
+  virtual void visitValue(const MetadataField<uint64_t>& field, uint64_t value) = 0;
+
+  virtual void visitValue(const MetadataField<InputShapes>& field, const InputShapes& value) = 0;
 };
 
 } // namespace libkineto

--- a/libkineto/include/TypedMetadataJson.h
+++ b/libkineto/include/TypedMetadataJson.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 // Migration-only typed metadata -> metadataJson compatibility helpers.
@@ -76,6 +77,18 @@ class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
     appendField(field, [&](std::string& json) { appendArray(json, value); });
   }
 
+  void visitValue(const MetadataField<RawJson>& field, const RawJson& value) override {
+    appendField(field, [&](std::string& json) { json += value.value; });
+  }
+
+  void visitValue(const MetadataField<uint64_t>& field, uint64_t value) override {
+    appendField(field, [&](std::string& json) { appendUIntValue(json, value); });
+  }
+
+  void visitValue(const MetadataField<InputShapes>& field, const InputShapes& value) override {
+    appendField(field, [&](std::string& json) { appendArray(json, value); });
+  }
+
   // Emit a visible placeholder rather than silently dropping a metadata type
   // the JSON serializer doesn't handle, so the gap shows up in the trace.
   void visitUnsupported(std::string_view name) override {
@@ -121,6 +134,12 @@ class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
     json.append(buf, static_cast<size_t>(result.ptr - buf));
   }
 
+  static void appendUIntValue(std::string& json, uint64_t value) {
+    char buf[kMaxInt64Chars];
+    const auto result = std::to_chars(buf, buf + sizeof(buf), value);
+    json.append(buf, static_cast<size_t>(result.ptr - buf));
+  }
+
   static void appendDoubleValue(std::string& json, double value) {
     if (std::isfinite(value)) {
       fmt::format_to(std::back_inserter(json), "{}", value);
@@ -149,6 +168,15 @@ class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
 
   static void appendArrayValue(std::string& json, const std::string& value) {
     appendQuoted(json, value);
+  }
+
+  // Nested-array entries so InputShapes serializes through the appendArray recursion
+  static void appendArrayValue(std::string& json, const std::vector<int64_t>& value) {
+    appendArray(json, value);
+  }
+
+  static void appendArrayValue(std::string& json, const std::variant<std::vector<int64_t>, TensorListShapes>& value) {
+    std::visit([&json](const auto& shapes) { appendArray(json, shapes); }, value);
   }
 
   std::string json_;

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -139,6 +139,19 @@ class RecordingTypedMetadataVisitor final : public ITypedMetadataVisitor {
     values_[std::string{field.name}] = value;
   }
 
+  void visitValue(const MetadataField<RawJson>& field, const RawJson& value)
+      override {
+    values_[std::string{field.name}] = std::string{value.value};
+  }
+
+  void visitValue(
+      [[maybe_unused]] const MetadataField<uint64_t>& field,
+      [[maybe_unused]] uint64_t value) override {}
+
+  void visitValue(
+      [[maybe_unused]] const MetadataField<InputShapes>& field,
+      [[maybe_unused]] const InputShapes& value) override {}
+
   void visitUnsupported(std::string_view /*name*/) override {}
 
   void beginDict(std::string_view /*name*/) override {}

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -113,6 +113,15 @@ struct RocmStreamTypedMetadataVisitor final : public ITypedMetadataVisitor {
   void visitValue(
       [[maybe_unused]] const MetadataField<std::vector<std::string>>& field,
       [[maybe_unused]] const std::vector<std::string>& value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<RawJson>& field,
+      [[maybe_unused]] const RawJson& value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<uint64_t>& field,
+      [[maybe_unused]] uint64_t value) override {}
+  void visitValue(
+      [[maybe_unused]] const MetadataField<InputShapes>& field,
+      [[maybe_unused]] const InputShapes& value) override {}
 
   void visitUnsupported(std::string_view /*name*/) override {}
 

--- a/libkineto/test/TypedMetadataTest.cpp
+++ b/libkineto/test/TypedMetadataTest.cpp
@@ -29,6 +29,9 @@ constexpr MetadataField<bool> kEnabled{"enabled"};
 constexpr MetadataField<std::vector<std::string>> kNames{"names"};
 constexpr MetadataField<std::pair<int64_t, int64_t>> kPair{"pair"};
 constexpr MetadataField<std::string> kSpecialChars{"special"};
+constexpr MetadataField<RawJson> kRaw{"raw"};
+constexpr MetadataField<uint64_t> kAddress{"address"};
+constexpr MetadataField<InputShapes> kInputDims{"input_dims"};
 constexpr MetadataDict kNested{"nested"};
 constexpr MetadataField<int64_t> kNestedCount{"nested_count"};
 constexpr MetadataField<int64_t> kNestedOther{"nested_other"};
@@ -75,6 +78,19 @@ class RecordingTypedMetadataVisitor : public ITypedMetadataVisitor {
       const std::vector<std::string>& value) override {
     record(field, value);
   }
+
+  void visitValue(const MetadataField<RawJson>& field, const RawJson& value)
+      override {
+    record(field, std::string{value.value});
+  }
+
+  void visitValue(
+      [[maybe_unused]] const MetadataField<uint64_t>& field,
+      [[maybe_unused]] uint64_t value) override {}
+
+  void visitValue(
+      [[maybe_unused]] const MetadataField<InputShapes>& field,
+      [[maybe_unused]] const InputShapes& value) override {}
 
   void visitUnsupported(std::string_view /*name*/) override {}
 
@@ -193,4 +209,37 @@ TEST(TypedMetadataVisitorTest, FallsBackToVisitUnsupported) {
 
   EXPECT_EQ(std::get<int64_t>(recorder.values.at("count")), int64_t{5});
   EXPECT_EQ(recorder.unsupportedFields, std::vector<std::string>({"pair"}));
+}
+
+TEST(TypedMetadataVisitorTest, SerializesRawJsonVerbatim) {
+  internal::JsonTypedMetadataVisitor jsonVisitor;
+  ITypedMetadataVisitor& visitor = jsonVisitor;
+
+  visitor.visit(kCount, int64_t{5});
+  visitor.visit(kRaw, RawJson{"[1, 2, 3]"});
+
+  const auto json = std::move(jsonVisitor).json();
+
+  // RawJson is emitted as-is, unquoted, so an array stays an array.
+  EXPECT_NE(json.find("\"raw\": [1, 2, 3]"), std::string::npos);
+}
+
+TEST(TypedMetadataVisitorTest, SerializesUInt64AndInputShapesToJson) {
+  internal::JsonTypedMetadataVisitor jsonVisitor;
+  ITypedMetadataVisitor& visitor = jsonVisitor;
+
+  visitor.visit(kAddress, uint64_t{18446744073709551615ULL});
+  InputShapes dims;
+  dims.emplace_back(std::vector<int64_t>{2, 2});
+  dims.emplace_back(TensorListShapes{{4, 1}, {4, 1}});
+  visitor.visit(kInputDims, dims);
+
+  const auto json = std::move(jsonVisitor).json();
+
+  // uint64 is emitted as an unsigned number, not truncated.
+  EXPECT_NE(json.find("\"address\": 18446744073709551615"), std::string::npos);
+  // Each arg is a single tensor's shape or a nested list of tensor shapes.
+  EXPECT_NE(
+      json.find("\"input_dims\": [[2, 2], [[4, 1], [4, 1]]]"),
+      std::string::npos);
 }


### PR DESCRIPTION
Summary: These are types that we need to support for the `GenericTraceActivity` migration to typed metadata.

Differential Revision: D110062366


