### PR TITLE
Consolidate createTempTraceFile into a RAII util (#1468)

### DIFF
--- a/libkineto/test/ActivityProfilerControllerTest.cpp
+++ b/libkineto/test/ActivityProfilerControllerTest.cpp
@@ -14,13 +14,13 @@
 #include <fstream>
 #include <string>
 
-#include <unistd.h>
-
 #include "include/Config.h"
 #include "src/ActivityProfilerController.h"
+#include "test/TestUtils.h"
 
 using namespace std::chrono;
 using namespace KINETO_NAMESPACE;
+using namespace libkineto::test;
 
 namespace {
 
@@ -32,12 +32,6 @@ std::string logUrlToPath(const std::string& url) {
   return url;
 }
 
-void createTempTraceFile(char* filename) {
-  const int fd = mkstemps(filename, 5);
-  ASSERT_GE(fd, 0) << "mkstemps failed for " << filename;
-  close(fd);
-}
-
 bool traceFileHasContent(const std::string& filename) {
   std::ifstream file(filename, std::ios::binary | std::ios::ate);
   return file.is_open() && file.tellg() > 0;
@@ -46,8 +40,7 @@ bool traceFileHasContent(const std::string& filename) {
 } // namespace
 
 TEST(ActivityProfilerController, PrepareTraceClearsPendingAsyncRequest) {
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
   Config asyncCfg;
   bool success = asyncCfg.parse(
       fmt::format(
@@ -58,7 +51,7 @@ TEST(ActivityProfilerController, PrepareTraceClearsPendingAsyncRequest) {
     ACTIVITIES_DURATION_SECS = 1
     ACTIVITIES_LOG_FILE = {}
   )CFG",
-          filename));
+          traceFile.path()));
   ASSERT_TRUE(success);
 
   // Start an async request via acceptConfig -- populate asyncRequestConfig_
@@ -92,8 +85,7 @@ TEST(ActivityProfilerController, PrepareTraceClearsPendingAsyncRequest) {
 }
 
 TEST(ActivityProfilerController, IgnoreAsyncRequestsWhileSyncTraceIsActive) {
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
   Config asyncCfg;
   bool success = asyncCfg.parse(
       fmt::format(
@@ -104,7 +96,7 @@ TEST(ActivityProfilerController, IgnoreAsyncRequestsWhileSyncTraceIsActive) {
     ACTIVITIES_DURATION_SECS = 1
     ACTIVITIES_LOG_FILE = {}
   )CFG",
-          filename));
+          traceFile.path()));
   ASSERT_TRUE(success);
 
   ActivityProfilerController controller(ConfigLoader::instance(), true);
@@ -142,8 +134,7 @@ TEST(ActivityProfilerController, IgnoreAsyncRequestsWhileSyncTraceIsActive) {
 }
 
 TEST(ActivityProfilerController, PrepareTracePreemptsActiveAsyncRequest) {
-  char asyncFilename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(asyncFilename);
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
   Config asyncCfg;
   bool success = asyncCfg.parse(
       fmt::format(
@@ -154,7 +145,7 @@ TEST(ActivityProfilerController, PrepareTracePreemptsActiveAsyncRequest) {
     ACTIVITIES_DURATION_SECS = 1
     ACTIVITIES_LOG_FILE = {}
   )CFG",
-          asyncFilename));
+          traceFile.path()));
   ASSERT_TRUE(success);
 
   ActivityProfilerController controller(ConfigLoader::instance(), true);

--- a/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
+++ b/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
@@ -24,9 +24,11 @@
 #include "src/GenericActivityProfiler.h"
 
 #include "src/Logger.h"
+#include "test/TestUtils.h"
 
 using namespace std::chrono;
 using namespace KINETO_NAMESPACE;
+using namespace libkineto::test;
 
 // Subclass that lets us control isGpuCollectionStopped() for testing
 // the buffer-overflow-during-warmup path without needing real CUPTI.
@@ -69,12 +71,6 @@ static void checkTracefile(const char* filename) {
 #endif
 }
 
