### PR TITLE
Explicitly wrap NCCL strings in output json (#1482)

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -50,6 +50,17 @@ constexpr std::string_view kP2pDst = "Dst Rank";
 constexpr std::string_view kSeqNum = "Seq";
 constexpr std::string_view kCommsId = "Comms Id";
 
+// Collective string metadata arrives quoted from the legacy RawJson path and
+// unquoted from the typed path; strip a single surrounding pair of double
+// quotes so downstream emission can re-quote uniformly (tolerates both).
+std::string stripQuotes(std::string s) {
+  if (s.size() >= 2 && s.front() == '"' && s.back() == '"') {
+    s.pop_back();
+    s.erase(0, 1);
+  }
+  return s;
+}
+
 #ifdef __linux__
 constexpr std::string_view kDefaultLogFileFmt =
     "/tmp/libkineto_activities_{}.json";
@@ -152,8 +163,6 @@ class ArgsBuilder {
   }
 
   // Add a key with a string value (will be JSON-quoted).
-  // Note: this member function does not have any callers yet. We define it
-  // so that if it is needed, we don't accidentally call `addRaw()`.
   void addQuoted(std::string_view key, std::string_view value) {
     appendComma();
     fmt::format_to(std::back_inserter(buf_), R"("{}": "{}")", key, value);
@@ -668,62 +677,62 @@ void ChromeTraceLogger::handleCounterEvent(
 void ChromeTraceLogger::appendCollectiveArgs(
     ArgsBuilder& args,
     const ITraceActivity& collectiveRecord) {
-  const auto& collectiveName =
-      collectiveRecord.getMetadataValue(std::string(kCollectiveName));
+  auto collectiveName = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kCollectiveName)));
   const auto& inMsgSize =
       collectiveRecord.getMetadataValue(std::string(kInMsgNelems));
   const auto& outMsgSize =
       collectiveRecord.getMetadataValue(std::string(kOutMsgNelems));
   const auto& groupSize =
       collectiveRecord.getMetadataValue(std::string(kGroupSize));
-  const auto& dtype = collectiveRecord.getMetadataValue(std::string(kDtype));
+  auto dtype =
+      stripQuotes(collectiveRecord.getMetadataValue(std::string(kDtype)));
   if (!collectiveName.empty() && !inMsgSize.empty() && !outMsgSize.empty() &&
       !groupSize.empty() && !dtype.empty()) {
-    args.addRaw(kCollectiveName, collectiveName);
+    args.addQuoted(kCollectiveName, collectiveName);
     args.addRaw(kInMsgNelems, inMsgSize);
     args.addRaw(kOutMsgNelems, outMsgSize);
     args.addRaw(kGroupSize, groupSize);
-    args.addRaw(kDtype, dtype);
+    args.addQuoted(kDtype, dtype);
   }
 
-  const auto& input_tensor_starts =
-      collectiveRecord.getMetadataValue(std::string(kInTensorsStart));
-  const auto& output_tensor_starts =
-      collectiveRecord.getMetadataValue(std::string(kOutTensorsStart));
-  if (!input_tensor_starts.empty()) {
-    args.addRaw(kInTensorsStart, input_tensor_starts);
+  auto inputTensorStarts = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kInTensorsStart)));
+  auto outputTensorStarts = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kOutTensorsStart)));
+  if (!inputTensorStarts.empty()) {
+    args.addQuoted(kInTensorsStart, inputTensorStarts);
   }
-  if (!output_tensor_starts.empty()) {
-    args.addRaw(kOutTensorsStart, output_tensor_starts);
+  if (!outputTensorStarts.empty()) {
+    args.addQuoted(kOutTensorsStart, outputTensorStarts);
   }
 
   // In/out split size are valid for all_to_all
-  const auto& inSplitSize =
-      collectiveRecord.getMetadataValue(std::string(kInSplit));
-  const auto& outSplitSize =
-      collectiveRecord.getMetadataValue(std::string(kOutSplit));
+  auto inSplitSize =
+      stripQuotes(collectiveRecord.getMetadataValue(std::string(kInSplit)));
+  auto outSplitSize =
+      stripQuotes(collectiveRecord.getMetadataValue(std::string(kOutSplit)));
   if (!inSplitSize.empty() && !outSplitSize.empty()) {
-    args.addRaw(kInSplit, inSplitSize);
-    args.addRaw(kOutSplit, outSplitSize);
+    args.addQuoted(kInSplit, inSplitSize);
+    args.addQuoted(kOutSplit, outSplitSize);
   }
 
-  const auto& processGroupName =
-      collectiveRecord.getMetadataValue(std::string(kProcessGroupName));
+  auto processGroupName = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupName)));
   if (!processGroupName.empty()) {
-    args.addRaw(kProcessGroupName, processGroupName);
+    args.addQuoted(kProcessGroupName, processGroupName);
   }
 
