### PR TITLE
Migrate `-c fbcode.platform010_cuda_version` to the cuda constraint modifier

### DIFF
--- a/libkineto/stress_test/run_multiproc_stress_test.sh
+++ b/libkineto/stress_test/run_multiproc_stress_test.sh
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-build_cmd="buck build --show-output @mode/opt -c fbcode.nvcc_arch=b200a -c fbcode.platform010_cuda_version=12.8 :kineto_stress_test"
+build_cmd="buck build --show-output @mode/opt -c fbcode.nvcc_arch=b200a -m ovr_config//third-party/cuda/constraints:12.8 :kineto_stress_test"
 build_out=$($build_cmd)
 
 mpi_path=/usr/local/fbcode/platform010-aarch64/bin//mpirun


### PR DESCRIPTION
Summary:
`fbcode.platform010_cuda_version` is a command-line-only buckconfig -- nothing
sets it in any `.buckconfig`. The CUDA toolkit version also comes from
`CUDA_DEFAULT_VERSION` in `arvr/tools/build_defs/config/third-party/cuda/defs.bzl`,
from a `-m ovr_config//third-party/cuda/constraints:<ver>` modifier, and from a
PACKAGE-file `third_party.versions` modifier. All three flow through the
`ovr_config//third-party/cuda/constraints:*` constraint and never touch the
buckconfig, so a `-c` flag is the one path that constraint-aware code cannot see.

This is the mechanical half of that migration (misc-2): every
`-c fbcode.platform010_cuda_version=<V>` invocation becomes
`-m ovr_config//third-party/cuda/constraints:<V>`.

90 file(s) in this diff: 34 .py, 20 .sh, 18 .md, 9 .yaml, 4 Makefile, 2 BUCK.

Applied by script, not by hand. The rewrite only fires when the value is an exact
member of `CUDA_VERSIONS` (`12`, `12.2.2`, `12.4`, `12.8`, `12.8_jetson`, `13.0`,
`13.1`, `13.2`, `13.3`, `latest`), so values with no corresponding constraint are
deliberately left alone -- repo-wide those were `11.8`, `rocm`, and
`cuda-12.4-trt-10.0`. A value followed by sentence punctuation (`...=12.8.` in
prose) keeps the trailing period outside the constraint label.

Part of T282903149. The `read_config` gates that *read* this buckconfig were
migrated first -- D114285835 (landed), D114286514, D114288881, D114289532 -- so
removing the `-c` here cannot silently flip an unmigrated gate to its hardcoded
default.

Reviewed By: florazzz

Differential Revision: D114299821


