### PR TITLE
Close leaked /proc/self/ns/pid fd in pidNamespace()

### DIFF
--- a/libkineto/src/ThreadUtil.cpp
+++ b/libkineto/src/ThreadUtil.cpp
@@ -56,7 +56,9 @@ int32_t pidNamespace(ino_t& ns) {
   }
 
   struct stat self_stat;
-  if (fstat(fd, &self_stat) == -1) {
+  int rc = fstat(fd, &self_stat);
+  close(fd);
+  if (rc == -1) {
     return -1;
   }
   ns = self_stat.st_ino;


### PR DESCRIPTION
Summary:
`libkineto::pidNamespace()` opens `/proc/self/ns/pid` but never calls `close(fd)` on either the `fstat` error path or the success path, so it leaks one nsfs file descriptor on every successful call. It is invoked from `DynoConfigClient::getLibkinetoOndemandConfig` on the on-demand config polling path, so any long-running kineto-linked process leaks fds continuously.

Fix: capture the `fstat` result, `close(fd)` unconditionally, then branch on the result. `close()` is already available via the `<unistd.h>` include.

Reviewed By: mzzchy

Differential Revision: D110859288


