### PR TITLE
Migrate GenericTraceActivity to typed metadata (#1464)

### DIFF
--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -9,15 +9,18 @@
 #pragma once
 
 #include <fmt/format.h>
-#include <sstream>
+#include <optional>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 #include "ITraceActivity.h"
 #include "ThreadUtil.h"
 #include "TraceSpan.h"
+#include "TypedMetadata.h"
 
 namespace libkineto {
 
@@ -93,14 +96,22 @@ class GenericTraceActivity : public ITraceActivity {
 
   void log(ActivityLogger& logger) const override;
 
-  // Encode client side metadata as a key/value
+  // Encode client side metadata as a key/value (as a JSON fragment)
   template <typename ValType>
   void addMetadata(const std::string& key, const ValType& value) {
-    metadataMap_.emplace(key, std::make_pair(fmt::format("{}", value), false));
+    metadataMap_.emplace(key, RawJson{fmt::format("{}", value)});
   }
 
+  // Typed metadata: the value is stored as the field's declared type
+  template <typename T, typename V>
+  void addMetadata(const MetadataField<T>& field, const V& value) {
+    static_assert(std::is_same_v<T, std::decay_t<V>>, "value type must match field's declared type");
+    metadataMap_.emplace(std::string{field.name}, TypedValue{value});
+  }
+
+  // The value is a plain string to be emitted quoted in JSON.
   void addMetadataQuoted(const std::string& key, const std::string& value) {
-    metadataMap_.emplace(key, std::make_pair(value, true));
+    metadataMap_.emplace(key, value);
   }
 
   // Store a typed counter value. Preferred over addMetadata for counter
@@ -114,26 +125,29 @@ class GenericTraceActivity : public ITraceActivity {
     return counterValues_;
   }
 
-  const std::string getMetadataValue(const std::string& key) const override {
-    if (auto it = metadataMap_.find(key); it != metadataMap_.end()) {
-      return it->second.first;
+  // Return the metadata value in string format
+  const std::string getMetadataValue(const std::string& key) const override;
+
+  // Typed read-back
+  template <typename T>
+  std::optional<T> getMetadataValue(const MetadataField<T>& field) const {
+    const auto it = metadataMap_.find(std::string{field.name});
+    if (it != metadataMap_.end()) {
+      if (const T* value = std::get_if<T>(&it->second)) {
+        return *value;
+      }
     }
-    return "";
+    return std::nullopt;
   }
 
-  const std::string metadataJson() const override {
-    std::stringstream json;
-    bool first = true;
-    for (const auto& [key, val] : metadataMap_) {
-      if (!first) {
-        json << ", ";
-      }
-      // Ok to use fmt::format here as we are not logging
-      val.second ? json << fmt::format("\"{}\": \"{}\"", key, val.first)
-                 : json << fmt::format("\"{}\": {}", key, val.first);
-      first = false;
+  const std::string metadataJson() const override;
+
+  void visitTypedMetadata(ITypedMetadataVisitor& visitor) const override {
+    // Dynamically build a MetadataField during visit
+    for (const auto& kv : metadataMap_) {
+      std::visit([&](const auto& v) { visitor.visit(MetadataField<std::decay_t<decltype(v)>>{kv.first}, v); },
+                 kv.second);
     }
-    return json.str();
   }
 
   virtual ~GenericTraceActivity() override {}
@@ -159,8 +173,7 @@ class GenericTraceActivity : public ITraceActivity {
 
  private:
   const TraceSpan* traceSpan_;
-  // Metadata map: { key: (value, quoted)}
-  std::unordered_map<std::string, std::pair<std::string, bool>> metadataMap_;
+  std::unordered_map<std::string, TypedValue> metadataMap_;
   // Typed counter values: (name, double) to avoid round-tripping though string
   std::vector<std::pair<std::string, double>> counterValues_;
 };

--- a/libkineto/include/TypedMetadata.h
+++ b/libkineto/include/TypedMetadata.h
@@ -42,6 +42,17 @@ using TensorListShapes = std::vector<std::vector<int64_t>>;
 // a single tensor's shape or, for a TensorList argument, a list of tensor shapes.
 using InputShapes = std::vector<std::variant<std::vector<int64_t>, TensorListShapes>>;
 
+// The set of value types the typed-metadata system supports.
+using TypedValue = std::variant<int64_t,
+                                uint64_t,
+                                double,
+                                bool,
+                                std::string,
+                                std::vector<int64_t>,
+                                std::vector<std::string>,
+                                RawJson,
+                                InputShapes>;
+
 /*
  * ITypedMetadataVisitor is a per-activity visitor for structured metadata with
  * field-level type checking.

--- a/libkineto/include/TypedMetadataJson.h
+++ b/libkineto/include/TypedMetadataJson.h
@@ -45,6 +45,22 @@ class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
     return std::move(json_);
   }
 
+  // Public so GenericTraceActivity's metadata serialization can render
+  // collections without duplicating this logic.
+  template <typename T>
+  static void appendArray(std::string& json, const std::vector<T>& values) {
+    json += '[';
+    bool first = true;
+    for (const auto& value : values) {
+      if (!first) {
+        json += ", ";
+      }
+      appendArrayValue(json, value);
+      first = false;
+    }
+    json += ']';
+  }
+
  private:
   // Sized to hold the largest common CUDA activity (kernels) in one allocation, with some buffer
   static constexpr size_t kInitialJsonCapacity = 1024;
@@ -146,20 +162,6 @@ class JsonTypedMetadataVisitor final : public ITypedMetadataVisitor {
       return;
     }
     appendQuoted(json, fmt::format("{}", value));
-  }
-
-  template <typename T>
-  static void appendArray(std::string& json, const std::vector<T>& values) {
-    json += '[';
-    bool first = true;
-    for (const auto& value : values) {
-      if (!first) {
-        json += ", ";
-      }
-      appendArrayValue(json, value);
-      first = false;
-    }
-    json += ']';
   }
 
   static void appendArrayValue(std::string& json, int64_t value) {

--- a/libkineto/src/GenericTraceActivity.cpp
+++ b/libkineto/src/GenericTraceActivity.cpp
@@ -7,10 +7,60 @@
  */
 
 #include "GenericTraceActivity.h"
+#include "TypedMetadataJson.h"
 #include "output_base.h"
 
 namespace libkineto {
+
+namespace {
+template <typename>
+inline constexpr bool kAlwaysFalse = false;
+
+// Render a stored metadata value back to its legacy string form.
+std::string metadataValueToString(const TypedValue& value) {
+  return std::visit(
+      [](const auto& v) -> std::string {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::string>) {
+          return v;
+        } else if constexpr (std::is_same_v<T, RawJson>) {
+          return v.value;
+        } else if constexpr (
+            std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t> ||
+            std::is_same_v<T, double> || std::is_same_v<T, bool>) {
+          return fmt::format("{}", v);
+        } else if constexpr (
+            std::is_same_v<T, std::vector<int64_t>> ||
+            std::is_same_v<T, std::vector<std::string>> ||
+            std::is_same_v<T, InputShapes>) {
+          // Serialize collections through the JSON visitor's array helper.
+          std::string out;
+          internal::JsonTypedMetadataVisitor::appendArray(out, v);
+          return out;
+        } else {
+          static_assert(
+              kAlwaysFalse<T>,
+              "unhandled TypedValue alternative in metadataValueToString");
+        }
+      },
+      value);
+}
+} // namespace
+
 void GenericTraceActivity::log(ActivityLogger& logger) const {
   logger.handleGenericActivity(*this);
 }
+
+const std::string GenericTraceActivity::getMetadataValue(
+    const std::string& key) const {
+  const auto it = metadataMap_.find(key);
+  return it == metadataMap_.end() ? "" : metadataValueToString(it->second);
+}
+
+const std::string GenericTraceActivity::metadataJson() const {
+  internal::JsonTypedMetadataVisitor visitor;
+  visitTypedMetadata(visitor);
+  return std::move(visitor).json();
+}
+
 } // namespace libkineto

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -128,3 +128,28 @@ target_link_libraries(PidInfoTest PRIVATE
     kineto_base kineto_api
     ${XPU_XPUPTI_LIBRARY})
 gtest_discover_tests(PidInfoTest)
+
+# TypedMetadataTest
+add_executable(TypedMetadataTest TypedMetadataTest.cpp)
+target_link_libraries(TypedMetadataTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+target_include_directories(TypedMetadataTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src")
+gtest_discover_tests(TypedMetadataTest)
+
+# GenericTraceActivityMetadataTest
+add_executable(GenericTraceActivityMetadataTest
+    GenericTraceActivityMetadataTest.cpp)
+target_link_libraries(GenericTraceActivityMetadataTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+target_include_directories(GenericTraceActivityMetadataTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src")
+gtest_discover_tests(GenericTraceActivityMetadataTest)

--- a/libkineto/test/GenericTraceActivityMetadataTest.cpp
+++ b/libkineto/test/GenericTraceActivityMetadataTest.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "include/GenericTraceActivity.h"
+#include "include/TypedMetadata.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using namespace libkineto;
+
+namespace {
+
+// Records each visited field tagged by the visitValue overload that fired, so
+// tests can tell the verbatim RawJson path (string-keyed addMetadata) apart
+// from the typed path (the MetadataField overload).
+class RecordingVisitor : public ITypedMetadataVisitor {
+ public:
+  std::map<std::string, std::string> recorded;
+
+  void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
+    recorded[std::string{field.name}] = fmt::format("int64={}", value);
+  }
+  void visitValue(const MetadataField<double>& field, double value) override {
+    recorded[std::string{field.name}] = fmt::format("double={}", value);
+  }
+  void visitValue(const MetadataField<bool>& field, bool value) override {
+    recorded[std::string{field.name}] = fmt::format("bool={}", value);
+  }
+  void visitValue(
+      const MetadataField<std::string>& field,
+      std::string_view value) override {
+    recorded[std::string{field.name}] = fmt::format("string={}", value);
+  }
+  void visitValue(const MetadataField<RawJson>& field, const RawJson& value)
+      override {
+    recorded[std::string{field.name}] = fmt::format("rawjson={}", value.value);
+  }
+  void visitValue(
+      const MetadataField<std::vector<int64_t>>& field,
+      const std::vector<int64_t>& /*value*/) override {
+    recorded[std::string{field.name}] = "vector<int64>";
+  }
+  void visitValue(
+      const MetadataField<std::vector<std::string>>& field,
+      const std::vector<std::string>& /*value*/) override {
+    recorded[std::string{field.name}] = "vector<string>";
+  }
+  void visitValue(const MetadataField<uint64_t>& field, uint64_t value)
+      override {
+    recorded[std::string{field.name}] = fmt::format("uint64={}", value);
+  }
+  void visitValue(
+      const MetadataField<InputShapes>& field,
+      const InputShapes& /*value*/) override {
+    recorded[std::string{field.name}] = "inputshapes";
+  }
+  void visitUnsupported(std::string_view name) override {
+    recorded[std::string{name}] = "unsupported";
+  }
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
+};
+
+constexpr uint64_t kBigUnsigned = 18446744073709551615ULL;
+
+constexpr MetadataField<int64_t> kCount{"count"};
+constexpr MetadataField<double> kRatio{"ratio"};
+constexpr MetadataField<bool> kFlag{"flag"};
+constexpr MetadataField<std::string> kLabel{"label"};
+constexpr MetadataField<uint64_t> kAddress{"address"};
+constexpr MetadataField<InputShapes> kInputDims{"input_dims"};
+
+} // namespace
+
+TEST(GenericTraceActivityMetadataTest, StringKeyAddMetadataStoresRawJson) {
+  GenericTraceActivity activity;
+  activity.addMetadata("count", 5);
+  activity.addMetadata("ratio", 1.5);
+  activity.addMetadata("flag", true);
+  activity.addMetadataQuoted("label", "hello");
+  activity.addMetadata("dims", "[1, 2, 3]");
+  activity.addMetadata("addr", kBigUnsigned);
+
+  RecordingVisitor visitor;
+  activity.visitTypedMetadata(visitor);
+
+  // String-keyed addMetadata stores every non-string value as a verbatim JSON
+  // fragment
+  const std::map<std::string, std::string> expected{
+      {"count", "rawjson=5"},
+      {"ratio", "rawjson=1.5"},
+      {"flag", "rawjson=true"},
+      {"label", "string=hello"},
+      {"dims", "rawjson=[1, 2, 3]"},
+      {"addr", "rawjson=18446744073709551615"},
+  };
+  EXPECT_EQ(visitor.recorded, expected);
+}
+
+TEST(GenericTraceActivityMetadataTest, TypedFieldOverloadStoresDeclaredType) {
+  GenericTraceActivity activity;
+  activity.addMetadata(kCount, int64_t{5});
+  activity.addMetadata(kRatio, 1.5);
+  activity.addMetadata(kFlag, true);
+  activity.addMetadata(kLabel, std::string{"hello"});
+
+  RecordingVisitor visitor;
+  activity.visitTypedMetadata(visitor);
+
+  // The MetadataField overload stores each value as its declared type.
+  const std::map<std::string, std::string> expected{
+      {"count", "int64=5"},
+      {"ratio", "double=1.5"},
+      {"flag", "bool=true"},
+      {"label", "string=hello"},
+  };
+  EXPECT_EQ(visitor.recorded, expected);
+}
+
+TEST(GenericTraceActivityMetadataTest, MetadataJsonPreservesValueShapes) {
+  GenericTraceActivity activity;
+  activity.addMetadata("count", 5);
+  activity.addMetadata("ratio", 1.5);
+  activity.addMetadata("flag", true);
+  activity.addMetadataQuoted("label", "hello");
+  activity.addMetadata("dims", "[1, 2, 3]");
+  activity.addMetadata("addr", kBigUnsigned);
+
+  // Order is unspecified (unordered_map), so assert each field independently.
+  const std::string json = activity.metadataJson();
+  EXPECT_NE(json.find("\"count\": 5"), std::string::npos);
+  EXPECT_NE(json.find("\"ratio\": 1.5"), std::string::npos);
+  EXPECT_NE(json.find("\"flag\": true"), std::string::npos);
+  EXPECT_NE(json.find("\"label\": \"hello\""), std::string::npos);
+  // A raw JSON array stays an array, not a quoted string.
+  EXPECT_NE(json.find("\"dims\": [1, 2, 3]"), std::string::npos);
+  // 64-bit unsigned is emitted verbatim, not truncated.
+  EXPECT_NE(json.find("\"addr\": 18446744073709551615"), std::string::npos);
+}
+
+TEST(GenericTraceActivityMetadataTest, GetMetadataValueReturnsStringForm) {
+  GenericTraceActivity activity;
+  activity.addMetadata("count", 5);
+  activity.addMetadataQuoted("label", "hello");
+  activity.addMetadata("dims", "[1, 2, 3]");
+  activity.addMetadata("addr", kBigUnsigned);
+
+  // Each value comes back in the same string form addMetadata used to store
+  EXPECT_EQ(activity.getMetadataValue("count"), "5");
+  EXPECT_EQ(activity.getMetadataValue("label"), "hello");
+  EXPECT_EQ(activity.getMetadataValue("dims"), "[1, 2, 3]");
+  EXPECT_EQ(activity.getMetadataValue("addr"), "18446744073709551615");
+  EXPECT_EQ(activity.getMetadataValue("missing"), "");
+}
+
+TEST(GenericTraceActivityMetadataTest, TypedGetMetadataValueReturnsTypedValue) {
+  GenericTraceActivity activity;
+  activity.addMetadata(kCount, int64_t{5});
+  activity.addMetadata(kLabel, std::string{"hello"});
+  activity.addMetadata("rawInt", 7); // string path -> stored as RawJson
+
+  EXPECT_EQ(activity.getMetadataValue(kCount), std::optional<int64_t>{5});
+  EXPECT_EQ(
+      activity.getMetadataValue(kLabel), std::optional<std::string>{"hello"});
+  // Missing key.
+  EXPECT_EQ(activity.getMetadataValue(kRatio), std::nullopt);
+  // Stored as RawJson via the string path, so a typed int64 read doesn't match.
+  EXPECT_EQ(
+      activity.getMetadataValue(MetadataField<int64_t>{"rawInt"}),
+      std::nullopt);
+}
+
+TEST(GenericTraceActivityMetadataTest, TypedFieldOverloadStoresRichTypes) {
+  GenericTraceActivity activity;
+  activity.addMetadata(kAddress, kBigUnsigned);
+  InputShapes dims;
+  dims.emplace_back(std::vector<int64_t>{2, 2});
+  dims.emplace_back(TensorListShapes{{4, 1}, {4, 1}});
+  activity.addMetadata(kInputDims, dims);
+
+  // uint64 is stored typed and read back without truncation.
+  EXPECT_EQ(
+      activity.getMetadataValue(kAddress),
+      std::optional<uint64_t>{kBigUnsigned});
+
+  // Both rich types reach the visitor as their declared types.
+  RecordingVisitor visitor;
+  activity.visitTypedMetadata(visitor);
+  EXPECT_EQ(visitor.recorded.at("address"), "uint64=18446744073709551615");
+  EXPECT_EQ(visitor.recorded.at("input_dims"), "inputshapes");
+}
+
+TEST(
+    GenericTraceActivityMetadataTest,
+    GetMetadataValueSerializesTypedCollections) {
+  GenericTraceActivity activity;
+  activity.addMetadata(
+      MetadataField<std::vector<int64_t>>{"vec"},
+      std::vector<int64_t>{1, 2, 3});
+  InputShapes dims;
+  dims.emplace_back(std::vector<int64_t>{2, 2});
+  dims.emplace_back(TensorListShapes{{4, 1}, {4, 1}});
+  activity.addMetadata(kInputDims, dims);
+
+  // The string accessor renders a typed collection as the same JSON array
+  // string metadataJson() emits, not "".
+  EXPECT_EQ(activity.getMetadataValue("vec"), "[1, 2, 3]");
+  EXPECT_EQ(
+      activity.getMetadataValue("input_dims"), "[[2, 2], [[4, 1], [4, 1]]]");
+}


### PR DESCRIPTION
Summary:

`GenericTraceActivity` is an `ITraceActivity` class that is used to store arbitrary Kineto metadata. For example, it's used in the profiler (pytorch/pytorch) frontend to store things like input shapes/strides when record_shapes is turned on. Consumers interact with this class via `addMetadata` calls, storing metadata values as strings in a map. This means we need to be careful with compatibility both on the input and the output sides.

The changes in this diff maintain existing behavior while enabling us to slowly migrate callsites in a backwards compatible way. Concretely, we:

1. Modify `addMetadata` to store values as `RawJson` objects. In the last diff, we added handling to the Protobuf/JSON serializers to be able to write these. No change to existing callers is needed.
2. Add an `addMetadata` overload which takes a `MetadataField` object. This means that we can move `addMetadata` calls over to using typed `MetadataField` one by one, without breaking other callsites.
3. Modify `getMetadataValue` to unwrap the `RawJson` or convert the typed metadata value to a string, so that anyone consuming this downstream will still get the type they expect.
4. Add a `getMetadataValue` overload so that callers who pass in a `MetadataField` can get the same metadata, but without string conversion.

It is still a little awkward that `GenericTraceActivity` needs to materialize the metadata in a map, so we need to introduce new concepts (like `TypedValue`). Down the line I'd like to make sure we're using dedicated `ITraceActivity` overrides instead of dumping everything into `GenericTraceActivity`, but that'll be a problem for later.

Reviewed By: scotts

Differential Revision: D110063422