-  const auto& processGroupDesc =
-      collectiveRecord.getMetadataValue(std::string(kProcessGroupDesc));
-  if (processGroupDesc.size() >= 2 && processGroupDesc.front() == '"' &&
-      processGroupDesc.back() == '"') {
-    args.addRaw(kProcessGroupDesc, processGroupDesc);
+  auto processGroupDesc = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupDesc)));
+  if (!processGroupDesc.empty()) {
+    args.addQuoted(kProcessGroupDesc, processGroupDesc);
   }
 
-  const auto& groupRanks =
-      collectiveRecord.getMetadataValue(std::string(kGroupRanks));
+  auto groupRanks =
+      stripQuotes(collectiveRecord.getMetadataValue(std::string(kGroupRanks)));
   if (!groupRanks.empty()) {
-    args.addRaw(kGroupRanks, groupRanks);
+    args.addQuoted(kGroupRanks, groupRanks);
   }
 
   const auto& dstRank = collectiveRecord.getMetadataValue(std::string(kP2pDst));
@@ -756,14 +765,14 @@ void ChromeTraceLogger::appendCollectiveMetadata(
 
   const auto& groupSize =
       collectiveRecord.getMetadataValue(std::string(kGroupSize));
-  const auto& processGroupName =
-      collectiveRecord.getMetadataValue(std::string(kProcessGroupName));
-  const auto& processGroupDesc =
-      collectiveRecord.getMetadataValue(std::string(kProcessGroupDesc));
-  const auto& groupRanks =
-      collectiveRecord.getMetadataValue(std::string(kGroupRanks));
+  auto processGroupName = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupName)));
+  auto processGroupDesc = stripQuotes(
+      collectiveRecord.getMetadataValue(std::string(kProcessGroupDesc)));
+  auto groupRanks =
+      stripQuotes(collectiveRecord.getMetadataValue(std::string(kGroupRanks)));
 
