### PR TITLE
Add XPU PTI version to Metadata

### DIFF
--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
@@ -11,6 +11,7 @@
 
 #include "time_since_epoch.h"
 
+#include <pti/pti_version.h>
 #include <sycl/sycl.hpp>
 
 #include <algorithm>
@@ -114,6 +115,14 @@ std::vector<libkineto::ResourceInfo> XpuptiActivityProfilerSession::
   }
   resourceInfo_.clear();
   return result;
+}
+
+std::unordered_map<std::string, std::string> XpuptiActivityProfilerSession::
+    getMetadata() {
+  const char* version = ptiVersionString();
+  return {
+      {"xpupti_version",
+       fmt::format("\"{}\"", version != nullptr ? version : "unknown")}};
 }
 
 void XpuptiActivityProfilerSession::pushCorrelationId(uint64_t id) {

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
@@ -56,6 +56,7 @@ class XpuptiActivityProfilerSession : public libkineto::IActivityProfilerSession
   }
   std::vector<libkineto::ResourceInfo> getResourceInfos() override;
   std::unique_ptr<libkineto::CpuTraceBuffer> getTraceBuffer() override;
+  std::unordered_map<std::string, std::string> getMetadata() override;
 
   void pushCorrelationId(uint64_t id) override;
   void popCorrelationId() override;

--- a/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
+++ b/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
@@ -90,6 +90,17 @@ class XpuptiActivityHandlersTest : public ::testing::Test {
   }
 };
 
+TEST_F(XpuptiActivityHandlersTest, SessionMetadataIncludesPtiVersion) {
+  Config config;
+  std::set<ActivityType> activity_types = {ActivityType::COLLECTIVE_COMM};
+  KN::XpuptiActivityProfilerSession session(
+      mockApi_, "__test_profiler__", config, activity_types);
+
+  const auto metadata = session.getMetadata();
+  ASSERT_TRUE(metadata.contains("xpupti_version"));
+  EXPECT_FALSE(metadata.at("xpupti_version").empty());
+}
+
 // --- Communication Activity Tests ---
 
 TEST_F(XpuptiActivityHandlersTest, CommunicationActivityHasXcclPrefix) {


### PR DESCRIPTION
Add the Intel PTI version to XPU Kineto trace metadata as xpupti_version.

The XPU profiler session now obtains the runtime version through `ptiVersionString()` and emits it as a JSON string value. This lets exported traces identify the PTI version that produced them, aiding diagnosis of profiler behavior across Intel PTI versions.

Add a focused XPU PTI unit test confirming that the metadata field is present and non-empty.