### PR TITLE
Clean up dtypes for metadata fields (#1499)

### DIFF
--- a/libkineto/include/MetadataFieldCatalog.h
+++ b/libkineto/include/MetadataFieldCatalog.h
@@ -33,7 +33,7 @@ inline constexpr MetadataField<uint64_t> kTotalReserved{"Total Reserved"};
 inline constexpr MetadataField<int64_t> kDeviceType{"Device Type"};
 inline constexpr MetadataField<int64_t> kDeviceId{"Device Id"};
 inline constexpr MetadataField<uint64_t> kPythonId{"Python id"};
-inline constexpr MetadataField<int64_t> kPythonParentId{"Python parent id"};
+inline constexpr MetadataField<uint64_t> kPythonParentId{"Python parent id"};
 inline constexpr MetadataField<uint64_t> kPythonModuleId{"Python module id"};
 inline constexpr MetadataField<uint64_t> kPythonThread{"Python thread"};
 inline constexpr MetadataField<std::string> kBackend{"Backend"};
@@ -73,9 +73,9 @@ inline constexpr MetadataField<uint64_t> kCommsId{"Comms Id"};
 } // namespace libkineto::CollectiveMetadataFields
 
 namespace libkineto::DevicePropertyMetadataFields {
-inline constexpr MetadataField<int64_t> kId{"id"};
+inline constexpr MetadataField<uint64_t> kId{"id"};
 inline constexpr MetadataField<std::string> kName{"name"};
-inline constexpr MetadataField<int64_t> kTotalGlobalMem{"totalGlobalMem"};
+inline constexpr MetadataField<uint64_t> kTotalGlobalMem{"totalGlobalMem"};
 inline constexpr MetadataField<int64_t> kComputeMajor{"computeMajor"};
 inline constexpr MetadataField<int64_t> kComputeMinor{"computeMinor"};
 inline constexpr MetadataField<int64_t> kMaxThreadsPerBlock{
@@ -84,15 +84,16 @@ inline constexpr MetadataField<int64_t> kMaxThreadsPerMultiprocessor{
     "maxThreadsPerMultiprocessor"};
 inline constexpr MetadataField<int64_t> kRegsPerBlock{"regsPerBlock"};
 inline constexpr MetadataField<int64_t> kWarpSize{"warpSize"};
-inline constexpr MetadataField<int64_t> kSharedMemPerBlock{"sharedMemPerBlock"};
+inline constexpr MetadataField<uint64_t> kSharedMemPerBlock{
+    "sharedMemPerBlock"};
 inline constexpr MetadataField<int64_t> kNumSms{"numSms"};
 inline constexpr MetadataField<int64_t> kRegsPerMultiprocessor{
     "regsPerMultiprocessor"};
-inline constexpr MetadataField<int64_t> kSharedMemPerBlockOptin{
+inline constexpr MetadataField<uint64_t> kSharedMemPerBlockOptin{
     "sharedMemPerBlockOptin"};
-inline constexpr MetadataField<int64_t> kSharedMemPerMultiprocessor{
+inline constexpr MetadataField<uint64_t> kSharedMemPerMultiprocessor{
     "sharedMemPerMultiprocessor"};
-inline constexpr MetadataField<int64_t> kMaxSharedMemoryPerMultiProcessor{
+inline constexpr MetadataField<uint64_t> kMaxSharedMemoryPerMultiProcessor{
     "maxSharedMemoryPerMultiProcessor"};
 } // namespace libkineto::DevicePropertyMetadataFields
 
@@ -102,7 +103,7 @@ inline constexpr MetadataField<int64_t> kActiveBlocksPerMultiprocessor{
     "activeBlocksPerMultiprocessor"};
 inline constexpr MetadataField<int64_t> kAllocatedRegistersPerBlock{
     "allocatedRegistersPerBlock"};
-inline constexpr MetadataField<int64_t> kAllocatedSharedMemPerBlock{
+inline constexpr MetadataField<uint64_t> kAllocatedSharedMemPerBlock{
     "allocatedSharedMemPerBlock"};
 inline constexpr MetadataField<std::vector<int64_t>> kBlock{"block"};
 inline constexpr MetadataField<int64_t> kBlockLimitBarriers{
@@ -113,36 +114,36 @@ inline constexpr MetadataField<int64_t> kBlockLimitSharedMem{
     "blockLimitSharedMem"};
 inline constexpr MetadataField<int64_t> kBlockLimitWarps{"blockLimitWarps"};
 inline constexpr MetadataField<double> kBlocksPerSm{"blocks per SM"};
-inline constexpr MetadataField<int64_t> kBytes{"bytes"};
-inline constexpr MetadataField<int64_t> kCbid{"cbid"};
-inline constexpr MetadataField<int64_t> kChannel{"channel"};
+inline constexpr MetadataField<uint64_t> kBytes{"bytes"};
+inline constexpr MetadataField<uint64_t> kCbid{"cbid"};
+inline constexpr MetadataField<uint64_t> kChannel{"channel"};
 inline constexpr MetadataField<int64_t> kChannelType{"channel_type"};
-inline constexpr MetadataField<int64_t> kContext{"context"};
-inline constexpr MetadataField<int64_t> kCorrelation{"correlation"};
+inline constexpr MetadataField<uint64_t> kContext{"context"};
+inline constexpr MetadataField<uint64_t> kCorrelation{"correlation"};
 inline constexpr MetadataField<std::string> kCudaSyncKind{"cuda_sync_kind"};
 inline constexpr MetadataField<int64_t> kDevice{"device"};
 inline constexpr MetadataField<int64_t> kEstAchievedOccupancyPercent{
     "est. achieved occupancy %"};
-inline constexpr MetadataField<int64_t> kEventId{"event_id"};
-inline constexpr MetadataField<int64_t> kFromContext{"fromContext"};
-inline constexpr MetadataField<int64_t> kFromDevice{"fromDevice"};
-inline constexpr MetadataField<int64_t> kGraphId{"graph id"};
-inline constexpr MetadataField<int64_t> kGraphNodeId{"graph node id"};
+inline constexpr MetadataField<uint64_t> kEventId{"event_id"};
+inline constexpr MetadataField<uint64_t> kFromContext{"fromContext"};
+inline constexpr MetadataField<uint64_t> kFromDevice{"fromDevice"};
+inline constexpr MetadataField<uint64_t> kGraphId{"graph id"};
+inline constexpr MetadataField<uint64_t> kGraphNodeId{"graph node id"};
 inline constexpr MetadataField<std::vector<int64_t>> kGrid{"grid"};
-inline constexpr MetadataField<int64_t> kInContext{"inContext"};
-inline constexpr MetadataField<int64_t> kInDevice{"inDevice"};
+inline constexpr MetadataField<uint64_t> kInContext{"inContext"};
+inline constexpr MetadataField<uint64_t> kInDevice{"inDevice"};
 inline constexpr MetadataField<std::string> kLimitingFactors{"limitingFactors"};
 inline constexpr MetadataField<double> kMemoryBandwidthGbps{
     "memory bandwidth (GB/s)"};
 inline constexpr MetadataField<int64_t> kPriority{"priority"};
-inline constexpr MetadataField<int64_t> kQueued{"queued"};
-inline constexpr MetadataField<int64_t> kRegistersPerThread{
+inline constexpr MetadataField<uint64_t> kQueued{"queued"};
+inline constexpr MetadataField<uint64_t> kRegistersPerThread{
     "registers per thread"};
 inline constexpr MetadataField<int64_t> kSharedMemory{"shared memory"};
 inline constexpr MetadataField<int64_t> kStream{"stream"};
-inline constexpr MetadataField<int64_t> kToContext{"toContext"};
-inline constexpr MetadataField<int64_t> kToDevice{"toDevice"};
-inline constexpr MetadataField<int64_t> kWaitOnCudaEventId{
+inline constexpr MetadataField<uint64_t> kToContext{"toContext"};
+inline constexpr MetadataField<uint64_t> kToDevice{"toDevice"};
+inline constexpr MetadataField<uint64_t> kWaitOnCudaEventId{
     "wait_on_cuda_event_id"};
 inline constexpr MetadataField<int64_t> kWaitOnCudaEventRecordCorrId{
     "wait_on_cuda_event_record_corr_id"};
@@ -152,19 +153,19 @@ inline constexpr MetadataField<double> kWarpsPerSm{"warps per SM"};
 
 namespace libkineto::RocmMetadataFields {
 inline constexpr MetadataField<std::vector<int64_t>> kBlock{"block"};
-inline constexpr MetadataField<int64_t> kBytes{"bytes"};
-inline constexpr MetadataField<int64_t> kCid{"cid"};
-inline constexpr MetadataField<int64_t> kCorrelation{"correlation"};
+inline constexpr MetadataField<uint64_t> kBytes{"bytes"};
+inline constexpr MetadataField<uint64_t> kCid{"cid"};
+inline constexpr MetadataField<uint64_t> kCorrelation{"correlation"};
 inline constexpr MetadataField<int64_t> kDevice{"device"};
 inline constexpr MetadataField<std::string> kDst{"dst"};
 inline constexpr MetadataField<std::vector<int64_t>> kGrid{"grid"};
-inline constexpr MetadataField<int64_t> kHsaQueue{"hsa_queue"};
+inline constexpr MetadataField<uint64_t> kHsaQueue{"hsa_queue"};
 inline constexpr MetadataField<std::string> kKernel{"kernel"};
 inline constexpr MetadataField<std::string> kKind{"kind"};
 inline constexpr MetadataField<double> kMemoryBandwidthGbps{
     "memory bandwidth (GB/s)"};
 inline constexpr MetadataField<std::string> kPtr{"ptr"};
-inline constexpr MetadataField<int64_t> kSharedMemory{"shared memory"};
+inline constexpr MetadataField<uint64_t> kSharedMemory{"shared memory"};
 inline constexpr MetadataField<std::string> kSrc{"src"};
 inline constexpr MetadataField<int64_t> kStream{"stream"};
 } // namespace libkineto::RocmMetadataFields

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -408,17 +408,17 @@ inline void CudaSyncActivity::visitTypedMetadata(
         static_cast<int64_t>(srcCorrId_));
     visitor.visit(
         CudaMetadataFields::kWaitOnCudaEventId,
-        static_cast<int64_t>(sync.cudaEventId));
+        static_cast<uint64_t>(sync.cudaEventId));
   }
   visitor.visit(
       CudaMetadataFields::kStream,
       static_cast<int64_t>(streamIdForTrace(sync.streamId)));
   visitor.visit(
       CudaMetadataFields::kCorrelation,
-      static_cast<int64_t>(sync.correlationId));
+      static_cast<uint64_t>(sync.correlationId));
   visitor.visit(CudaMetadataFields::kDevice, deviceId());
   visitor.visit(
-      CudaMetadataFields::kContext, static_cast<int64_t>(sync.contextId));
+      CudaMetadataFields::kContext, static_cast<uint64_t>(sync.contextId));
 }
 
 inline const std::string CudaEventActivity::name() const {
@@ -447,16 +447,16 @@ inline void CudaEventActivity::visitTypedMetadata(
     ITypedMetadataVisitor& visitor) const {
   const CUpti_ActivityCudaEventType& event = raw();
   visitor.visit(
-      CudaMetadataFields::kEventId, static_cast<int64_t>(event.eventId));
+      CudaMetadataFields::kEventId, static_cast<uint64_t>(event.eventId));
   visitor.visit(
       CudaMetadataFields::kStream,
       static_cast<int64_t>(streamIdForTrace(event.streamId)));
   visitor.visit(
       CudaMetadataFields::kCorrelation,
-      static_cast<int64_t>(event.correlationId));
+      static_cast<uint64_t>(event.correlationId));
   visitor.visit(CudaMetadataFields::kDevice, deviceId());
   visitor.visit(
-      CudaMetadataFields::kContext, static_cast<int64_t>(event.contextId));
+      CudaMetadataFields::kContext, static_cast<uint64_t>(event.contextId));
 }
 
 template <class T>
@@ -476,10 +476,10 @@ inline void addGraphNodeTypedMetadata(
     [[maybe_unused]] const T& activity) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
   visitor.visit(
-      CudaMetadataFields::kGraphId, static_cast<int64_t>(activity.graphId));
+      CudaMetadataFields::kGraphId, static_cast<uint64_t>(activity.graphId));
   visitor.visit(
       CudaMetadataFields::kGraphNodeId,
-      static_cast<int64_t>(activity.graphNodeId));
+      static_cast<uint64_t>(activity.graphNodeId));
 #endif
 }
 