-static void createTempTraceFile(char* filename) {
-  const int fd = mkstemps(filename, 5);
-  ASSERT_GE(fd, 0) << "mkstemps failed for " << filename;
-  close(fd);
-}
-
 TEST(AsyncActivityProfilerHandler, AsyncTrace) {
   std::vector<std::string> log_modules(
       {"CuptiActivityProfiler.cpp", "output_json.cpp"});
@@ -83,8 +79,7 @@ TEST(AsyncActivityProfilerHandler, AsyncTrace) {
   GenericActivityProfiler profiler(/*cpu only*/ true);
   AsyncActivityProfilerHandler handler(profiler);
 
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
 
   Config cfg;
 
@@ -102,7 +97,7 @@ TEST(AsyncActivityProfilerHandler, AsyncTrace) {
     PROFILE_START_TIME = {}
   )CFG",
           warmup,
-          filename,
+          traceFile.path(),
           duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
 
   EXPECT_TRUE(success);
@@ -160,8 +155,7 @@ TEST(AsyncActivityProfilerHandler, AsyncTraceUsingIter) {
     GenericActivityProfiler profiler(/*cpu only*/ true);
     AsyncActivityProfilerHandler handler(profiler);
 
-    char filename[] = "/tmp/libkineto_testXXXXXX.json";
-    createTempTraceFile(filename);
+    auto traceFile = createTempTraceFile("libkineto_test", ".json");
 
     Config cfg;
 
@@ -180,7 +174,7 @@ TEST(AsyncActivityProfilerHandler, AsyncTraceUsingIter) {
             start_iter,
             warmup_iters,
             trace_iters,
-            filename));
+            traceFile.path()));
 
     EXPECT_TRUE(success);
     EXPECT_FALSE(handler.isAsyncActive());
