### PR TITLE
Test controller async request arbitration

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -201,7 +201,7 @@ void ActivityProfilerController::logInvariantViolation(
   }
 }
 
-// Async-only functions
+// ConfigLoader::ConfigHandler callback API.
 bool ActivityProfilerController::canAcceptConfig() {
   return !isActive();
 }
@@ -212,6 +212,8 @@ void ActivityProfilerController::acceptConfig(const Config& config) {
   }
   asyncHandler_->acceptConfig(config);
 }
+
+// These API are used for On-Demand Tracing.
 void ActivityProfilerController::asyncScheduleTrace(const Config& config) {
   if (isActive()) {
     logRequestCancellation(config, "Ignored request - profiler busy");
@@ -223,7 +225,7 @@ void ActivityProfilerController::asyncStep() {
   asyncHandler_->step();
 }
 
-// Sync-only functions
+// These API are used for Synchronous Tracing.
 void ActivityProfilerController::syncPrepareTrace(const Config& config) {
   // Sync-trace requests preempt any active trace.
   asyncHandler_->cancel();

--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -205,12 +205,12 @@ void ActivityProfilerController::logInvariantViolation(
 bool ActivityProfilerController::canAcceptConfig() {
   return !isActive();
 }
-void ActivityProfilerController::acceptConfig(const Config& config) {
+bool ActivityProfilerController::acceptConfig(const Config& config) {
   if (isActive()) {
     logRequestCancellation(config, "Ignored request - profiler busy");
-    return;
+    return false;
   }
-  asyncHandler_->acceptConfig(config);
+  return asyncHandler_->acceptConfig(config);
 }
 
 // These API are used for On-Demand Tracing.

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -50,7 +50,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
 
   // ConfigLoader::ConfigHandler callback API.
   bool canAcceptConfig() override;
-  void acceptConfig(const Config& config) override;
+  bool acceptConfig(const Config& config) override;
 
   // These API are used for On-Demand Tracing.
   void asyncScheduleTrace(const Config& config);

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -36,7 +36,7 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   ActivityProfilerController(const ActivityProfilerController&) = delete;
   ActivityProfilerController& operator=(const ActivityProfilerController&) = delete;
 
-  ~ActivityProfilerController();
+  ~ActivityProfilerController() override;
 
 #if !USE_GOOGLE_LOG
   static void addLoggerCollectorFactory(const std::function<std::shared_ptr<LoggerCollector>()>& factory);

--- a/libkineto/src/ActivityProfilerProxy.cpp
+++ b/libkineto/src/ActivityProfilerProxy.cpp
@@ -43,7 +43,9 @@ bool ActivityProfilerProxy::isStopped() const {
 void ActivityProfilerProxy::scheduleTrace(const std::string& configStr) {
   resetTLS();
   Config config;
-  config.parse(configStr);
+  if (!config.parse(configStr)) {
+    LOG(WARNING) << "Failed to parse config : " << configStr;
+  }
   controller_->asyncScheduleTrace(config);
 }
 

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -37,7 +37,11 @@ class ConfigLoader {
   struct ConfigHandler {
     virtual ~ConfigHandler() = default;
     virtual bool canAcceptConfig() = 0;
-    virtual void acceptConfig(const Config& cfg) = 0;
+    // Returns true if the handler accepted the config for scheduling, false if
+    // it declined. Acceptance means the request was queued, NOT that profiling
+    // will run: a queued request can still be dropped later on the profiler
+    // thread (e.g. canStart() fails, or GPU buffers overflow during warmup).
+    virtual bool acceptConfig(const Config& cfg) = 0;
   };
 
   void addHandler(ConfigKind kind, ConfigHandler* handler) {

--- a/libkineto/src/EventProfilerController.cpp
+++ b/libkineto/src/EventProfilerController.cpp
@@ -267,18 +267,19 @@ bool EventProfilerController::canAcceptConfig() {
   return !newOnDemandConfig_;
 }
 
-void EventProfilerController::acceptConfig(const Config& config) {
+bool EventProfilerController::acceptConfig(const Config& config) {
   if (config.eventProfilerOnDemandDuration().count() == 0) {
     // Ignore - not for this profiler
-    return;
+    return false;
   }
   std::lock_guard<std::mutex> guard(mutex_);
   if (newOnDemandConfig_) {
     LOG(WARNING) << "On demand request already queued - ignoring new request";
-    return;
+    return false;
   }
   newOnDemandConfig_ = config.clone();
   LOG(INFO) << "Received new on-demand config";
+  return true;
 }
 
 bool EventProfilerController::enableForDevice(Config& cfg) {

--- a/libkineto/src/EventProfilerController.h
+++ b/libkineto/src/EventProfilerController.h
@@ -47,7 +47,7 @@ class EventProfilerController : public ConfigLoader::ConfigHandler {
 
   bool canAcceptConfig() override;
 
-  void acceptConfig(const Config& config) override;
+  bool acceptConfig(const Config& config) override;
 
  private:
   explicit EventProfilerController(CUcontext context,

--- a/libkineto/test/ActivityProfilerControllerTest.cpp
+++ b/libkineto/test/ActivityProfilerControllerTest.cpp
@@ -173,3 +173,83 @@ TEST(ActivityProfilerController, PrepareTracePreemptsActiveAsyncRequest) {
   const std::string logFile = logUrlToPath(asyncCfg.activitiesLogUrl());
   EXPECT_FALSE(traceFileHasContent(logFile)) << logFile;
 }
+
+// While an async trace is already active, the controller drops a second
+// on-demand request instead of scheduling it. This complements the tests above,
+// which cover a sync trace blocking or preempting async.
+TEST(ActivityProfilerController, SecondAsyncRequestIgnoredWhileAsyncActive) {
+  auto firstFile = createTempTraceFile("libkineto_test_first", ".json");
+  auto secondFile = createTempTraceFile("libkineto_test_second", ".json");
+
+  Config firstCfg;
+  ASSERT_TRUE(firstCfg.parse(
+      fmt::format(
+          R"CFG(
+    PROFILE_START_ITERATION = 3
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 4
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+          firstFile.path())));
+
+  Config secondCfg;
+  ASSERT_TRUE(secondCfg.parse(
+      fmt::format(
+          R"CFG(
+    PROFILE_START_ITERATION = 3
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 4
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+          secondFile.path())));
+
+  ActivityProfilerController controller(ConfigLoader::instance(), true);
+  controller.asyncStep();
+
+  // Bring the first request to the active state; acceptConfig reports that it
+  // scheduled the request.
+  EXPECT_TRUE(controller.acceptConfig(firstCfg));
+  controller.asyncStep();
+  controller.asyncStep();
+  EXPECT_TRUE(controller.isActive());
+  EXPECT_FALSE(controller.canAcceptConfig());
+
+  // A second on-demand request arriving now is rejected by the controller.
+  EXPECT_FALSE(controller.acceptConfig(secondCfg));
+  EXPECT_TRUE(controller.isActive());
+
+  // The rejected request also never produced a trace.
+  const std::string secondLog = logUrlToPath(secondCfg.activitiesLogUrl());
+  EXPECT_FALSE(traceFileHasContent(secondLog)) << secondLog;
+}
+
+// canAcceptConfig() gates on the profiler being idle: it is true before a
+// request and false once one becomes active. Return-to-idle happens on the
+// background loop after collection finishes and is not asserted here.
+TEST(ActivityProfilerController, CanAcceptConfigReflectsActiveState) {
+  auto traceFile = createTempTraceFile("libkineto_test", ".json");
+
+  Config cfg;
+  ASSERT_TRUE(cfg.parse(
+      fmt::format(
+          R"CFG(
+    PROFILE_START_ITERATION = 3
+    ACTIVITIES_WARMUP_ITERATIONS = 1
+    ACTIVITIES_ITERATIONS = 2
+    ACTIVITIES_DURATION_SECS = 1
+    ACTIVITIES_LOG_FILE = {}
+  )CFG",
+          traceFile.path())));
+
+  ActivityProfilerController controller(ConfigLoader::instance(), true);
+  EXPECT_TRUE(controller.canAcceptConfig());
+
+  controller.asyncStep();
+  EXPECT_TRUE(controller.acceptConfig(cfg));
+  controller.asyncStep();
+  controller.asyncStep();
+  EXPECT_TRUE(controller.isActive());
+  EXPECT_FALSE(controller.canAcceptConfig());
+}


### PR DESCRIPTION
Summary: Adds new, deterministic `ActivityProfilerController` tests for the async path. In order to make the path easier to test, we again modify some member functions to return a bool so we can do synchronous checks.

Differential Revision: D110937606


