### PR TITLE
Make ConfigLoader poll-thread exception test deterministic and generic (#1501)

### DIFF
--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -40,6 +40,15 @@ target_link_libraries(ConfigLoaderTest PRIVATE
     ${XPU_XPUPTI_LIBRARY})
 gtest_discover_tests(ConfigLoaderTest)
 
+# ConfigLoaderPollThreadExceptionTest
+add_executable(ConfigLoaderPollThreadExceptionTest
+    ConfigLoaderPollThreadExceptionTest.cpp)
+target_link_libraries(ConfigLoaderPollThreadExceptionTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(ConfigLoaderPollThreadExceptionTest)
+
 # ActivityProfilerControllerTest
 # Not supported on Windows, uses unix "unistd.h"
 if(NOT WIN32)

--- a/libkineto/test/ConfigLoaderPollThreadExceptionTest.cpp
+++ b/libkineto/test/ConfigLoaderPollThreadExceptionTest.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/ConfigLoader.h"
+#include "src/DaemonConfigLoader.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+
+namespace KINETO_NAMESPACE {
+namespace {
+
+struct NoopConfigHandler final : ConfigLoader::ConfigHandler {
+  bool canAcceptConfig() override {
+    return true;
+  }
+  bool acceptConfig(const Config& /*cfg*/) override {
+    return true;
+  }
+};
+
+// One-shot handshake the poll thread raises once it reaches readOnDemandConfig.
+// post() is idempotent so the poll loop firing it on repeated iterations is
+// fine.
+struct OnDemandSignal {
+  void post() {
+    {
+      std::scoped_lock lock(mutex_);
+      reached_ = true;
+    }
+    cv_.notify_all();
+  }
+
+  bool waitFor(std::chrono::seconds timeout) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, timeout, [this] { return reached_; });
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  bool reached_ = false;
+};
+
+// Throws out of every daemon call the poll thread makes. readBaseConfig() feeds
+// the base-config branch; readOnDemandConfig() feeds the on-demand branch and
+// posts onDemandReached so the test can observe that the loop got there.
+struct ThrowingDaemonConfigLoader final : IDaemonConfigLoader {
+  explicit ThrowingDaemonConfigLoader(
+      std::shared_ptr<OnDemandSignal> onDemandReached)
+      : onDemandReached_(std::move(onDemandReached)) {}
+
+  [[noreturn]] std::string readBaseConfig() override {
+    throw std::runtime_error("injected base-config failure");
+  }
+
+  [[noreturn]] std::string readOnDemandConfig(bool /*activities*/) override {
+    onDemandReached_->post();
+    throw std::runtime_error("injected on-demand failure");
+  }
+
+  void setCommunicationFabric(bool /*enabled*/) override {}
+
+ private:
+  std::shared_ptr<OnDemandSignal> onDemandReached_;
+};
+
+// Drives the process-global ConfigLoader singleton and sets KINETO_CONFIG,
+// which configFileName() reads once and memoizes. It assumes a fresh process
+// (tpx runs each gtest case in its own), so the singleton starts clean here.
+//
+// The poll thread runs updateBaseConfig()/configureFromDaemon() on a bare
+// std::thread, where an escaped exception calls std::terminate() and aborts the
+// whole process -- the fleet SIGABRT this guard fixed. Assert generically that
+// an exception from the config work is swallowed and the loop keeps running,
+// without reproducing any specific throw site.
+TEST(ConfigLoaderPollThreadExceptionTest, ConfigUpdateExceptionDoesNotCrash) {
+  // Non-existent path so updateBaseConfig() falls through to the daemon loader.
+  ::setenv("KINETO_CONFIG", "/tmp/nonexistent_libkineto_test.conf", 1);
+
+  auto onDemandReached = std::make_shared<OnDemandSignal>();
+  ConfigLoader::setDaemonConfigLoaderFactory([onDemandReached] {
+    return std::make_unique<ThrowingDaemonConfigLoader>(onDemandReached);
+  });
+
+  NoopConfigHandler handler;
+  // Stops and joins the poll thread before `handler` is destroyed, on every
+  // exit path including an ASSERT early-return, so the thread can never touch
+  // the freed stack handler. Declared after `handler` so it runs before
+  // handler's destructor.
+  struct ThreadStopper {
+    ConfigLoader::ConfigHandler* handler;
+    ~ThreadStopper() {
+      ConfigLoader::instance().stopUpdateThread();
+      ConfigLoader::instance().removeHandler(
+          ConfigLoader::ConfigKind::ActivityProfiler, handler);
+      ConfigLoader::setDaemonConfigLoaderFactory(nullptr);
+    }
+  } threadStopper{&handler};
+
+  // Starts the poll thread; its first iteration fires both branches
+  // immediately.
+  ConfigLoader::instance().addHandler(
+      ConfigLoader::ConfigKind::ActivityProfiler, &handler);
+
+  // readBaseConfig() throws first. Reaching readOnDemandConfig() -- which posts
+  // this signal -- is only possible if the base-config branch caught the
+  // exception and the loop continued. Deterministic handshake, no sleeps.
+  // readOnDemandConfig() then throws too, so the clean join in ThreadStopper
+  // (no std::terminate) also shows the on-demand branch caught it.
+  ASSERT_TRUE(onDemandReached->waitFor(std::chrono::seconds(30)))
+      << "poll thread did not survive the base-config exception";
+}
+
+} // namespace
+} // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Summary:

Follow-up to D113579180, addressing review feedback that the
`ConfigLoaderShutdownRaceTest` added there, while the source fix was good,
were not good tests:

1. They synchronized with the background thread via an arbitrary
   `std::this_thread::sleep_for(3s)`, which is non-deterministic and
   flaky on loaded CI hosts (also flagged by `CLANGTIDY` and AI review).
2. They pulled in an incidental OpenSSL dependency to reproduce the exact
   `X509_STORE_new() -> std::bad_alloc` prod path, coupling the test to
   one specific throw site instead of the behavior.

Replace them with a single deterministic unit test that exercises the
guard generically. It injects a throwing `IDaemonConfigLoader` through the
existing `setDaemonConfigLoaderFactory()` seam (the same pattern
`ConfigLoaderForkTest` uses) so `updateBaseConfig()` throws, and
synchronizes with the poll thread via a `folly::Baton` instead of a sleep.

The assertion is positive rather than crash-based: `readBaseConfig()`
throws (base-config branch), and reaching `readOnDemandConfig()` -- which
posts the baton -- is only possible if the base-config branch caught the
exception and the loop continued. `readOnDemandConfig()` then throws too,
so the clean join that follows also exercises the on-demand branch guard.

No OpenSSL, no sleeps, no mocks of internal crypto -- just the documented
factory seam. Applied to both the fbcode and xplat mirrors.

Reviewed By: scotts

Differential Revision: D113771045


