### PR TITLE
Don't warn on the intentional fb "file" logger-factory override

### DIFF
--- a/libkineto/src/ActivityProfilerController.cpp
+++ b/libkineto/src/ActivityProfilerController.cpp
@@ -120,8 +120,10 @@ ActivityLoggerFactory& ActivityProfilerController::loggerFactory() {
 
 void ActivityProfilerController::addLoggerFactory(
     const std::string& protocol,
-    ActivityLoggerFactory::FactoryFunc factory) {
-  if (loggerFactory().addProtocol(protocol, std::move(factory))) {
+    ActivityLoggerFactory::FactoryFunc factory,
+    bool warnOnOverwrite) {
+  if (loggerFactory().addProtocol(protocol, std::move(factory)) &&
+      warnOnOverwrite) {
     LOG(WARNING) << "Overwriting logger factory for protocol: " << protocol;
   }
 }

--- a/libkineto/src/ActivityProfilerController.h
+++ b/libkineto/src/ActivityProfilerController.h
@@ -45,9 +45,13 @@ class ActivityProfilerController : public ConfigLoader::ConfigHandler {
   static std::vector<std::shared_ptr<LoggerCollector>> getLoggerCollectors();
 #endif // !USE_GOOGLE_LOG
 
+  // Pass warnOnOverwrite=false to silently replace an already-registered
+  // factory for the protocol. Intentional overrides (e.g. the fb "file"
+  // protocol override) use this to avoid a benign startup WARNING.
   static void addLoggerFactory(
       const std::string& protocol,
-      ActivityLoggerFactory::FactoryFunc factory);
+      ActivityLoggerFactory::FactoryFunc factory,
+      bool warnOnOverwrite = true);
 
   static void setInvariantViolationsLoggerFactory(
       const std::function<std::unique_ptr<InvariantViolationsLogger>()>&


### PR DESCRIPTION
Summary:
Every fbcode binary that links libkineto's fb init prints this benign line to
stderr at process startup:

  WARNING:... ActivityProfilerController.cpp:125] Overwriting logger factory for protocol: file

Root cause: `loggerFactory()` lazily registers the built-in `"file"` ->
`ChromeTraceLogger` factory (`ActivityProfilerController.cpp:112`), then the fb
init (`InitHelper` static ctor -> `FileChromeTraceLogger::registerFactory()`)
deliberately re-registers `"file"` so traces also emit `.pb` output.
`addLoggerFactory` sees the existing key and unconditionally logs `LOG(WARNING)`.
The message fires during C++ static initialization, before `main()`, so it
cannot be suppressed from application code or via an env var (kineto's `LOG`
macro is always on for `WARNING` by default).

Fix: give `addLoggerFactory` an opt-out for intentional overrides via a
defaulted `warnOnOverwrite = true` parameter. All existing callers keep the
safety warning that catches accidental double-registration; only the known,
by-design fb `"file"` override passes `warnOnOverwrite = false`.

No change to trace output — this only gates a startup log line.

The identical `xplat/kineto/libkineto/` mirror is updated automatically by the
fbcode<->xplat sync hook, so both copies stay in sync within this diff.

Reviewed By: ryanzhang22

Differential Revision: D113898365