@@ -499,7 +499,7 @@ inline void addChannelTypedMetadata(
     [[maybe_unused]] const T& activity) {
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
   visitor.visit(
-      CudaMetadataFields::kChannel, static_cast<int64_t>(activity.channelID));
+      CudaMetadataFields::kChannel, static_cast<uint64_t>(activity.channelID));
   visitor.visit(
       CudaMetadataFields::kChannelType,
       static_cast<int64_t>(activity.channelType));
@@ -554,19 +554,19 @@ inline void GpuActivity<CUpti_ActivityKernelType>::visitTypedMetadata(
   const OccupancyMetrics occMetrics = computeOccupancyMetrics(kernel);
 
   visitor.visit(
-      CudaMetadataFields::kQueued, static_cast<int64_t>(kernel.queued));
+      CudaMetadataFields::kQueued, static_cast<uint64_t>(kernel.queued));
   visitor.visit(
       CudaMetadataFields::kDevice, static_cast<int64_t>(kernel.deviceId));
   visitor.visit(
-      CudaMetadataFields::kContext, static_cast<int64_t>(kernel.contextId));
+      CudaMetadataFields::kContext, static_cast<uint64_t>(kernel.contextId));
   visitor.visit(
       CudaMetadataFields::kStream, static_cast<int64_t>(kernel.streamId));
   visitor.visit(
       CudaMetadataFields::kCorrelation,
-      static_cast<int64_t>(kernel.correlationId));
+      static_cast<uint64_t>(kernel.correlationId));
   visitor.visit(
       CudaMetadataFields::kRegistersPerThread,
-      static_cast<int64_t>(kernel.registersPerThread));
+      static_cast<uint64_t>(kernel.registersPerThread));
   visitor.visit(
       CudaMetadataFields::kSharedMemory,
       static_cast<int64_t>(
@@ -617,7 +617,7 @@ inline void GpuActivity<CUpti_ActivityKernelType>::visitTypedMetadata(
         static_cast<int64_t>(occMetrics.result.allocatedRegistersPerBlock));
     d.visit(
         CudaMetadataFields::kAllocatedSharedMemPerBlock,
-        static_cast<int64_t>(occMetrics.result.allocatedSharedMemPerBlock));
+        static_cast<uint64_t>(occMetrics.result.allocatedSharedMemPerBlock));
   });
   addGraphNodeTypedMetadata(visitor, kernel);
   addPriorityTypedMetadata(visitor, kernel);
