### PR TITLE
Move vendor_dynolog.sh into third_party/dynolog (#1466)

### DIFF
--- a/libkineto/third_party/dynolog/vendor_dynolog.sh
+++ b/libkineto/third_party/dynolog/vendor_dynolog.sh
@@ -13,8 +13,9 @@
 
 set -euo pipefail
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-dest_dir="${script_dir}/dynolog"
+# Destination is the same directory this script lives in.
+dest_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 version_file="${dest_dir}/version.txt"
 repo_url="https://github.com/facebookincubator/dynolog.git"
 rel_headers="dynolog/src/ipcfabric"


### PR DESCRIPTION
Summary:

**Problem** — The dynolog re-vendor script landed at `libkineto/third_party/vendor_dynolog.sh`, one level above the directory it maintains. It belongs inside the vendored tree, next to the `version.txt`, `LICENSE`, and headers it writes.

**Fix** — Move it into `libkineto/third_party/dynolog/`.

Reviewed By: ryanzhang22

Differential Revision: D110509053
