### PR TITLE
Add old dynolog path to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ __pycache__
 
 # CMake build output
 libkineto/build/
+
+# Stale nested-submodule checkout left behind in existing recursive PyTorch checkouts.
+# Dynolog is no longer a submodule; required headers are vendored under dynolog_headers/.
+/libkineto/third_party/dynolog/


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/189276 contains pytorch/kineto#1446 which removes kineto/third_party/dynolog as a submodule of Kineto. Since it's a nested submodule of pytorch/pytorch, it looks like git submodule update --init --recursive refuses to clean it up and marks the entire Kineto submodule as dirty.

We can't land the bump as is because it'll just get reverted by the backwards compat test continuing to recognize the dirty submodule. So try adding the dynolog path to .gitignore so it doesn't come up again.

Differential Revision: D111291137