@@ -657,13 +657,14 @@ inline void GpuActivity<CUpti_ActivityMemcpyType>::visitTypedMetadata(
   visitor.visit(
       CudaMetadataFields::kDevice, static_cast<int64_t>(memcpy.deviceId));
   visitor.visit(
-      CudaMetadataFields::kContext, static_cast<int64_t>(memcpy.contextId));
+      CudaMetadataFields::kContext, static_cast<uint64_t>(memcpy.contextId));
   visitor.visit(
       CudaMetadataFields::kStream, static_cast<int64_t>(memcpy.streamId));
   visitor.visit(
       CudaMetadataFields::kCorrelation,
-      static_cast<int64_t>(memcpy.correlationId));
-  visitor.visit(CudaMetadataFields::kBytes, static_cast<int64_t>(memcpy.bytes));
+      static_cast<uint64_t>(memcpy.correlationId));
+  visitor.visit(
+      CudaMetadataFields::kBytes, static_cast<uint64_t>(memcpy.bytes));
   addBandwidthTypedMetadata(visitor, memcpy.bytes, duration());
   addGraphNodeTypedMetadata(visitor, memcpy);
   addChannelTypedMetadata(visitor, memcpy);
@@ -694,25 +695,26 @@ inline void GpuActivity<CUpti_ActivityMemcpyPtoPType>::visitTypedMetadata(
   const CUpti_ActivityMemcpyPtoPType& memcpy = raw();
   visitor.visit(
       CudaMetadataFields::kFromDevice,
-      static_cast<int64_t>(memcpy.srcDeviceId));
+      static_cast<uint64_t>(memcpy.srcDeviceId));
   visitor.visit(
-      CudaMetadataFields::kInDevice, static_cast<int64_t>(memcpy.deviceId));
+      CudaMetadataFields::kInDevice, static_cast<uint64_t>(memcpy.deviceId));
   visitor.visit(
-      CudaMetadataFields::kToDevice, static_cast<int64_t>(memcpy.dstDeviceId));
+      CudaMetadataFields::kToDevice, static_cast<uint64_t>(memcpy.dstDeviceId));
   visitor.visit(
       CudaMetadataFields::kFromContext,
-      static_cast<int64_t>(memcpy.srcContextId));
+      static_cast<uint64_t>(memcpy.srcContextId));
   visitor.visit(
-      CudaMetadataFields::kInContext, static_cast<int64_t>(memcpy.contextId));
+      CudaMetadataFields::kInContext, static_cast<uint64_t>(memcpy.contextId));
   visitor.visit(
       CudaMetadataFields::kToContext,
-      static_cast<int64_t>(memcpy.dstContextId));
+      static_cast<uint64_t>(memcpy.dstContextId));
   visitor.visit(
       CudaMetadataFields::kStream, static_cast<int64_t>(memcpy.streamId));
   visitor.visit(
       CudaMetadataFields::kCorrelation,
-      static_cast<int64_t>(memcpy.correlationId));
-  visitor.visit(CudaMetadataFields::kBytes, static_cast<int64_t>(memcpy.bytes));
+      static_cast<uint64_t>(memcpy.correlationId));
+  visitor.visit(
+      CudaMetadataFields::kBytes, static_cast<uint64_t>(memcpy.bytes));
   addBandwidthTypedMetadata(visitor, memcpy.bytes, duration());
   addGraphNodeTypedMetadata(visitor, memcpy);
   addChannelTypedMetadata(visitor, memcpy);
