### PR TITLE
Fix CI by using non-editable PyTorch installs

### DIFF
--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -117,13 +117,12 @@ done
 # inflates the thread counts that some profiler tests assert on. The tradeoff is
 # that signal cannot interrupt a hang holding the GIL in native code.
 pip install pytest pytest-timeout
+
 # Run pytest with PYTHONSAFEPATH so Python does not prepend the current
-# directory (the PyTorch source checkout) to sys.path. Without it, python -m
-# pytest puts the source tree first and import torch loads the uncompiled
-# source torch package instead of the wheel we just installed non-editable,
-# failing with "Failed to load PyTorch C extensions". pytest still adds test
-# and test/profiler to sys.path, and neither shadows torch. Requires Python
-# 3.11+; older versions ignore the variable rather than erroring.
+# directory (the PyTorch source checkout) to sys.path. Without it, the pytest
+# call below would put the source tree first and importing torch would load the
+# uncompiled source torch package instead of the wheel we just installed.
 PYTHONSAFEPATH=1 python -m pytest test/profiler/ -v --timeout=300 --timeout-method=signal "${DESELECT_ARGS[@]}"
+
 popd
 echo "====: Ran PyTorch profiler tests"

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -117,6 +117,13 @@ done
 # inflates the thread counts that some profiler tests assert on. The tradeoff is
 # that signal cannot interrupt a hang holding the GIL in native code.
 pip install pytest pytest-timeout
-python -m pytest test/profiler/ -v --timeout=300 --timeout-method=signal "${DESELECT_ARGS[@]}"
+# Run pytest with PYTHONSAFEPATH so Python does not prepend the current
+# directory (the PyTorch source checkout) to sys.path. Without it, python -m
+# pytest puts the source tree first and import torch loads the uncompiled
+# source torch package instead of the wheel we just installed non-editable,
+# failing with "Failed to load PyTorch C extensions". pytest still adds test
+# and test/profiler to sys.path, and neither shadows torch. Requires Python
+# 3.11+; older versions ignore the variable rather than erroring.
+PYTHONSAFEPATH=1 python -m pytest test/profiler/ -v --timeout=300 --timeout-method=signal "${DESELECT_ARGS[@]}"
 popd
 echo "====: Ran PyTorch profiler tests"

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -84,7 +84,12 @@ if [[ "${GPU_ARCH}" == "rocm" ]]; then
   echo "====: Hipified PyTorch source for ROCm"
 fi
 
-python -m pip install --no-build-isolation -v -e .
+# Install non-editable (no -e). scikit-build-core's editable "redirect" mode
+# keeps the built C++ headers in the build tree, but torch.utils.cpp_extension
+# looks for them under the source tree's torch/include. The profiler tests
+# JIT-compile a C++ extension, so an editable install can't find headers like
+# profiler_kineto.h. A regular install stages torch/include into site-packages.
+python -m pip install --no-build-isolation -v .
 echo "====: Built PyTorch from source"
 
 # Surface cache hit rates so warm-vs-cold runs are diagnosable from the log.


### PR DESCRIPTION
We started getting CI failures when building PyTorch from source and running the tests, https://github.com/pytorch/kineto/actions/runs/29939146658/job/89015057521?pr=1489:
```
FAILED: [code=1] test_cpp_thread.o 
sccache c++ -MMD -MF test_cpp_thread.o.d -DTORCH_EXTENSION_NAME=profiler_test_cpp_thread_lib -DTORCH_API_INCLUDE_EXTENSION_H -isystem /pytorch/pytorch/torch/include -isystem /pytorch/pytorch/torch/include/torch/csrc/api/include -isystem /opt/conda/include/python3.11 -fPIC -std=c++20 -c /pytorch/pytorch/test/profiler/test_cpp_thread.cpp -o test_cpp_thread.o 
/pytorch/pytorch/test/profiler/test_cpp_thread.cpp:2:10: fatal error: torch/csrc/autograd/profiler_kineto.h: No such file or directory
    2 | #include <torch/csrc/autograd/profiler_kineto.h>  // @manual
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

PyTorch migrated its build from setuptools to scikit-build-core (pytorch/pytorch#180247). Up until now, our tests used editable install (`pip install -e`) which now use redirect mode: Python modules resolve from the source tree while the CMake-installed C++ headers under `torch/include` stay in the build tree. `torch.utils.cpp_extension` derives its header search path from the source tree's `torch/include`, which the editable install never populates, so no installed torch header is found.

We have two fixes:

1. Drop the `-e` to its a non-editable install. We shouldn't need those for tests.
2. Set `PYTHONSAFEPATH=1` on the pytest invocation. On Python 3.11+ this stops the interpreter from prepending the current directory, so import torch resolves to the installed wheel, which has both the compiled `_C` extension and the headers. This mirrors how PyTorch's own CI runs tests from the `test/` directory rather than the repo root.

Authored with assistance from an AI agent (Claude Code).