### PR TITLE
[XPUPTI] Disable XPUPTI if cpuOnly flag is true.

### DIFF
--- a/libkineto/src/init.cpp
+++ b/libkineto/src/init.cpp
@@ -157,15 +157,17 @@ void libkineto_init(bool cpuOnly, [[maybe_unused]] bool logOnError) {
       std::make_unique<ActivityProfilerProxy>(cpuOnly, config_loader));
 
 #ifdef HAS_XPUPTI
-  // register xpu pti profiler
-  libkineto::api().registerProfilerFactory(
-      []() -> std::unique_ptr<IActivityProfiler> {
-        XPUPTI_CALL(
-            ptiViewGPULocalAvailable(),
-            /*error_message=*/"Failed to enable Kineto Profiler on XPU.");
-        XpuptiScopeProfilerConfig::registerFactory();
-        return std::make_unique<XPUActivityProfiler>();
-      });
+  if (!cpuOnly) {
+    // register xpu pti profiler
+    libkineto::api().registerProfilerFactory(
+        []() -> std::unique_ptr<IActivityProfiler> {
+          XPUPTI_CALL(
+              ptiViewGPULocalAvailable(),
+              /*error_message=*/"Failed to enable Kineto Profiler on XPU.");
+          XpuptiScopeProfilerConfig::registerFactory();
+          return std::make_unique<XPUActivityProfiler>();
+        });
+  }
 #endif // HAS_XPUPTI
 
 #if __linux__

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -40,18 +40,18 @@ target_link_libraries(ConfigLoaderTest PRIVATE
     ${XPU_XPUPTI_LIBRARY})
 gtest_discover_tests(ConfigLoaderTest)
 
-# ConfigLoaderPollThreadExceptionTest
-add_executable(ConfigLoaderPollThreadExceptionTest
-    ConfigLoaderPollThreadExceptionTest.cpp)
-target_link_libraries(ConfigLoaderPollThreadExceptionTest PRIVATE
-    gtest_main
-    kineto_base kineto_api
-    ${XPU_XPUPTI_LIBRARY})
-gtest_discover_tests(ConfigLoaderPollThreadExceptionTest)
-
 # ActivityProfilerControllerTest
 # Not supported on Windows, uses unix "unistd.h"
 if(NOT WIN32)
+    # ConfigLoaderPollThreadExceptionTest
+    add_executable(ConfigLoaderPollThreadExceptionTest
+        ConfigLoaderPollThreadExceptionTest.cpp)
+    target_link_libraries(ConfigLoaderPollThreadExceptionTest PRIVATE
+        gtest_main
+        kineto_base kineto_api
+        ${XPU_XPUPTI_LIBRARY})
+    gtest_discover_tests(ConfigLoaderPollThreadExceptionTest)
+
     add_executable(ActivityProfilerControllerTest
         ActivityProfilerControllerTest.cpp
         TestUtils.cpp)

--- a/libkineto/test/xpupti/CMakeLists.txt
+++ b/libkineto/test/xpupti/CMakeLists.txt
@@ -92,8 +92,8 @@ function(add_sycl_test test_file)
     xpupti_compute)
   set_target_properties(${test_name} PROPERTIES
     BUILD_RPATH ${CMAKE_CURRENT_BINARY_DIR})
-  gtest_discover_tests(${test_name})
+  gtest_discover_tests(${test_name} ${ARGN})
 endfunction()
 
 add_sycl_test(XpuptiProfilerTest.cpp)
-add_sycl_test(XpuptiScopeProfilerTest.cpp)
+add_sycl_test(XpuptiScopeProfilerTest.cpp PROPERTIES ENVIRONMENT "ZET_ENABLE_METRICS=1")


### PR DESCRIPTION
This PR align `XPUPTI` behavior to `CUDA` and `ROCM`.
Don't enable the plugin in `cpuOnly` mode.

Extra: skip Linux only test.