@@ -239,8 +233,7 @@ TEST(AsyncActivityProfilerHandler, MetadataJsonFormatingTest) {
   GenericActivityProfiler profiler(/*cpu only*/ true);
   AsyncActivityProfilerHandler handler(profiler);
 
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
 
   Config cfg;
 
@@ -255,7 +248,7 @@ TEST(AsyncActivityProfilerHandler, MetadataJsonFormatingTest) {
     ACTIVITIES_LOG_FILE = {}
     PROFILE_START_TIME = {}
   )CFG",
-          filename,
+          traceFile.path(),
           duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
 
   EXPECT_TRUE(success);
@@ -326,8 +319,7 @@ TEST(AsyncActivityProfilerHandler, Cancel) {
   handler.cancel();
   EXPECT_FALSE(handler.isAsyncActive());
 
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
 
   Config cfg;
   auto now = system_clock::now();
@@ -341,7 +333,7 @@ TEST(AsyncActivityProfilerHandler, Cancel) {
     ACTIVITIES_LOG_FILE = {}
     PROFILE_START_TIME = {}
   )CFG",
-          filename,
+          traceFile.path(),
           duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
   EXPECT_TRUE(success);
 
@@ -370,8 +362,7 @@ TEST(AsyncActivityProfilerHandler, FinalizesPendingTraceOnTeardown) {
   // let the profiler loop finalize it, not drop it.
   GenericActivityProfiler profiler(/*cpu only*/ true);
 
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
 
   Config cfg;
 
@@ -384,7 +375,7 @@ TEST(AsyncActivityProfilerHandler, FinalizesPendingTraceOnTeardown) {
     ACTIVITIES_DURATION_SECS = 1
     ACTIVITIES_LOG_FILE = {}
   )CFG",
-          filename));
+          traceFile.path()));
   EXPECT_TRUE(success);
 
   {
@@ -417,8 +408,7 @@ TEST(AsyncActivityProfilerHandler, BufferSizeLimitDuringWarmup) {
   MockGpuProfiler profiler;
   AsyncActivityProfilerHandler handler(profiler);
 
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
 
   Config cfg;
   auto now = system_clock::now();
@@ -433,7 +423,7 @@ TEST(AsyncActivityProfilerHandler, BufferSizeLimitDuringWarmup) {
     PROFILE_START_TIME = {}
     ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB = 3
   )CFG",
-          filename,
+          traceFile.path(),
           duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
   EXPECT_TRUE(success);
 

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -33,7 +33,9 @@ target_link_libraries(ConfigTest PRIVATE
 gtest_discover_tests(ConfigTest)
 
 # ActivityProfilerControllerTest
-add_executable(ActivityProfilerControllerTest ActivityProfilerControllerTest.cpp)
+add_executable(ActivityProfilerControllerTest
+    ActivityProfilerControllerTest.cpp
+    TestUtils.cpp)
 target_link_libraries(ActivityProfilerControllerTest PRIVATE
     gtest_main
     kineto_base kineto_api
@@ -44,7 +46,8 @@ if(KINETO_BACKEND STREQUAL "cuda")
 # CuptiActivityProfilerTest
 add_executable(CuptiActivityProfilerTest
     CuptiActivityProfilerTest.cpp
-    MockActivitySubProfiler.cpp)
+    MockActivitySubProfiler.cpp
+    TestUtils.cpp)
 target_link_libraries(CuptiActivityProfilerTest PRIVATE
     gtest_main
     gmock
@@ -84,7 +87,8 @@ if(KINETO_BACKEND STREQUAL "rocm")
 # RocmActivityProfilerTest
 add_executable(RocmActivityProfilerTest
     RocmActivityProfilerTest.cpp
-    MockActivitySubProfiler.cpp)
+    MockActivitySubProfiler.cpp
+    TestUtils.cpp)
 target_compile_definitions(RocmActivityProfilerTest PRIVATE
     "__HIP_PLATFORM_HCC__"
     "__HIP_PLATFORM_AMD__")

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -21,8 +21,6 @@
 #include <optional>
 #include <variant>
 
-#include <unistd.h>
-
 #ifdef __linux__
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -42,9 +40,11 @@
 
 #include "src/Logger.h"
 #include "test/MockActivitySubProfiler.h"
+#include "test/TestUtils.h"
 
 using namespace std::chrono;
 using namespace KINETO_NAMESPACE;
+using namespace libkineto::test;
 
 const std::string kParamCommsCallName = "record_param_comms";
 static constexpr auto kCollectiveName = "Collective name";
@@ -79,12 +79,6 @@ namespace {
 const TraceSpan& defaultTraceSpan() {
   static TraceSpan span(0, 0, "Unknown", "");
   return span;
-}
-
-void createTempTraceFile(char* filename) {
-  const int fd = mkstemps(filename, 5);
-  ASSERT_GE(fd, 0) << "mkstemps failed for " << filename;
-  close(fd);
 }
 
 using RecordedMetadataValue = std::variant<
@@ -529,13 +523,12 @@ TEST_F(CuptiActivityProfilerTest, SyncTrace) {
   EXPECT_EQ(resourceIds[2], 1);
 
 #ifdef __linux__
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
-  trace.save(filename);
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  trace.save(tmpTrace.path());
   // Check that the expected file was written and that it has some content
-  int fd = open(filename, O_RDONLY);
+  int fd = open(tmpTrace.c_str(), O_RDONLY);
   if (!fd) {
-    perror(filename);
+    perror(tmpTrace.c_str());
   }
   EXPECT_TRUE(fd);
   // Should expect at least 100 bytes
@@ -546,7 +539,7 @@ TEST_F(CuptiActivityProfilerTest, SyncTrace) {
   // Verify Stream Sync events are on a separate row from kernel events
   // in the JSON trace output (tid offset by kSyncStreamTidOffset).
   {
-    std::ifstream traceFile(filename);
+    std::ifstream traceFile(tmpTrace.path());
     std::string traceStr(
         (std::istreambuf_iterator<char>(traceFile)),
         std::istreambuf_iterator<char>());
@@ -706,10 +699,9 @@ TEST_F(CuptiActivityProfilerTest, SyncEventCorrIdOutOfOrder) {
   EXPECT_EQ(eventSyncFound, 1) << "Expected exactly one Event Sync";
 
 #ifdef __linux__
-  char filename[] = "/tmp/libkineto_out_of_order_XXXXXX.json";
-  createTempTraceFile(filename);
-  trace.save(filename);
-  LOG(INFO) << "Trace exported to: " << filename;
+  auto tmpTrace = createTempTraceFile("libkineto_out_of_order_", ".json");
+  trace.save(tmpTrace.path());
+  LOG(INFO) << "Trace exported to: " << tmpTrace.path();
 #endif
 }
 
@@ -847,13 +839,12 @@ TEST_F(CuptiActivityProfilerTest, GpuNCCLCollectiveTest) {
 
 #ifdef __linux__
   // Test saved output can be loaded as JSON
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
-  LOG(INFO) << "Logging to tmp file: " << filename;
-  trace.save(filename);
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file: " << tmpTrace.path();
+  trace.save(tmpTrace.path());
 
   // Check that the saved JSON file can be loaded and deserialized
-  std::ifstream file(filename);
+  std::ifstream file(tmpTrace.path());
   if (!file.is_open()) {
     throw std::runtime_error("Failed to open the trace JSON file.");
   }
@@ -1003,9 +994,8 @@ TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
   profiler.startTrace(start_time);
   profiler.stopTrace(start_time + nanoseconds(duration_ns));
 
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
-  LOG(INFO) << "Logging to tmp file " << filename;
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file " << tmpTrace.path();
 
   // process trace
   auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
@@ -1016,16 +1006,16 @@ TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
   profiler.reset();
 
   ActivityTrace trace(std::move(logger), loggerFactory);
-  trace.save(filename);
+  trace.save(tmpTrace.path());
   const auto& traced_activites = trace.activities();
 
   // Test we have all the events
   EXPECT_EQ(traced_activites->size(), test_activities.size());
 
   // Check that the expected file was written and that it has some content
-  int fd = open(filename, O_RDONLY);
+  int fd = open(tmpTrace.c_str(), O_RDONLY);
   if (!fd) {
-    perror(filename);
+    perror(tmpTrace.c_str());
   }
   EXPECT_TRUE(fd);
 
@@ -1079,13 +1069,12 @@ TEST_F(CuptiActivityProfilerTest, JsonGPUIDSortTest) {
 
 #ifdef __linux__
   // Test saved output can be loaded as JSON
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
-  LOG(INFO) << "Logging to tmp file: " << filename;
-  trace.save(filename);
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file: " << tmpTrace.path();
+  trace.save(tmpTrace.path());
 
   // Check that the saved JSON file can be loaded and deserialized
-  std::ifstream file(filename);
+  std::ifstream file(tmpTrace.path());
   if (!file.is_open()) {
     throw std::runtime_error("Failed to open the trace JSON file.");
   }

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -45,9 +45,11 @@
 
 #include "src/Logger.h"
 #include "test/MockActivitySubProfiler.h"
+#include "test/TestUtils.h"
 
 using namespace std::chrono;
 using namespace KINETO_NAMESPACE;
+using namespace libkineto::test;
 
 const std::string kParamCommsCallName = "record_param_comms";
 static constexpr auto kCollectiveName = "Collective name";
@@ -73,12 +75,6 @@ namespace {
 const TraceSpan& defaultTraceSpan() {
   static TraceSpan span(0, 0, "Unknown", "");
   return span;
-}
-
-void createTempTraceFile(char* filename) {
-  const int fd = mkstemps(filename, 5);
-  ASSERT_GE(fd, 0) << "mkstemps failed for " << filename;
-  close(fd);
 }
 
 bool isAsyncCopy(const rocprofAsyncRow& async) {
@@ -460,13 +456,12 @@ TEST_F(RocmActivityProfilerTest, SyncTrace) {
   EXPECT_EQ(resourceIds[2], 2);
 
 #ifdef __linux__
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
-  trace.save(filename);
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  trace.save(tmpTrace.path());
   // Check that the expected file was written and that it has some content
-  int fd = open(filename, O_RDONLY);
+  int fd = open(tmpTrace.c_str(), O_RDONLY);
   if (!fd) {
-    perror(filename);
+    perror(tmpTrace.c_str());
   }
   EXPECT_TRUE(fd);
   // Should expect at least 100 bytes
@@ -559,11 +554,10 @@ TEST_F(
   EXPECT_EQ(memcpyActivity->resourceId(), 1);
 
 #ifdef __linux__
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
-  trace.save(filename);
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  trace.save(tmpTrace.path());
 
-  std::ifstream file(filename);
+  std::ifstream file(tmpTrace.path());
   ASSERT_TRUE(file.is_open());
   std::string jsonStr(
       (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
@@ -801,13 +795,12 @@ TEST_F(RocmActivityProfilerTest, GpuNCCLCollectiveTest) {
 
 #ifdef __linux__
   // Test saved output can be loaded as JSON
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
-  LOG(INFO) << "Logging to tmp file: " << filename;
-  trace.save(filename);
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file: " << tmpTrace.path();
+  trace.save(tmpTrace.path());
 
   // Check that the saved JSON file can be loaded and deserialized
-  std::ifstream file(filename);
+  std::ifstream file(tmpTrace.path());
   if (!file.is_open()) {
     throw std::runtime_error("Failed to open the trace JSON file.");
   }
@@ -955,9 +948,8 @@ TEST_F(RocmActivityProfilerTest, SubActivityProfilers) {
   profiler.startTrace(start_time);
   profiler.stopTrace(start_time + nanoseconds(duration_ns));
 
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
-  LOG(INFO) << "Logging to tmp file " << filename;
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file " << tmpTrace.path();
 
   // process trace
   auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
@@ -968,16 +960,16 @@ TEST_F(RocmActivityProfilerTest, SubActivityProfilers) {
   profiler.reset();
 
   ActivityTrace trace(std::move(logger), loggerFactory);
-  trace.save(filename);
+  trace.save(tmpTrace.path());
   const auto& traced_activites = trace.activities();
 
   // Test we have all the events
   EXPECT_EQ(traced_activites->size(), test_activities.size());
 
   // Check that the expected file was written and that it has some content
-  int fd = open(filename, O_RDONLY);
+  int fd = open(tmpTrace.c_str(), O_RDONLY);
   if (!fd) {
-    perror(filename);
+    perror(tmpTrace.c_str());
   }
   EXPECT_TRUE(fd);
 
@@ -1031,13 +1023,12 @@ TEST_F(RocmActivityProfilerTest, JsonGPUIDSortTest) {
 
 #ifdef __linux__
   // Test saved output can be loaded as JSON
-  char filename[] = "/tmp/libkineto_testXXXXXX.json";
-  createTempTraceFile(filename);
-  LOG(INFO) << "Logging to tmp file: " << filename;
-  trace.save(filename);
+  auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
+  LOG(INFO) << "Logging to tmp file: " << tmpTrace.path();
+  trace.save(tmpTrace.path());
 
   // Check that the saved JSON file can be loaded and deserialized
-  std::ifstream file(filename);
+  std::ifstream file(tmpTrace.path());
   if (!file.is_open()) {
     throw std::runtime_error("Failed to open the trace JSON file.");
   }

--- a/libkineto/test/TestUtils.cpp
+++ b/libkineto/test/TestUtils.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "test/TestUtils.h"
+
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace libkineto::test {
+
+TempTraceFile::TempTraceFile(std::string_view prefix, std::string_view suffix) {
+  std::string nameTemplate;
+  nameTemplate.reserve(5 + prefix.size() + 6 + suffix.size());
+  nameTemplate += "/tmp/";
+  nameTemplate += prefix;
+  nameTemplate += "XXXXXX";
+  nameTemplate += suffix;
+
+  const int fd = mkstemps(nameTemplate.data(), static_cast<int>(suffix.size()));
+  if (fd < 0) {
+    throw std::runtime_error("mkstemps failed for " + nameTemplate);
+  }
+  close(fd);
+  path_ = std::move(nameTemplate);
+}
+
+TempTraceFile::~TempTraceFile() {
+  if (!path_.empty()) {
+    unlink(path_.c_str());
+  }
+}
+
+TempTraceFile::TempTraceFile(TempTraceFile&& other) noexcept
+    : path_(std::move(other.path_)) {
+  other.path_.clear();
+}
+
+TempTraceFile& TempTraceFile::operator=(TempTraceFile&& other) noexcept {
+  if (this != &other) {
+    if (!path_.empty()) {
+      unlink(path_.c_str());
+    }
+    path_ = std::move(other.path_);
+    other.path_.clear();
+  }
+  return *this;
+}
+
+TempTraceFile createTempTraceFile(
+    std::string_view prefix,
+    std::string_view suffix) {
+  return TempTraceFile(prefix, suffix);
+}
+
+} // namespace libkineto::test

--- a/libkineto/test/TestUtils.h
+++ b/libkineto/test/TestUtils.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace libkineto::test {
+
+// Owns a uniquely-named temporary file for a test to write a trace into. The
+// file is created and its descriptor immediately closed on construction, and
+// the file is removed when the owner goes out of scope, so tests never leak
+// files under /tmp.
+class TempTraceFile {
+ public:
+  // Creates a file named /tmp/<prefix>XXXXXX<suffix>, where mkstemps replaces
+  // the six X characters with a unique component. suffix is preserved after
+  // that component so callers can keep a .json extension; pass an empty suffix
+  // for a name that ends in the random component.
+  explicit TempTraceFile(std::string_view prefix, std::string_view suffix);
+  ~TempTraceFile();
+
+  TempTraceFile(const TempTraceFile&) = delete;
+  TempTraceFile& operator=(const TempTraceFile&) = delete;
+
+  TempTraceFile(TempTraceFile&& other) noexcept;
+  TempTraceFile& operator=(TempTraceFile&& other) noexcept;
+
+  [[nodiscard]] const std::string& path() const {
+    return path_;
+  }
+
+  [[nodiscard]] const char* c_str() const {
+    return path_.c_str();
+  }
+
+ private:
+  std::string path_;
+};
+
+// Creates a self-cleaning temporary trace file; see TempTraceFile for the
+// naming scheme. The returned object removes the file when it goes out of
+// scope.
+[[nodiscard]] TempTraceFile createTempTraceFile(std::string_view prefix, std::string_view suffix);
+
+} // namespace libkineto::test


### PR DESCRIPTION
Summary:

The Kineto tests reimplemented `createTempTraceFile()` several times. Tests also usually leaked files in `/tmp`, because individual tests were responsible for calling `unlink()`. We create reusable test utils, and it first contains an RAII-based class for temp files.

Follow-ups will pull more duplicated test code into test utils.

Reviewed By: ryanzhang22

Differential Revision: D110533335


