### PR TITLE
Add addTypedMetadata to GenericTraceActivity

### DIFF
--- a/libkineto/include/GenericTraceActivity.h
+++ b/libkineto/include/GenericTraceActivity.h
@@ -11,9 +11,11 @@
 #include <fmt/format.h>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <type_traits>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -107,6 +109,11 @@ class GenericTraceActivity : public ITraceActivity {
   void addMetadata(const MetadataField<T>& field, const V& value) {
     static_assert(std::is_same_v<T, std::decay_t<V>>, "value type must match field's declared type");
     metadataMap_.emplace(std::string{field.name}, TypedValue{value});
+  }
+
+  // Adds typed metadata dynamically by key. Catalog registration is not required.
+  void addTypedMetadata(std::string_view key, TypedValue value) {
+    metadataMap_.emplace(std::string{key}, std::move(value));
   }
 
   // The value is a plain string to be emitted quoted in JSON.

--- a/libkineto/test/GenericTraceActivityMetadataTest.cpp
+++ b/libkineto/test/GenericTraceActivityMetadataTest.cpp
@@ -130,6 +130,17 @@ TEST(GenericTraceActivityMetadataTest, TypedFieldOverloadStoresDeclaredType) {
   EXPECT_EQ(visitor.recorded, expected);
 }
 
+TEST(GenericTraceActivityMetadataTest, AddTypedMetadataStoresTypedValue) {
+  GenericTraceActivity activity;
+  activity.addTypedMetadata("count", TypedValue{int64_t{5}});
+
+  RecordingVisitor visitor;
+  activity.visitTypedMetadata(visitor);
+
+  const std::map<std::string, std::string> expected{{"count", "int64=5"}};
+  EXPECT_EQ(visitor.recorded, expected);
+}
+
 TEST(GenericTraceActivityMetadataTest, MetadataJsonPreservesValueShapes) {
   GenericTraceActivity activity;
   activity.addMetadata("count", 5);


### PR DESCRIPTION
Summary:
One of the nice things about the old string-only JSON approach was that you could super easily add a new metadata field on the PyTorch side without doing additional work to reflect the change in Kineto. Since `GenericTraceActivity` ultimately stores a string key and `TypedValue`, we should support adding typed metadata dynamically by key.

Note -- the catalog is still valuable and should remain the contract for fields Kineto explicitly reads or interprets. For example, NCCL metadata fields that are written on the PyTorch side and explicitly fetched via `getMetadataValue` in `output_json.cpp`. Right now we rely on strings happening to match between PyTorch and Kineto; using the catalog is a more official way of matching the two. For `GenericTraceActivity` metadata that is only access through a visitor class though (which NCCL metadata should eventually migrate to), it's not strictly necessary to go through the catalog.

Differential Revision: D112555947


