### PR TITLE
Broaden AsyncActivityProfilerHandler test coverage

### DIFF
--- a/libkineto/src/AsyncActivityProfilerHandler.cpp
+++ b/libkineto/src/AsyncActivityProfilerHandler.cpp
@@ -47,14 +47,15 @@ AsyncActivityProfilerHandler::~AsyncActivityProfilerHandler() {
   ensureCollectTraceDone();
 }
 
-void AsyncActivityProfilerHandler::acceptConfig(const Config& config) {
+bool AsyncActivityProfilerHandler::acceptConfig(const Config& config) {
   VLOG(1) << "acceptConfig";
   if (config.activityProfilerEnabled()) {
-    scheduleTrace(config);
+    return scheduleTrace(config);
   }
+  return false;
 }
 
-void AsyncActivityProfilerHandler::scheduleTrace(const Config& config) {
+bool AsyncActivityProfilerHandler::scheduleTrace(const Config& config) {
   VLOG(1) << "scheduleTrace";
 
   int64_t currentIter = iterationCount_;
@@ -73,7 +74,7 @@ void AsyncActivityProfilerHandler::scheduleTrace(const Config& config) {
       logRequestCancellation(
           config,
           "Ignored profile iteration count based request as application is not updating iteration count");
-      return;
+      return false;
     }
   } else {
     configToSchedule = config.clone();
@@ -91,7 +92,7 @@ void AsyncActivityProfilerHandler::scheduleTrace(const Config& config) {
   if (!newConfigScheduled) {
     logRequestCancellation(
         config, "Ignored request - another profile request is pending.");
-    return;
+    return false;
   }
 
   // start a profilerLoop() thread to handle request
@@ -109,6 +110,7 @@ void AsyncActivityProfilerHandler::scheduleTrace(const Config& config) {
           &AsyncActivityProfilerHandler::profilerLoop, this);
     }
   }
+  return true;
 }
 
 void AsyncActivityProfilerHandler::step() {

--- a/libkineto/src/AsyncActivityProfilerHandler.h
+++ b/libkineto/src/AsyncActivityProfilerHandler.h
@@ -37,8 +37,13 @@ class AsyncActivityProfilerHandler {
   AsyncActivityProfilerHandler& operator=(AsyncActivityProfilerHandler&&) = delete;
   ~AsyncActivityProfilerHandler();
 
-  void acceptConfig(const Config& config);
-  void scheduleTrace(const Config& config);
+  // Returns true if the config enabled the activity profiler and the request
+  // was accepted (scheduled), false otherwise.
+  bool acceptConfig(const Config& config);
+  // Returns true if the request was accepted (scheduled), false if it was
+  // dropped (e.g. an iteration request with no duration when the application is
+  // not counting iterations, or another request is already pending).
+  bool scheduleTrace(const Config& config);
   void step();
 
   [[nodiscard]] bool isAsyncActive() const {

--- a/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
+++ b/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
@@ -7,11 +7,12 @@
  */
 
 #include <fmt/format.h>
-#include <folly/json/json.h>
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 #include <cstdlib>
 
 #include <chrono>
+#include <fstream>
 
 #include "include/Config.h"
 #include "src/AsyncActivityProfilerHandler.h"
@@ -23,6 +24,15 @@
 using namespace std::chrono;
 using namespace KINETO_NAMESPACE;
 using namespace libkineto::test;
+
+// Several tests step to timestamps derived from the warmup and duration values
+// they pass in the config, using named constants shared between the two so they
+// cannot drift apart. startTime leads now by the warmup period plus a
+// one-second buffer: canStart() requires at least ACTIVITIES_WARMUP_PERIOD_SECS
+// of lead time, and the buffer absorbs the millisecond truncation in the
+// PROFILE_START_TIME round-trip (a bare now + warmup can round just under and
+// be rejected). Steps meant to fall after collection add a second past
+// startTime + ACTIVITIES_DURATION_SECS.
 
 // Subclass that lets us control isGpuCollectionStopped() for testing
 // the buffer-overflow-during-warmup path without needing real CUPTI.
@@ -55,20 +65,22 @@ TEST(AsyncActivityProfilerHandler, AsyncTrace) {
 
   Config cfg;
 
+  constexpr int kWarmupSecs = 5;
+  constexpr int kDurationSecs = 1;
   int iter = 0;
-  int warmup = 5;
   auto now = system_clock::now();
-  auto startTime = now + seconds(10);
+  auto startTime = now + seconds(kWarmupSecs + 1);
 
   bool success = cfg.parse(
       fmt::format(
           R"CFG(
     ACTIVITIES_WARMUP_PERIOD_SECS = {}
-    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_DURATION_SECS = {}
     ACTIVITIES_LOG_FILE = {}
     PROFILE_START_TIME = {}
   )CFG",
-          warmup,
+          kWarmupSecs,
+          kDurationSecs,
           traceFile.path(),
           duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
 
@@ -85,7 +97,8 @@ TEST(AsyncActivityProfilerHandler, AsyncTrace) {
   // Warmup
   handler.performRunLoopStep(now, now);
 
-  auto next = now + milliseconds(1000);
+  // End of the collection window: startTime + duration.
+  auto next = startTime + seconds(kDurationSecs);
 
   // Iteration-based steps should have no effect on timestamp-based config
   while (++iter < 20) {
@@ -97,7 +110,8 @@ TEST(AsyncActivityProfilerHandler, AsyncTrace) {
 
   EXPECT_TRUE(handler.isAsyncActive());
 
-  auto nextnext = next + milliseconds(1000);
+  // Past the window, to drive the finalize (ProcessTrace) steps.
+  auto nextnext = next + seconds(kDurationSecs);
 
   while (++iter < 40) {
     handler.performRunLoopStep(next, next, iter);
@@ -209,17 +223,21 @@ TEST(AsyncActivityProfilerHandler, MetadataJsonFormatingTest) {
 
   Config cfg;
 
+  constexpr int kWarmupSecs = 1;
+  constexpr int kDurationSecs = 1;
   auto now = system_clock::now();
-  auto startTime = now + seconds(2);
+  auto startTime = now + seconds(kWarmupSecs + 1);
 
   bool success = cfg.parse(
       fmt::format(
           R"CFG(
-    ACTIVITIES_WARMUP_PERIOD_SECS = 1
-    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
+    ACTIVITIES_DURATION_SECS = {}
     ACTIVITIES_LOG_FILE = {}
     PROFILE_START_TIME = {}
   )CFG",
+          kWarmupSecs,
+          kDurationSecs,
           traceFile.path(),
           duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
 
@@ -235,8 +253,9 @@ TEST(AsyncActivityProfilerHandler, MetadataJsonFormatingTest) {
   profiler.addMetadata(keyPrefix + "NEWLINE", "\"metadata \nvalue\"");
   profiler.addMetadata(keyPrefix + "BACKSLASH", R"("/test/metadata\path")");
 
-  auto next = startTime + milliseconds(1000);
-  auto after = next + milliseconds(1000);
+  // End of the collection window, then a step past it to finalize.
+  auto next = startTime + seconds(kDurationSecs);
+  auto after = next + seconds(kDurationSecs);
 
   handler.performRunLoopStep(startTime, startTime);
   EXPECT_TRUE(handler.isAsyncActive());
@@ -255,15 +274,16 @@ TEST(AsyncActivityProfilerHandler, MetadataJsonFormatingTest) {
   }
   std::string jsonStr(
       (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-  folly::dynamic jsonData = folly::parseJson(jsonStr);
+  nlohmann::json jsonData = nlohmann::json::parse(jsonStr);
 
   EXPECT_EQ(3, countSubstrings(jsonStr, keyPrefix));
   EXPECT_EQ(2, countSubstrings(jsonStr, "metadata value"));
   EXPECT_EQ(1, countSubstrings(jsonStr, "/test/metadata/path"));
 
-  EXPECT_EQ(jsonData["PT_PROFILER_JOB_NAME"].asString(), "test_training_job");
-  EXPECT_EQ(jsonData["PT_PROFILER_JOB_VERSION"].asString(), "2");
-  EXPECT_EQ(jsonData["PT_PROFILER_JOB_ATTEMPT_INDEX"].asString(), "5");
+  EXPECT_EQ(
+      jsonData["PT_PROFILER_JOB_NAME"].get<std::string>(), "test_training_job");
+  EXPECT_EQ(jsonData["PT_PROFILER_JOB_VERSION"].get<std::string>(), "2");
+  EXPECT_EQ(jsonData["PT_PROFILER_JOB_ATTEMPT_INDEX"].get<std::string>(), "5");
 #endif
 
   unsetenv("PT_PROFILER_JOB_NAME");
@@ -283,17 +303,19 @@ TEST(AsyncActivityProfilerHandler, Cancel) {
   auto traceFile = createTempTraceFile("libkineto_test", ".json");
 
   Config cfg;
+  constexpr int kWarmupSecs = 5;
   auto now = system_clock::now();
-  auto startTime = now + seconds(10);
+  auto startTime = now + seconds(kWarmupSecs + 1);
 
   bool success = cfg.parse(
       fmt::format(
           R"CFG(
-    ACTIVITIES_WARMUP_PERIOD_SECS = 5
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
     ACTIVITIES_DURATION_SECS = 1
     ACTIVITIES_LOG_FILE = {}
     PROFILE_START_TIME = {}
   )CFG",
+          kWarmupSecs,
           traceFile.path(),
           duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
   EXPECT_TRUE(success);
@@ -372,18 +394,20 @@ TEST(AsyncActivityProfilerHandler, BufferSizeLimitDuringWarmup) {
   auto traceFile = createTempTraceFile("libkineto_test", ".json");
 
   Config cfg;
+  constexpr int kWarmupSecs = 5;
   auto now = system_clock::now();
-  auto startTime = now + seconds(10);
+  auto startTime = now + seconds(kWarmupSecs + 1);
 
   bool success = cfg.parse(
       fmt::format(
           R"CFG(
-    ACTIVITIES_WARMUP_PERIOD_SECS = 5
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
     ACTIVITIES_DURATION_SECS = 1
     ACTIVITIES_LOG_FILE = {}
     PROFILE_START_TIME = {}
     ACTIVITIES_MAX_GPU_BUFFER_SIZE_MB = 3
   )CFG",
+          kWarmupSecs,
           traceFile.path(),
           duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
   EXPECT_TRUE(success);
@@ -399,4 +423,236 @@ TEST(AsyncActivityProfilerHandler, BufferSizeLimitDuringWarmup) {
   now = startTime;
   handler.performRunLoopStep(now, now);
   EXPECT_FALSE(handler.isAsyncActive());
+}
+
+// An iteration-based request that arrives before the application has begun
+// counting iterations (iterationCount_ == -1) cannot be honored unless it also
+// carries a duration. With no duration it must be dropped, not scheduled.
+TEST(AsyncActivityProfilerHandler, IterationRequestWithoutStepIsRejected) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+  bool success = cfg.parse(
+      fmt::format(
+          R"CFG(
+    PROFILE_START_ITERATION = 5
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 2
+    ACTIVITIES_DURATION_SECS = 0
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+          traceFile.path()));
+  ASSERT_TRUE(success);
+  ASSERT_TRUE(cfg.hasProfileStartIteration());
+
+  // No step() has advanced the iteration count, so the request is dropped
+  // synchronously.
+  EXPECT_FALSE(handler.scheduleTrace(cfg));
+  EXPECT_FALSE(handler.isAsyncActive());
+}
+
+// The same iteration-based request is accepted when it carries a duration: the
+// handler falls back to duration/timestamp scheduling instead of rejecting it.
+// This is the path daemon configs take when the application is not reporting
+// iterations.
+TEST(
+    AsyncActivityProfilerHandler,
+    IterationRequestWithDurationFallsBackToTimestamp) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+  bool success = cfg.parse(
+      fmt::format(
+          R"CFG(
+    PROFILE_START_ITERATION = 5
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 2
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+          traceFile.path()));
+  ASSERT_TRUE(success);
+  ASSERT_TRUE(cfg.hasProfileStartIteration());
+
+  // Accepted via the duration fallback (contrast the no-duration case above,
+  // which is rejected). scheduleTrace() reports the decision synchronously.
+  EXPECT_TRUE(handler.scheduleTrace(cfg));
+}
+
+// Only one on-demand request may be pending at a time. A second request that
+// arrives while the first is still pending is dropped.
+TEST(AsyncActivityProfilerHandler, SecondRequestWhilePendingIsRejected) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto acceptedFile = createTempTraceFile("libkineto_test_accepted", ".json");
+  auto rejectedFile = createTempTraceFile("libkineto_test_rejected", ".json");
+
+  // Start far in the future so neither request activates during the test; the
+  // accept/reject decision is made synchronously inside scheduleTrace().
+  auto startMs = duration_cast<milliseconds>(
+                     (system_clock::now() + seconds(3600)).time_since_epoch())
+                     .count();
+
+  Config accepted;
+  ASSERT_TRUE(accepted.parse(
+      fmt::format(
+          R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = 0
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+          acceptedFile.path(),
+          startMs)));
+
+  Config rejected;
+  ASSERT_TRUE(rejected.parse(
+      fmt::format(
+          R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = 0
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+          rejectedFile.path(),
+          startMs)));
+
+  // The first request is accepted; a second arriving while it is still pending
+  // is rejected.
+  EXPECT_TRUE(handler.scheduleTrace(accepted));
+  EXPECT_FALSE(handler.scheduleTrace(rejected));
+}
+
+// configure() must refuse a request whose start time has already passed rather
+// than entering warmup for a trace that can never start on time. The start time
+// is kept within the max request age so the config still parses.
+TEST(AsyncActivityProfilerHandler, ConfigureRejectsStartTimeInThePast) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  auto now = system_clock::now();
+  auto startTime = now - seconds(5);
+
+  Config cfg;
+  bool success = cfg.parse(
+      fmt::format(
+          R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = 5
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+          traceFile.path(),
+          duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
+  ASSERT_TRUE(success);
+
+  handler.configure(cfg, now);
+  EXPECT_FALSE(handler.isAsyncActive());
+}
+
+// cancel() must tear down cleanly when the trace has finished collecting and is
+// waiting to be processed (RunloopState::ProcessTrace), returning the handler
+// to the idle state.
+TEST(AsyncActivityProfilerHandler, CancelDuringProcessTrace) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  constexpr int kWarmupSecs = 5;
+  constexpr int kDurationSecs = 1;
+  auto now = system_clock::now();
+  auto startTime = now + seconds(kWarmupSecs + 1);
+
+  Config cfg;
+  bool success = cfg.parse(
+      fmt::format(
+          R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = {}
+    ACTIVITIES_DURATION_SECS = {}
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+          kWarmupSecs,
+          kDurationSecs,
+          traceFile.path(),
+          duration_cast<milliseconds>(startTime.time_since_epoch()).count()));
+  ASSERT_TRUE(success);
+
+  handler.configure(cfg, now);
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  // Warmup -> CollectTrace at the start time.
+  now = startTime;
+  handler.performRunLoopStep(now, now);
+
+  // CollectTrace -> ProcessTrace once the collection window closes (a second
+  // past startTime + duration). Driving with the default currentIter (-1)
+  // collects inline, so the state settles on ProcessTrace.
+  auto afterEnd = startTime + seconds(kDurationSecs + 1);
+  handler.performRunLoopStep(afterEnd, afterEnd);
+  EXPECT_TRUE(handler.isAsyncActive());
+
+  handler.cancel();
+  EXPECT_FALSE(handler.isAsyncActive());
+}
+
+// acceptConfig() only schedules when the config actually enables the activity
+// profiler; a config with activities disabled is a no-op.
+TEST(
+    AsyncActivityProfilerHandler,
+    AcceptConfigIgnoresDisabledActivityProfiler) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  Config cfg;
+  ASSERT_TRUE(cfg.parse("ACTIVITIES_ENABLED = false"));
+  ASSERT_FALSE(cfg.activityProfilerEnabled());
+
+  // acceptConfig() reports that it declined the disabled config, rather than
+  // silently doing nothing.
+  EXPECT_FALSE(handler.acceptConfig(cfg));
+  EXPECT_FALSE(handler.isAsyncActive());
+}
+
+// acceptConfig() schedules and reports acceptance when the config enables the
+// activity profiler. Paired with the disabled case above, this pins that the
+// return value reflects the config rather than being constant.
+TEST(
+    AsyncActivityProfilerHandler,
+    AcceptConfigSchedulesEnabledActivityProfiler) {
+  GenericActivityProfiler profiler(/*cpu only*/ true);
+  AsyncActivityProfilerHandler handler(profiler);
+
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  // Far-future start so the request stays scheduled without activating during
+  // the test.
+  auto startMs = duration_cast<milliseconds>(
+                     (system_clock::now() + seconds(3600)).time_since_epoch())
+                     .count();
+
+  Config cfg;
+  ASSERT_TRUE(cfg.parse(
+      fmt::format(
+          R"CFG(
+    ACTIVITIES_WARMUP_PERIOD_SECS = 0
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+    PROFILE_START_TIME = {}
+  )CFG",
+          traceFile.path(),
+          startMs)));
+  ASSERT_TRUE(cfg.activityProfilerEnabled());
+
+  EXPECT_TRUE(handler.acceptConfig(cfg));
 }

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -42,6 +42,17 @@ target_link_libraries(ActivityProfilerControllerTest PRIVATE
     ${XPU_XPUPTI_LIBRARY})
 gtest_discover_tests(ActivityProfilerControllerTest)
 
+# AsyncActivityProfilerHandlerTest
+add_executable(AsyncActivityProfilerHandlerTest
+    AsyncActivityProfilerHandlerTest.cpp
+    TestUtils.cpp)
+target_link_libraries(AsyncActivityProfilerHandlerTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    nlohmann_json::nlohmann_json
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(AsyncActivityProfilerHandlerTest)
+
 if(KINETO_BACKEND STREQUAL "cuda")
 # CuptiActivityProfilerTest
 add_executable(CuptiActivityProfilerTest


### PR DESCRIPTION
Summary:
Adds new, deterministic unit tests for `AsyncActivityProfilerHandler`. Important changes other than the new unit tests:

1. We modify the implementations of `scheduleTrace()` and `acceptConfig()` so that they return a bool indicating if the operation succeeded or failed because something else was already going on. This makes the behavior easier to test without any thread synchronization.
2. Migrates the folly JSON usage to nlohmann JSON support. These tests were disabled externally because of this.
3. Modifies existing unit tests to make the relationship between the times provided to the APIs under test and the configs provided.

Differential Revision: D110935471


