### PR TITLE
Fix ConfigLoaderTest daemon-poll failures in single-process runs

### DIFF
--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -124,6 +124,12 @@ void ConfigLoader::resetDaemonConfigLoaderForTesting() {
   daemonConfigLoader_.reset();
 }
 
+void ConfigLoader::resetBaseConfigForTesting() {
+  std::scoped_lock lock(configLock_);
+  config_ = std::make_unique<Config>();
+  onDemandConfigUpdateIntervalSecs_ = kConfigUpdateIntervalSecs;
+}
+
 bool ConfigLoader::waitForUpdateThreadLoopCountForTesting(
     uint64_t target,
     std::chrono::milliseconds timeout) {

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -120,6 +120,15 @@ class ConfigLoader {
   // pointing at destroyed test state.
   void resetDaemonConfigLoaderForTesting();
 
+  // Test-only. Clears the cached base config so the next poll thread sees the
+  // base config as changed and rebuilds the daemon config loader from the
+  // registered factory. The base config is a member of this process-wide
+  // singleton and is reloaded only on change, so without this reset a later
+  // test in the same process reuses an earlier test's base config, never
+  // rebuilds the loader from its factory, and never reads the fake daemon. Call
+  // after stopping the thread.
+  void resetBaseConfigForTesting();
+
   // Test-only. Returns the on-demand poll interval the background thread is
   // currently using, taken from the loaded base config. Lets a test size a
   // timeout to the live cadence instead of assuming the default.

--- a/libkineto/test/ConfigLoaderTest.cpp
+++ b/libkineto/test/ConfigLoaderTest.cpp
@@ -137,6 +137,14 @@ class ConfigLoaderTest : public ::testing::Test {
     loader().resetDaemonConfigLoaderForTesting();
     ConfigLoader::setDaemonConfigLoaderFactory(nullptr);
 
+    // Clear the cached base config. The singleton reloads the base config only
+    // when it changes, so once an earlier test primes it (to a local config
+    // file, if present) a later test in the same process would see no change,
+    // never rebuild the daemon loader from its factory, and never poll the
+    // fake. gtest_discover_tests masks this by running each test in its own
+    // process.
+    loader().resetBaseConfigForTesting();
+
     // removeHandler is a no-op for a handler already removed by the test, so
     // double removal is safe.
     for (const auto& [kind, handler] : registered_) {
@@ -211,7 +219,9 @@ TEST_F(ConfigLoaderTest, CanHandlerAcceptConfigVacuouslyTrueWithNoHandlers) {
 //
 // These tests run the actual updateConfigThread() against a fake daemon and use
 // the iteration counter to synchronize. They tolerate a pre-existing local
-// config file (/etc/libkineto.conf or $KINETO_CONFIG) on the test system.
+// config file (/etc/libkineto.conf or $KINETO_CONFIG) on the test system: each
+// test starts from a cleared base config (see TearDown), so the poll thread
+// always re-detects a base-config change and rebuilds the fake daemon loader.
 
 // The poll thread reads the on-demand config from the daemon, parses it, and
 // dispatches it to registered handlers, requesting activities while the handler


### PR DESCRIPTION
**Problem**

The `ConfigLoader` daemon-poll tests pass under ctest and in CI but fail when the test binary is run directly (e.g. `./ConfigLoaderTest`). ctest runs each case in its own process via gtest_discover_tests; the raw binary runs all cases in one process, and three daemon-poll tests then fail. State leaks between them through the process-wide `ConfigLoader` singleton. This reproduces only on a host with a non-empty local config file (/etc/libkineto.conf), so CI stayed green.

**Fix**

Add `ConfigLoader::resetBaseConfigForTesting()` and call it in `ConfigLoaderTest::TearDown()`.

Validated locally: 9/9 running the binary directly and under `--gtest_shuffle --gtest_repeat=3`, and 9/9 under ctest.