### PR TITLE
Catch config-update exceptions so the poll thread can't crash the process

### DIFF
--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -231,16 +231,33 @@ void ConfigLoader::updateConfigThread() {
       break;
     }
     auto now = system_clock::now();
+    // This runs on a bare background thread: an escaped exception would
+    // terminate the process, so config-update failures are caught and skipped.
+    // Advance the load timestamps before the guarded work so a persistent
+    // failure backs off to the normal interval instead of hot-looping.
     if (now > prev_config_load_time + configUpdateIntervalSecs_) {
-      updateBaseConfig();
-      onDemandConfigUpdateIntervalSecs_ =
-          config_->onDemandConfigUpdateIntervalSecs();
       prev_config_load_time = now;
+      try {
+        updateBaseConfig();
+        onDemandConfigUpdateIntervalSecs_ =
+            config_->onDemandConfigUpdateIntervalSecs();
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Skipping base config update after error: " << e.what();
+      } catch (...) {
+        LOG(ERROR) << "Skipping base config update after unknown error";
+      }
     }
     if (now > prev_on_demand_load_time + onDemandConfigUpdateIntervalSecs_) {
-      onDemandConfig = std::make_unique<Config>();
-      configureFromDaemon(now, *onDemandConfig);
       prev_on_demand_load_time = now;
+      onDemandConfig = std::make_unique<Config>();
+      try {
+        configureFromDaemon(now, *onDemandConfig);
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Skipping on-demand config update after error: "
+                   << e.what();
+      } catch (...) {
+        LOG(ERROR) << "Skipping on-demand config update after unknown error";
+      }
     }
     if (onDemandConfig->verboseLogLevel() >= 0) {
       LOG(INFO) << "Setting verbose level to "


### PR DESCRIPTION
Summary:
libkineto's `ConfigLoader::updateConfigThread()` background thread ran
`updateBaseConfig()` / `configureFromDaemon()` with no exception handling, so any
exception escaping that work hits the bare `std::thread` boundary and calls
`std::terminate()`, aborting the whole host process.

Wrap the per-iteration config work in try/catch so a config-update failure is
logged and skipped instead of taking down the process; a telemetry/profiler
thread must never abort the host. Load timestamps are advanced before the guarded
work so a persistent failure backs off to the normal interval instead of
hot-looping. The wait/`stopFlag_`/`break` control flow stays outside the guard,
so shutdown is unaffected. Applied to both the fbcode and xplat mirrors of
`src/ConfigLoader.cpp`.

Differential Revision: D113579180