@@ -745,13 +747,14 @@ inline void GpuActivity<CUpti_ActivityMemsetType>::visitTypedMetadata(
   visitor.visit(
       CudaMetadataFields::kDevice, static_cast<int64_t>(memset.deviceId));
   visitor.visit(
-      CudaMetadataFields::kContext, static_cast<int64_t>(memset.contextId));
+      CudaMetadataFields::kContext, static_cast<uint64_t>(memset.contextId));
   visitor.visit(
       CudaMetadataFields::kStream, static_cast<int64_t>(memset.streamId));
   visitor.visit(
       CudaMetadataFields::kCorrelation,
-      static_cast<int64_t>(memset.correlationId));
-  visitor.visit(CudaMetadataFields::kBytes, static_cast<int64_t>(memset.bytes));
+      static_cast<uint64_t>(memset.correlationId));
+  visitor.visit(
+      CudaMetadataFields::kBytes, static_cast<uint64_t>(memset.bytes));
   addBandwidthTypedMetadata(visitor, memset.bytes, duration());
   addGraphNodeTypedMetadata(visitor, memset);
   addChannelTypedMetadata(visitor, memset);
@@ -804,10 +807,10 @@ inline const std::string RuntimeActivity::metadataJson() const {
 inline void RuntimeActivity::visitTypedMetadata(
     ITypedMetadataVisitor& visitor) const {
   visitor.visit(
-      CudaMetadataFields::kCbid, static_cast<int64_t>(activity_.cbid));
+      CudaMetadataFields::kCbid, static_cast<uint64_t>(activity_.cbid));
   visitor.visit(
       CudaMetadataFields::kCorrelation,
-      static_cast<int64_t>(activity_.correlationId));
+      static_cast<uint64_t>(activity_.correlationId));
 }
 
 inline bool isTrackedDriverCbid(const CUpti_ActivityAPI& activity_) {
@@ -829,10 +832,10 @@ inline const std::string DriverActivity::metadataJson() const {
 inline void DriverActivity::visitTypedMetadata(
     ITypedMetadataVisitor& visitor) const {
   visitor.visit(
-      CudaMetadataFields::kCbid, static_cast<int64_t>(activity_.cbid));
+      CudaMetadataFields::kCbid, static_cast<uint64_t>(activity_.cbid));
   visitor.visit(
       CudaMetadataFields::kCorrelation,
-      static_cast<int64_t>(activity_.correlationId));
+      static_cast<uint64_t>(activity_.correlationId));
 }
 
 inline const std::string DriverActivity::name() const {

--- a/libkineto/src/DeviceProperties.cpp
+++ b/libkineto/src/DeviceProperties.cpp
@@ -81,11 +81,11 @@ static void visitDeviceMetadata(
     size_t id,
     const gpuDeviceProp& props,
     libkineto::ITypedMetadataVisitor& visitor) {
-  visitor.visit(DevicePropertyFields::kId, static_cast<int64_t>(id));
+  visitor.visit(DevicePropertyFields::kId, static_cast<uint64_t>(id));
   visitor.visit(DevicePropertyFields::kName, std::string{props.name});
   visitor.visit(
       DevicePropertyFields::kTotalGlobalMem,
-      static_cast<int64_t>(props.totalGlobalMem));
+      static_cast<uint64_t>(props.totalGlobalMem));
   visitor.visit(
       DevicePropertyFields::kComputeMajor, static_cast<int64_t>(props.major));
   visitor.visit(
@@ -103,7 +103,7 @@ static void visitDeviceMetadata(
       DevicePropertyFields::kWarpSize, static_cast<int64_t>(props.warpSize));
   visitor.visit(
       DevicePropertyFields::kSharedMemPerBlock,
-      static_cast<int64_t>(props.sharedMemPerBlock));
+      static_cast<uint64_t>(props.sharedMemPerBlock));
   visitor.visit(
       DevicePropertyFields::kNumSms,
       static_cast<int64_t>(props.multiProcessorCount));
@@ -113,14 +113,14 @@ static void visitDeviceMetadata(
       static_cast<int64_t>(props.regsPerMultiprocessor));
   visitor.visit(
       DevicePropertyFields::kSharedMemPerBlockOptin,
-      static_cast<int64_t>(props.sharedMemPerBlockOptin));
+      static_cast<uint64_t>(props.sharedMemPerBlockOptin));
   visitor.visit(
       DevicePropertyFields::kSharedMemPerMultiprocessor,
-      static_cast<int64_t>(props.sharedMemPerMultiprocessor));
+      static_cast<uint64_t>(props.sharedMemPerMultiprocessor));
 #elif defined(HAS_ROCTRACER)
   visitor.visit(
       DevicePropertyFields::kMaxSharedMemoryPerMultiProcessor,
-      static_cast<int64_t>(props.maxSharedMemoryPerMultiProcessor));
+      static_cast<uint64_t>(props.maxSharedMemoryPerMultiProcessor));
 #endif
 }
 

