### PR TITLE
Catch config-update exceptions so the poll thread can't crash the process

### DIFF
--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -231,16 +231,33 @@ void ConfigLoader::updateConfigThread() {
       break;
     }
     auto now = system_clock::now();
+    // This runs on a bare background thread: an escaped exception would
+    // terminate the process, so config-update failures are caught and skipped.
+    // Advance the load timestamps before the guarded work so a persistent
+    // failure backs off to the normal interval instead of hot-looping.
     if (now > prev_config_load_time + configUpdateIntervalSecs_) {
-      updateBaseConfig();
-      onDemandConfigUpdateIntervalSecs_ =
-          config_->onDemandConfigUpdateIntervalSecs();
       prev_config_load_time = now;
+      try {
+        updateBaseConfig();
+        onDemandConfigUpdateIntervalSecs_ =
+            config_->onDemandConfigUpdateIntervalSecs();
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Skipping base config update after error: " << e.what();
+      } catch (...) {
+        LOG(ERROR) << "Skipping base config update after unknown error";
+      }
     }
     if (now > prev_on_demand_load_time + onDemandConfigUpdateIntervalSecs_) {
-      onDemandConfig = std::make_unique<Config>();
-      configureFromDaemon(now, *onDemandConfig);
       prev_on_demand_load_time = now;
+      onDemandConfig = std::make_unique<Config>();
+      try {
+        configureFromDaemon(now, *onDemandConfig);
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Skipping on-demand config update after error: "
+                   << e.what();
+      } catch (...) {
+        LOG(ERROR) << "Skipping on-demand config update after unknown error";
+      }
     }
     if (onDemandConfig->verboseLogLevel() >= 0) {
       LOG(INFO) << "Setting verbose level to "


### PR DESCRIPTION
## Summary

`ConfigLoader::updateConfigThread()` runs `updateBaseConfig()` and `configureFromDaemon()` on a bare `std::thread` with no exception handling. Any exception that escapes that work hits the raw thread boundary and calls `std::terminate()`, aborting the **entire host process** — not just the profiler/telemetry thread.

This is a real failure mode during process teardown: once global TLS/crypto state has been torn down (e.g. OpenSSL's `atexit` cleanup runs and frees global state), the still-running config thread can lazily first-build its client stack and hit an allocation/init failure that surfaces as an uncaught `std::bad_alloc` on the background thread → `std::terminate`.

## Fix

Wrap the per-iteration config work in `try/catch` so a config-update failure is logged and skipped instead of taking down the process. A telemetry/profiler thread should never be able to abort the host.

- Base-config and on-demand updates are each guarded independently.
- Load timestamps are advanced **before** the guarded work, so a persistent failure backs off to the normal poll interval instead of hot-looping.
- The `wait` / `stopFlag_` / `break` control flow stays **outside** the guard, so shutdown behavior is unchanged.

## Test plan

- Existing `ConfigLoader` tests continue to pass.
- Verified against the teardown scenario above: with the guard, the config thread catches the `std::bad_alloc` from the post-cleanup client build, logs `Skipping base config update after error: ...`, and the process exits cleanly; without the guard, the uncaught exception aborts the process via `std::terminate`.