-  if (distInfo_.backend.empty() && processGroupDesc == "\"default_pg\"") {
+  if (distInfo_.backend.empty() && processGroupDesc == "default_pg") {
     distInfo_.backend = backend;
     distInfo_.rank = collectiveRecord.getMetadataValue(std::string(kRank));
     distInfo_.world_size = groupSize;
@@ -777,10 +786,10 @@ void ChromeTraceLogger::appendCollectiveMetadata(
 
   auto pg_config = pgConfig();
   pg_config.pg_name = processGroupName;
-  pg_config.pg_desc = processGroupDesc;
+  pg_config.pg_desc = std::move(processGroupDesc);
   pg_config.backend_config = backendConfig;
   pg_config.pg_size = groupSize;
-  pg_config.ranks = groupRanks;
+  pg_config.ranks = std::move(groupRanks);
   pgMap_.insert({processGroupName, pg_config});
 }
 
@@ -996,7 +1005,7 @@ void ChromeTraceLogger::addOnDemandDistMetadata() {
     }
     fmt::print(
         traceOf_,
-        R"JSON({{"pg_name": {}, "pg_desc": {}, "backend_config": "{}", "pg_size": {}, "ranks": {}}})JSON",
+        R"JSON({{"pg_name": "{}", "pg_desc": "{}", "backend_config": "{}", "pg_size": {}, "ranks": "{}"}})JSON",
         element.second.pg_name,
         element.second.pg_desc,
         element.second.backend_config,

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -175,7 +175,9 @@ target_include_directories(GenericTraceActivityMetadataTest PRIVATE
 gtest_discover_tests(GenericTraceActivityMetadataTest)
 
 # OutputJsonTest
-add_executable(OutputJsonTest OutputJsonTest.cpp)
+add_executable(OutputJsonTest
+    OutputJsonTest.cpp
+    TestUtils.cpp)
 target_link_libraries(OutputJsonTest PRIVATE
     gtest_main
     kineto_base kineto_api

--- a/libkineto/test/OutputJsonTest.cpp
+++ b/libkineto/test/OutputJsonTest.cpp
@@ -9,14 +9,16 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
-#include <cstdio>
+#include <cstdint>
 #include <fstream>
 #include <iterator>
 #include <string>
+#include <string_view>
 
 #include "include/GenericTraceActivity.h"
 #include "include/TraceSpan.h"
 #include "src/output_json.h"
+#include "test/TestUtils.h"
 
 using namespace KINETO_NAMESPACE;
 using namespace libkineto;
@@ -41,7 +43,8 @@ std::string readFile(const std::string& path) {
 // Write a trace containing a single CPU-op event with the given name, parse it
 // back, and assert the trace is valid JSON and the name round-trips exactly.
 void expectEventNameRoundTrips(const std::string& eventName) {
-  const std::string filename = ::testing::TempDir() + "kineto_output_json.json";
+  const auto traceFile =
+      libkineto::test::createTempTraceFile("OutputJsonTest.", ".json");
 
   TraceSpan span(0, 0, "test_span");
   GenericTraceActivity act(span, ActivityType::CPU_OP, eventName);
@@ -50,13 +53,13 @@ void expectEventNameRoundTrips(const std::string& eventName) {
   act.device = 0;
   act.resource = 0;
 
-  TestableChromeTraceLogger logger(filename);
+  TestableChromeTraceLogger logger(traceFile.path());
   logger.handleTraceStart({}, "");
   logger.handleGenericActivity(act);
   logger.finalizeTrace(/*endTime=*/300);
 
   nlohmann::json data;
-  ASSERT_NO_THROW(data = nlohmann::json::parse(readFile(filename)));
+  ASSERT_NO_THROW(data = nlohmann::json::parse(readFile(traceFile.path())));
 
   bool found = false;
   for (const auto& event : data["traceEvents"]) {
@@ -67,8 +70,70 @@ void expectEventNameRoundTrips(const std::string& eventName) {
     }
   }
   EXPECT_TRUE(found) << "event name did not round-trip: " << eventName;
+}
 
-  std::remove(filename.c_str());
+// Write a trace with one CONCURRENT_KERNEL GPU event linked to a
+// record_param_comms CPU op carrying collective metadata, flush it, and parse
+// the result. `quoted` selects whether string fields use the legacy RawJson
+// path with surrounding double quotes or the typed path with bare values.
+// Kineto must emit identical valid JSON either way.
+nlohmann::json writeCollectiveTrace(bool quoted) {
+  const auto traceFile =
+      libkineto::test::createTempTraceFile("OutputJsonTest.", ".json");
+
+  TraceSpan span(0, 0, "test_span");
+  GenericTraceActivity recordOp(
+      span, ActivityType::CPU_OP, "record_param_comms");
+  auto addStringMetadata = [&](std::string_view key, const std::string& value) {
+    if (quoted) {
+      recordOp.addMetadata(std::string{key}, "\"" + value + "\"");
+    } else {
+      recordOp.addMetadata(MetadataField<std::string>{key}, value);
+    }
+  };
+  addStringMetadata("Collective name", "allreduce");
+  addStringMetadata("dtype", "Float");
+  addStringMetadata("Process Group Name", "0");
+  addStringMetadata("Process Group Description", "default_pg");
+  addStringMetadata("In split size", "[1, 2]");
+  addStringMetadata("Out split size", "[3, 4]");
+  addStringMetadata("Process Group Ranks", "[0, 1, 2, 3, 4, 5, 6, 7]");
+  addStringMetadata("Input Tensors start", "[[4096, 8192]]");
+  addStringMetadata("Output Tensors start", "[[12288]]");
+  recordOp.addMetadata(MetadataField<int64_t>{"In msg nelems"}, int64_t{1024});
+  recordOp.addMetadata(MetadataField<int64_t>{"Out msg nelems"}, int64_t{512});
+  recordOp.addMetadata(MetadataField<int64_t>{"Group size"}, int64_t{8});
+  recordOp.addMetadata(MetadataField<int64_t>{"Rank"}, int64_t{0});
+  recordOp.addMetadata(MetadataField<int64_t>{"Src Rank"}, int64_t{1});
+  recordOp.addMetadata(MetadataField<int64_t>{"Dst Rank"}, int64_t{2});
+  recordOp.addMetadata(MetadataField<int64_t>{"Seq"}, int64_t{3});
+  recordOp.addMetadata(MetadataField<uint64_t>{"Comms Id"}, uint64_t{4});
+
+  GenericTraceActivity kernel(
+      span, ActivityType::CONCURRENT_KERNEL, "nccl:all_reduce");
+  kernel.startTime = 100;
+  kernel.endTime = 200;
+  kernel.device = 0;
+  kernel.resource = 0;
+  kernel.linked = &recordOp;
+
+  TestableChromeTraceLogger logger(traceFile.path());
+  logger.handleTraceStart({}, "");
+  logger.handleActivity(kernel);
+  logger.finalizeTrace(/*endTime=*/300);
+
+  return nlohmann::json::parse(readFile(traceFile.path()));
+}
+
+// Return the "args" object of the single collective GPU-kernel event.
+nlohmann::json collectiveArgs(const nlohmann::json& trace) {
+  for (const auto& event : trace["traceEvents"]) {
+    if (event.contains("name") && event["name"] == "nccl:all_reduce" &&
+        event.contains("args")) {
+      return event["args"];
+    }
+  }
+  return nlohmann::json::object();
 }
 
 } // namespace
@@ -83,4 +148,50 @@ TEST(OutputJsonTest, EventNameWithQuotesProducesValidJson) {
 
 TEST(OutputJsonTest, PlainEventNameIsUnchanged) {
   expectEventNameRoundTrips("aten::addmm");
+}
+
+// Collective strings arrive quoted from the legacy RawJson path and unquoted
+// from the typed path. Kineto must strip and re-quote them so the GPU-kernel
+// args and distributedInfo have identical string shapes.
+TEST(OutputJsonTest, CollectiveMetadataToleratesQuotedAndUnquotedForms) {
+  const nlohmann::json quoted = writeCollectiveTrace(/*quoted=*/true);
+  const nlohmann::json unquoted = writeCollectiveTrace(/*quoted=*/false);
+
+  const nlohmann::json expectedArgs = {
+      {"Collective name", "allreduce"},
+      {"In msg nelems", 1024},
+      {"Out msg nelems", 512},
+      {"Group size", 8},
+      {"dtype", "Float"},
+      {"Input Tensors start", "[[4096, 8192]]"},
+      {"Output Tensors start", "[[12288]]"},
+      {"In split size", "[1, 2]"},
+      {"Out split size", "[3, 4]"},
+      {"Process Group Name", "0"},
+      {"Process Group Description", "default_pg"},
+      {"Process Group Ranks", "[0, 1, 2, 3, 4, 5, 6, 7]"},
+      {"Src Rank", 1},
+      {"Dst Rank", 2},
+      {"Seq", 3},
+      {"Comms Id", 4},
+  };
+  const nlohmann::json expectedDistInfo = {
+      {"backend", "nccl"},
+      {"rank", 0},
+      {"world_size", 8},
+      {"pg_count", 1},
+      {"pg_config",
+       {{{"pg_name", "0"},
+         {"pg_desc", "default_pg"},
+         {"backend_config", "cuda:nccl"},
+         {"pg_size", 8},
+         {"ranks", "[0, 1, 2, 3, 4, 5, 6, 7]"}}}},
+      {"nccl_version", "unknown"},
+  };
+  // Both input forms must normalize to the same collective args and
+  // distributedInfo; only environment-specific fields (e.g. traceName) differ.
+  EXPECT_EQ(collectiveArgs(quoted), expectedArgs);
+  EXPECT_EQ(collectiveArgs(unquoted), expectedArgs);
+  EXPECT_EQ(quoted["distributedInfo"], expectedDistInfo);
+  EXPECT_EQ(unquoted["distributedInfo"], expectedDistInfo);
 }


### PR DESCRIPTION
Summary:

We are moving NCCL metadata to to typed metadata, which means that string fields (collective name, dtype, pg name/desc) arrive unquoted instead of as pre-quoted JSON strings. Normally, `appendCollectiveArgs` copies these onto the linked GPU-kernel row with `addRaw(key, getMetadataValue())`. Currently, `getMetadataValue()` arrives with quotes, so the call is fine. But we will move these to raw strings on the PyTorch side, so these will arrive without quotes and `addRaw` will paste the value in as is, producing invalid JSON.

To make sure this doesn't break when we make the PyTorch side change, strip strings of quotes and then add them via `addQuoted`.

TODO in the future is to make NCCL metadata be represented as `MetadataField`s, then add a `CollectiveMetadataVisitor` that extracts typed values instead of directly adding raw to the output json.

Reviewed By: scotts

Differential Revision: D112147890


