### PR TITLE
Pull shared test helpers into the test-utils namespace

### DIFF
--- a/libkineto/test/ActivityProfilerControllerTest.cpp
+++ b/libkineto/test/ActivityProfilerControllerTest.cpp
@@ -24,14 +24,6 @@ using namespace libkineto::test;
 
 namespace {
 
-std::string logUrlToPath(const std::string& url) {
-  const std::string prefix = "file://";
-  if (url.substr(0, prefix.size()) == prefix) {
-    return url.substr(prefix.size());
-  }
-  return url;
-}
-
 bool traceFileHasContent(const std::string& filename) {
   std::ifstream file(filename, std::ios::binary | std::ios::ate);
   return file.is_open() && file.tellg() > 0;

--- a/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
+++ b/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
@@ -13,12 +13,6 @@
 
 #include <chrono>
 
-#ifdef __linux__
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#endif
-
 #include "include/Config.h"
 #include "src/AsyncActivityProfilerHandler.h"
 #include "src/GenericActivityProfiler.h"
@@ -48,28 +42,6 @@ class MockGpuProfiler : public GenericActivityProfiler {
  private:
   bool gpuStopped_{false};
 };
-
-static std::string logUrlToPath(const std::string& url) {
-  const std::string prefix = "file://";
-  if (url.substr(0, prefix.size()) == prefix) {
-    return url.substr(prefix.size());
-  }
-  return url;
-}
-
-static void checkTracefile(const char* filename) {
-#ifdef __linux__
-  int fd = open(filename, O_RDONLY);
-  if (fd == 0) {
-    perror(filename);
-  }
-  EXPECT_TRUE(fd);
-  struct stat buf{};
-  fstat(fd, &buf);
-  EXPECT_GT(buf.st_size, 100);
-  close(fd);
-#endif
-}
 
 TEST(AsyncActivityProfilerHandler, AsyncTrace) {
   std::vector<std::string> log_modules(
@@ -284,17 +256,6 @@ TEST(AsyncActivityProfilerHandler, MetadataJsonFormatingTest) {
   std::string jsonStr(
       (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
   folly::dynamic jsonData = folly::parseJson(jsonStr);
-
-  auto countSubstrings = [](const std::string& source,
-                            const std::string& substring) {
-    size_t count = 0;
-    size_t pos = source.find(substring);
-    while (pos != std::string::npos) {
-      ++count;
-      pos = source.find(substring, pos + substring.length());
-    }
-    return count;
-  };
 
   EXPECT_EQ(3, countSubstrings(jsonStr, keyPrefix));
   EXPECT_EQ(2, countSubstrings(jsonStr, "metadata value"));

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -47,6 +47,7 @@ if(KINETO_BACKEND STREQUAL "cuda")
 add_executable(CuptiActivityProfilerTest
     CuptiActivityProfilerTest.cpp
     MockActivitySubProfiler.cpp
+    MockCpuActivityBuffer.cpp
     TestUtils.cpp)
 target_link_libraries(CuptiActivityProfilerTest PRIVATE
     gtest_main
@@ -88,6 +89,7 @@ if(KINETO_BACKEND STREQUAL "rocm")
 add_executable(RocmActivityProfilerTest
     RocmActivityProfilerTest.cpp
     MockActivitySubProfiler.cpp
+    MockCpuActivityBuffer.cpp
     TestUtils.cpp)
 target_compile_definitions(RocmActivityProfilerTest PRIVATE
     "__HIP_PLATFORM_HCC__"

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -21,11 +21,6 @@
 #include <optional>
 #include <variant>
 
-#ifdef __linux__
-#include <fcntl.h>
-#include <sys/stat.h>
-#endif
-
 #include "include/Config.h"
 #include "include/libkineto.h"
 #include "include/output_base.h"
@@ -40,26 +35,12 @@
 
 #include "src/Logger.h"
 #include "test/MockActivitySubProfiler.h"
+#include "test/MockCpuActivityBuffer.h"
 #include "test/TestUtils.h"
 
 using namespace std::chrono;
 using namespace KINETO_NAMESPACE;
 using namespace libkineto::test;
-
-const std::string kParamCommsCallName = "record_param_comms";
-static constexpr auto kCollectiveName = "Collective name";
-static constexpr auto kDtype = "dtype";
-static constexpr auto kInMsgNelems = "In msg nelems";
-static constexpr auto kOutMsgNelems = "Out msg nelems";
-static constexpr auto kInSplit = "In split size";
-static constexpr auto kOutSplit = "Out split size";
-static constexpr auto kGroupSize = "Group size";
-static constexpr const char* kProcessGroupName = "Process Group Name";
-static constexpr const char* kProcessGroupDesc = "Process Group Description";
-static constexpr const char* kGroupRanks = "Process Group Ranks";
-static constexpr auto kSeqNum = "Seq";
-static constexpr const char* kCommsId = "Comms Id";
-static constexpr int32_t kTruncatLength = 30;
 
 #define CUDA_LAUNCH_KERNEL CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000
 #define CUDA_MEMCPY CUPTI_RUNTIME_TRACE_CBID_cudaMemcpy_v3020
@@ -76,11 +57,6 @@ static constexpr int32_t kTruncatLength = 30;
 #define CU_MEM_IMPORT CUPTI_DRIVER_TRACE_CBID_cuMemImportFromShareableHandle
 
 namespace {
-const TraceSpan& defaultTraceSpan() {
-  static TraceSpan span(0, 0, "Unknown", "");
-  return span;
-}
-
 using RecordedMetadataValue = std::variant<
     int64_t,
     double,
@@ -154,35 +130,6 @@ class RecordingTypedMetadataVisitor final : public ITypedMetadataVisitor {
   std::map<std::string, RecordedMetadataValue> values_;
 };
 } // namespace
-
-// Provides ability to easily create a few test CPU-side ops
-struct MockCpuActivityBuffer : public CpuTraceBuffer {
-  MockCpuActivityBuffer(int64_t startTime, int64_t endTime) {
-    span = TraceSpan(startTime, endTime, "Test trace");
-    gpuOpCount = 0;
-  }
-
-  void addOp(
-      std::string name,
-      int64_t startTime,
-      int64_t endTime,
-      int64_t correlation,
-      const std::unordered_map<std::string, std::string>& metadataMap = {}) {
-    GenericTraceActivity op(span, ActivityType::CPU_OP, name);
-    op.startTime = startTime;
-    op.endTime = endTime;
-    op.device = systemThreadId();
-    op.resource = systemThreadId();
-    op.id = correlation;
-
-    for (const auto& [key, val] : metadataMap) {
-      op.addMetadata(key, val);
-    }
-
-    emplace_activity(std::move(op));
-    span.opCount++;
-  }
-};
 
 // Provides ability to easily create a few test CUPTI ops
 struct MockCuptiActivityBuffer {
@@ -525,16 +472,7 @@ TEST_F(CuptiActivityProfilerTest, SyncTrace) {
 #ifdef __linux__
   auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
   trace.save(tmpTrace.path());
-  // Check that the expected file was written and that it has some content
-  int fd = open(tmpTrace.c_str(), O_RDONLY);
-  if (!fd) {
-    perror(tmpTrace.c_str());
-  }
-  EXPECT_TRUE(fd);
-  // Should expect at least 100 bytes
-  struct stat buf{};
-  fstat(fd, &buf);
-  EXPECT_GT(buf.st_size, 100);
+  checkTracefile(tmpTrace.c_str());
 
   // Verify Stream Sync events are on a separate row from kernel events
   // in the JSON trace output (tid offset by kSyncStreamTidOffset).
@@ -855,17 +793,6 @@ TEST_F(CuptiActivityProfilerTest, GpuNCCLCollectiveTest) {
   // Convert the JSON object to a string and check
   // if the substring exists
   std::string jsonString = jsonData.dump();
-  auto countSubstrings = [](const std::string& source,
-                            const std::string& substring) {
-    size_t count = 0;
-    size_t pos = source.find(substring);
-    while (pos != std::string::npos) {
-      ++count;
-      pos = source.find(substring, pos + substring.length());
-    }
-    return count;
-  };
-
   EXPECT_EQ(3, countSubstrings(jsonString, "65664"));
   EXPECT_EQ(3, countSubstrings(jsonString, kInMsgNelems));
   EXPECT_EQ(3, countSubstrings(jsonString, "65664"));
@@ -1012,17 +939,7 @@ TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
   // Test we have all the events
   EXPECT_EQ(traced_activites->size(), test_activities.size());
 
-  // Check that the expected file was written and that it has some content
-  int fd = open(tmpTrace.c_str(), O_RDONLY);
-  if (!fd) {
-    perror(tmpTrace.c_str());
-  }
-  EXPECT_TRUE(fd);
-
-  // Should expect at least 100 bytes
-  struct stat buf{};
-  fstat(fd, &buf);
-  EXPECT_GT(buf.st_size, 100);
+  checkTracefile(tmpTrace.c_str());
 }
 
 TEST_F(CuptiActivityProfilerTest, JsonGPUIDSortTest) {

--- a/libkineto/test/MockCpuActivityBuffer.cpp
+++ b/libkineto/test/MockCpuActivityBuffer.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "test/MockCpuActivityBuffer.h"
+
+#include "include/GenericTraceActivity.h"
+#include "include/ThreadUtil.h"
+
+namespace libkineto::test {
+
+const TraceSpan& defaultTraceSpan() {
+  static TraceSpan span(0, 0, "Unknown", "");
+  return span;
+}
+
+MockCpuActivityBuffer::MockCpuActivityBuffer(
+    int64_t startTime,
+    int64_t endTime) {
+  span = TraceSpan(startTime, endTime, "Test trace");
+  gpuOpCount = 0;
+}
+
+void MockCpuActivityBuffer::addOp(
+    const std::string& name,
+    int64_t startTime,
+    int64_t endTime,
+    int32_t correlation,
+    const std::unordered_map<std::string, std::string>& metadataMap) {
+  GenericTraceActivity op(span, ActivityType::CPU_OP, name);
+  op.startTime = startTime;
+  op.endTime = endTime;
+  op.device = systemThreadId();
+  op.resource = systemThreadId();
+  op.id = correlation;
+
+  for (const auto& [key, val] : metadataMap) {
+    op.addMetadata(key, val);
+  }
+
+  emplace_activity(std::move(op));
+  span.opCount++;
+}
+
+} // namespace libkineto::test

--- a/libkineto/test/MockCpuActivityBuffer.h
+++ b/libkineto/test/MockCpuActivityBuffer.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+#include "include/libkineto.h"
+
+// Shared fixtures for the CUDA and ROCm activity-profiler tests: a mock CPU-op
+// buffer, a default trace span, and the param-comms / collective metadata
+// field-name constants both tests assert on. These depend on the kineto
+// activity types, so they live here rather than in the generic TestUtils.h.
+
+namespace libkineto::test {
+
+inline const std::string kParamCommsCallName = "record_param_comms";
+inline constexpr auto kCollectiveName = "Collective name";
+inline constexpr auto kDtype = "dtype";
+inline constexpr auto kInMsgNelems = "In msg nelems";
+inline constexpr auto kOutMsgNelems = "Out msg nelems";
+inline constexpr auto kInSplit = "In split size";
+inline constexpr auto kOutSplit = "Out split size";
+inline constexpr auto kGroupSize = "Group size";
+inline constexpr const char* kProcessGroupName = "Process Group Name";
+inline constexpr const char* kProcessGroupDesc = "Process Group Description";
+inline constexpr const char* kGroupRanks = "Process Group Ranks";
+inline constexpr auto kSeqNum = "Seq";
+inline constexpr const char* kCommsId = "Comms Id";
+inline constexpr int32_t kTruncatLength = 30;
+
+// A shared default TraceSpan used to seed test activities.
+const TraceSpan& defaultTraceSpan();
+
+// A CpuTraceBuffer with a convenience addOp() for building CPU-side ops.
+struct MockCpuActivityBuffer : public CpuTraceBuffer {
+  MockCpuActivityBuffer(int64_t startTime, int64_t endTime);
+
+  void addOp(const std::string& name,
+             int64_t startTime,
+             int64_t endTime,
+             int32_t correlation,
+             const std::unordered_map<std::string, std::string>& metadataMap = {});
+};
+
+} // namespace libkineto::test

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -45,24 +45,12 @@
 
 #include "src/Logger.h"
 #include "test/MockActivitySubProfiler.h"
+#include "test/MockCpuActivityBuffer.h"
 #include "test/TestUtils.h"
 
 using namespace std::chrono;
 using namespace KINETO_NAMESPACE;
 using namespace libkineto::test;
-
-const std::string kParamCommsCallName = "record_param_comms";
-static constexpr auto kCollectiveName = "Collective name";
-static constexpr auto kDtype = "dtype";
-static constexpr auto kInMsgNelems = "In msg nelems";
-static constexpr auto kOutMsgNelems = "Out msg nelems";
-static constexpr auto kInSplit = "In split size";
-static constexpr auto kOutSplit = "Out split size";
-static constexpr auto kGroupSize = "Group size";
-static constexpr const char* kProcessGroupName = "Process Group Name";
-static constexpr const char* kProcessGroupDesc = "Process Group Description";
-static constexpr const char* kGroupRanks = "Process Group Ranks";
-static constexpr int32_t kTruncatLength = 30;
 
 // API ID macros for rocprofiler-sdk
 #define HIP_LAUNCH_KERNEL ROCPROFILER_HIP_RUNTIME_API_ID_hipLaunchKernel
@@ -72,11 +60,6 @@ static constexpr int32_t kTruncatLength = 30;
 #define RUNTIME_DOMAIN ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API
 
 namespace {
-const TraceSpan& defaultTraceSpan() {
-  static TraceSpan span(0, 0, "Unknown", "");
-  return span;
-}
-
 bool isAsyncCopy(const rocprofAsyncRow& async) {
   return async.domain == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY;
 }
@@ -128,35 +111,6 @@ struct RocmStreamTypedMetadataVisitor final : public ITypedMetadataVisitor {
   std::optional<int64_t> hsaQueue;
 };
 } // namespace
-
-// Provides ability to easily create a test CPU-side ops
-struct MockCpuActivityBuffer : public CpuTraceBuffer {
-  MockCpuActivityBuffer(int64_t startTime, int64_t endTime) {
-    span = TraceSpan(startTime, endTime, "Test trace");
-    gpuOpCount = 0;
-  }
-
-  void addOp(
-      std::string name,
-      int64_t startTime,
-      int64_t endTime,
-      int64_t correlation,
-      const std::unordered_map<std::string, std::string>& metadataMap = {}) {
-    GenericTraceActivity op(span, ActivityType::CPU_OP, name);
-    op.startTime = startTime;
-    op.endTime = endTime;
-    op.device = systemThreadId();
-    op.resource = systemThreadId();
-    op.id = correlation;
-
-    for (const auto& [key, val] : metadataMap) {
-      op.addMetadata(key, val);
-    }
-
-    emplace_activity(std::move(op));
-    span.opCount++;
-  }
-};
 
 // Provides ability to easily create test ROCm ops using the shared types
 // from RocLogger.h (rocprofKernelRow, rocprofAsyncRow, etc.)
@@ -355,22 +309,6 @@ class RocmActivityProfilerTest : public ::testing::Test {
   ActivityLoggerFactory loggerFactory;
 };
 
-void checkTracefile(const char* filename) {
-#ifdef __linux__
-  // Check that the expected file was written and that it has some content
-  int fd = open(filename, O_RDONLY);
-  if (!fd) {
-    perror(filename);
-  }
-  EXPECT_TRUE(fd);
-  // Should expect at least 100 bytes
-  struct stat buf{};
-  fstat(fd, &buf);
-  EXPECT_GT(buf.st_size, 100);
-  close(fd);
-#endif
-}
-
 TEST_F(RocmActivityProfilerTest, SyncTrace) {
   // Verbose logging is useful for debugging
   std::vector<std::string> log_modules({"RocmActivityProfiler.cpp"});
@@ -458,16 +396,7 @@ TEST_F(RocmActivityProfilerTest, SyncTrace) {
 #ifdef __linux__
   auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
   trace.save(tmpTrace.path());
-  // Check that the expected file was written and that it has some content
-  int fd = open(tmpTrace.c_str(), O_RDONLY);
-  if (!fd) {
-    perror(tmpTrace.c_str());
-  }
-  EXPECT_TRUE(fd);
-  // Should expect at least 100 bytes
-  struct stat buf{};
-  fstat(fd, &buf);
-  EXPECT_GT(buf.st_size, 100);
+  checkTracefile(tmpTrace.c_str());
 #endif
 }
 
@@ -811,17 +740,6 @@ TEST_F(RocmActivityProfilerTest, GpuNCCLCollectiveTest) {
   // Convert the JSON object to a string and check
   // if the substring exists
   std::string jsonString = jsonData.dump();
-  auto countSubstrings = [](const std::string& source,
-                            const std::string& substring) {
-    size_t count = 0;
-    size_t pos = source.find(substring);
-    while (pos != std::string::npos) {
-      ++count;
-      pos = source.find(substring, pos + substring.length());
-    }
-    return count;
-  };
-
   // Check that the metadata fields are present in the JSON file
   EXPECT_EQ(2, countSubstrings(jsonString, "65664"));
   EXPECT_EQ(2, countSubstrings(jsonString, kInMsgNelems));
@@ -966,17 +884,7 @@ TEST_F(RocmActivityProfilerTest, SubActivityProfilers) {
   // Test we have all the events
   EXPECT_EQ(traced_activites->size(), test_activities.size());
 
-  // Check that the expected file was written and that it has some content
-  int fd = open(tmpTrace.c_str(), O_RDONLY);
-  if (!fd) {
-    perror(tmpTrace.c_str());
-  }
-  EXPECT_TRUE(fd);
-
-  // Should expect at least 100 bytes
-  struct stat buf{};
-  fstat(fd, &buf);
-  EXPECT_GT(buf.st_size, 100);
+  checkTracefile(tmpTrace.c_str());
 }
 
 TEST_F(RocmActivityProfilerTest, JsonGPUIDSortTest) {

--- a/libkineto/test/TestUtils.cpp
+++ b/libkineto/test/TestUtils.cpp
@@ -17,6 +17,11 @@
 #include <string_view>
 #include <utility>
 
+#ifdef __linux__
+#include <fcntl.h>
+#include <sys/stat.h>
+#endif
+
 namespace libkineto::test {
 
 TempTraceFile::TempTraceFile(std::string_view prefix, std::string_view suffix) {
@@ -61,6 +66,41 @@ TempTraceFile createTempTraceFile(
     std::string_view prefix,
     std::string_view suffix) {
   return TempTraceFile(prefix, suffix);
+}
+
+std::string logUrlToPath(const std::string& url) {
+  const std::string prefix = "file://";
+  if (url.starts_with(prefix)) {
+    return url.substr(prefix.size());
+  }
+  return url;
+}
+
+size_t countSubstrings(
+    const std::string& source,
+    const std::string& substring) {
+  if (source.empty() || substring.empty()) {
+    return 0;
+  }
+  size_t count = 0;
+  size_t pos = source.find(substring);
+  while (pos != std::string::npos) {
+    ++count;
+    pos = source.find(substring, pos + substring.length());
+  }
+  return count;
+}
+
+void checkTracefile(const char* path) {
+#ifdef __linux__
+  // @lint-ignore NULLSAFECLANG callers always pass a non-null path
+  int fd = open(path, O_RDONLY);
+  ASSERT_GE(fd, 0) << "failed to open " << path;
+  struct stat buf{};
+  fstat(fd, &buf);
+  EXPECT_GT(buf.st_size, 100);
+  close(fd);
+#endif
 }
 
 } // namespace libkineto::test

--- a/libkineto/test/TestUtils.h
+++ b/libkineto/test/TestUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <string_view>
 
@@ -48,5 +49,15 @@ class TempTraceFile {
 // naming scheme. The returned object removes the file when it goes out of
 // scope.
 [[nodiscard]] TempTraceFile createTempTraceFile(std::string_view prefix, std::string_view suffix);
+
+// Strips a leading "file://" from url, returning the bare filesystem path.
+std::string logUrlToPath(const std::string& url);
+
+// Returns the number of non-overlapping occurrences of substring in source.
+size_t countSubstrings(const std::string& source, const std::string& substring);
+
+// Asserts (via gtest) that the file at path exists and holds more than 100
+// bytes. No-op on non-Linux platforms.
+void checkTracefile(const char* path);
 
 } // namespace libkineto::test


### PR DESCRIPTION
Summary:
Beyond `createTempTraceFile()`, the libkineto tests still carry several copy-pasted helpers duplicated across the CPU-handler and CUDA/ROCm profiler tests:

1. `logUrlToPath()`
2. `countSubstrings` lambda
3. `checkTracefile` file-size assertion (both as named copies and inlined open/fstat blocks)
4. `defaultTraceSpan` accessor,
5. `MockCpuActivityBuffer`, and a block of param-comms / collective metadata constants.

We pull the functions into the generic test utils, and create new source files for `MockCpuActivityBuffer`.

Differential Revision: D110774475