--- a/libkineto/src/RocprofActivity_inl.h
+++ b/libkineto/src/RocprofActivity_inl.h
@@ -151,9 +151,9 @@ inline void GpuActivity::visitTypedMetadata(
       RocmMetadataFields::kDevice, static_cast<int64_t>(gpuActivity.device));
   visitor.visit(RocmMetadataFields::kStream, resourceId());
   visitor.visit(
-      RocmMetadataFields::kHsaQueue, static_cast<int64_t>(gpuActivity.queue));
+      RocmMetadataFields::kHsaQueue, static_cast<uint64_t>(gpuActivity.queue));
   visitor.visit(
-      RocmMetadataFields::kCorrelation, static_cast<int64_t>(gpuActivity.id));
+      RocmMetadataFields::kCorrelation, static_cast<uint64_t>(gpuActivity.id));
   visitor.visit(
       RocmMetadataFields::kKind,
       std::string{
@@ -163,7 +163,7 @@ inline void GpuActivity::visitTypedMetadata(
   auto sizeIt = correlationToSize.find(gpuActivity.id);
   if (sizeIt != correlationToSize.end()) {
     visitor.visit(
-        RocmMetadataFields::kBytes, static_cast<int64_t>(sizeIt->second));
+        RocmMetadataFields::kBytes, static_cast<uint64_t>(sizeIt->second));
     addBandwidthTypedMetadata(
         visitor, sizeIt->second, gpuActivity.end - gpuActivity.begin);
     return;
@@ -221,14 +221,14 @@ inline void RuntimeActivity<rocprofKernelRow>::visitTypedMetadata(
   correlationToGrid[raw().id] = rocprofKernelGrid(raw());
   correlationToBlock[raw().id] = rocprofKernelBlock(raw());
 
-  visitor.visit(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
+  visitor.visit(RocmMetadataFields::kCid, static_cast<uint64_t>(raw().cid));
   visitor.visit(
-      RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
+      RocmMetadataFields::kCorrelation, static_cast<uint64_t>(raw().id));
   visitor.visit(RocmMetadataFields::kGrid, correlationToGrid[raw().id]);
   visitor.visit(RocmMetadataFields::kBlock, correlationToBlock[raw().id]);
   visitor.visit(
       RocmMetadataFields::kSharedMemory,
-      static_cast<int64_t>(raw().groupSegmentSize));
+      static_cast<uint64_t>(raw().groupSegmentSize));
 }
 
 template <>
@@ -243,12 +243,12 @@ template <>
 inline void RuntimeActivity<rocprofCopyRow>::visitTypedMetadata(
     ITypedMetadataVisitor& visitor) const {
   correlationToSize[raw().id] = raw().size;
-  visitor.visit(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
+  visitor.visit(RocmMetadataFields::kCid, static_cast<uint64_t>(raw().cid));
   visitor.visit(
-      RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
+      RocmMetadataFields::kCorrelation, static_cast<uint64_t>(raw().id));
   visitor.visit(RocmMetadataFields::kSrc, fmt::format("{}", raw().src));
   visitor.visit(RocmMetadataFields::kDst, fmt::format("{}", raw().dst));
-  visitor.visit(RocmMetadataFields::kBytes, static_cast<int64_t>(raw().size));
+  visitor.visit(RocmMetadataFields::kBytes, static_cast<uint64_t>(raw().size));
   visitor.visit(
       RocmMetadataFields::kKind,
       fmt::format("{}", fmt::underlying(raw().kind)));
@@ -266,11 +266,12 @@ inline void RuntimeActivity<rocprofMallocRow>::visitTypedMetadata(
     ITypedMetadataVisitor& visitor) const {
   correlationToSize[raw().id] = raw().size;
   if (raw().cid == ROCPROFILER_HIP_RUNTIME_API_ID_hipMalloc) {
-    visitor.visit(RocmMetadataFields::kBytes, static_cast<int64_t>(raw().size));
+    visitor.visit(
+        RocmMetadataFields::kBytes, static_cast<uint64_t>(raw().size));
   }
-  visitor.visit(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
+  visitor.visit(RocmMetadataFields::kCid, static_cast<uint64_t>(raw().cid));
   visitor.visit(
-      RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
+      RocmMetadataFields::kCorrelation, static_cast<uint64_t>(raw().id));
   visitor.visit(RocmMetadataFields::kPtr, fmt::format("{}", raw().ptr));
 }
 
@@ -292,9 +293,9 @@ inline const std::string RuntimeActivity<T>::metadataJson() const {
 template <class T>
 inline void RuntimeActivity<T>::visitTypedMetadata(
     ITypedMetadataVisitor& visitor) const {
-  visitor.visit(RocmMetadataFields::kCid, static_cast<int64_t>(raw().cid));
+  visitor.visit(RocmMetadataFields::kCid, static_cast<uint64_t>(raw().cid));
   visitor.visit(
-      RocmMetadataFields::kCorrelation, static_cast<int64_t>(raw().id));
+      RocmMetadataFields::kCorrelation, static_cast<uint64_t>(raw().id));
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -59,6 +59,7 @@ using namespace libkineto::test;
 namespace {
 using RecordedMetadataValue = std::variant<
     int64_t,
+    uint64_t,
     double,
     bool,
     std::string,
@@ -114,9 +115,10 @@ class RecordingTypedMetadataVisitor final : public ITypedMetadataVisitor {
     values_[std::string{field.name}] = std::string{value.value};
   }
 
-  void visitValue(
-      [[maybe_unused]] const MetadataField<uint64_t>& field,
-      [[maybe_unused]] uint64_t value) override {}
+  void visitValue(const MetadataField<uint64_t>& field, uint64_t value)
+      override {
+    values_[std::string{field.name}] = value;
+  }
 
   void visitValue(
       [[maybe_unused]] const MetadataField<InputShapes>& field,
@@ -602,7 +604,7 @@ TEST_F(CuptiActivityProfilerTest, SyncEventCorrIdOutOfOrder) {
       activity->visitTypedMetadata(typedMetadata);
       EXPECT_EQ(
           typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventId),
-          static_cast<int64_t>(kEventId));
+          static_cast<uint64_t>(kEventId));
       EXPECT_EQ(
           typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventRecordCorrId),
           static_cast<int64_t>(kRecordCorrId));
@@ -623,7 +625,7 @@ TEST_F(CuptiActivityProfilerTest, SyncEventCorrIdOutOfOrder) {
       activity->visitTypedMetadata(typedMetadata);
       EXPECT_EQ(
           typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventId),
-          static_cast<int64_t>(kEventId));
+          static_cast<uint64_t>(kEventId));
       EXPECT_EQ(
           typedMetadata.get(CudaMetadataFields::kWaitOnCudaEventRecordCorrId),
           static_cast<int64_t>(kRecordCorrId));

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -72,7 +72,12 @@ struct RocmStreamTypedMetadataVisitor final : public ITypedMetadataVisitor {
   void visitValue(const MetadataField<int64_t>& field, int64_t value) override {
     if (field.name == RocmMetadataFields::kStream.name) {
       stream = value;
-    } else if (field.name == RocmMetadataFields::kHsaQueue.name) {
+    }
+  }
+
+  void visitValue(const MetadataField<uint64_t>& field, uint64_t value)
+      override {
+    if (field.name == RocmMetadataFields::kHsaQueue.name) {
       hsaQueue = value;
     }
   }
@@ -96,9 +101,6 @@ struct RocmStreamTypedMetadataVisitor final : public ITypedMetadataVisitor {
       [[maybe_unused]] const MetadataField<RawJson>& field,
       [[maybe_unused]] const RawJson& value) override {}
   void visitValue(
-      [[maybe_unused]] const MetadataField<uint64_t>& field,
-      [[maybe_unused]] uint64_t value) override {}
-  void visitValue(
       [[maybe_unused]] const MetadataField<InputShapes>& field,
       [[maybe_unused]] const InputShapes& value) override {}
 
@@ -108,7 +110,7 @@ struct RocmStreamTypedMetadataVisitor final : public ITypedMetadataVisitor {
   void endDict() override {}
 
   std::optional<int64_t> stream;
-  std::optional<int64_t> hsaQueue;
+  std::optional<uint64_t> hsaQueue;
 };
 } // namespace
 
@@ -435,7 +437,7 @@ TEST_F(RocmActivityProfilerTest, GpuTypedMetadataMatchesLegacyStreamMetadata) {
   const auto jsonMetadata =
       nlohmann::json::parse("{" + memcpyActivity->metadataJson() + "}");
   EXPECT_EQ(typedMetadata.stream, jsonMetadata["stream"].get<int64_t>());
-  EXPECT_EQ(typedMetadata.hsaQueue, jsonMetadata["hsa_queue"].get<int64_t>());
+  EXPECT_EQ(typedMetadata.hsaQueue, jsonMetadata["hsa_queue"].get<uint64_t>());
 }
 
 TEST_F(


### PR DESCRIPTION
Summary:

Update a bunch of fields from int64_t to uint64_t:

- Generic: kPythonParentId
- Device properties: kId, kTotalGlobalMem, kSharedMemPerBlock, kSharedMemPerBlockOptin, kSharedMemPerMultiprocessor, kMaxSharedMemoryPerMultiProcessor
- CUDA: kAllocatedSharedMemPerBlock, kBytes, kCbid, kChannel, kContext, kCorrelation, kEventId, kFromContext, kFromDevice, kGraphId, kGraphNodeId, kInContext, kInDevice, kQueued, kRegistersPerThread, kToContext, kToDevice, kWaitOnCudaEventId
- ROCm: kBytes, kCid, kCorrelation, kHsaQueue, kSharedMemory, kStream

Previously, for simplicity, we represented all of these as `int64_t`, and just called static cast to move the fields that are actually produced as `uint64_t` to `int64_t`. This was fine for JSON write, and the unsigned -> signed cast is safe, but the Perfetto logger represents many of these fields as unsigned. I'd like to avoid the unnecessary unsigned -> signed -> unsigned roundtrip and we recently added uint64_t as a TypedValue -- so we can accurately represent this now.

All of the changes are used by Kineto only, so they should be safe. `kPythonParentId` is not used on the profiler side yet, so no compat issue there.

Reviewed By: scotts

Differential Revision: D113458168


