### PR TITLE
Enforce PyTorch's RAWTHROW and CMAKE linters in Kineto

### DIFF
--- a/.cmakelintrc
+++ b/.cmakelintrc
@@ -1,0 +1,1 @@
+filter=-convention/filename,-linelength,-package/consistency,-readability/logic,-readability/mixedcase,-readability/wonkycase,-syntax,-whitespace/eol,+whitespace/extra,-whitespace/indent,-whitespace/mismatch,-whitespace/newline,-whitespace/tabs

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -110,3 +110,59 @@ command = [
     '--',
     '@{{PATHSFILE}}'
 ]
+
+[[linter]]
+code = 'RAWTHROW'
+include_patterns = [
+    'libkineto/**/*.cpp',
+    'libkineto/**/*.h',
+    'libkineto/**/*.cc',
+    'libkineto/**/*.hpp',
+]
+exclude_patterns = [
+    'libkineto/third_party/**',
+    'libkineto/build/**',
+    # stress_test is a standalone CUDA/NCCL benchmark harness that CMake never
+    # builds and that is not vendored into PyTorch, so its raw throw is left in
+    # place rather than routed through KINETO_THROW.
+    'libkineto/stress_test/**',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=\bthrow\b',
+    '--allowlist-pattern=@allow-raw-throw',
+    '--linter-name=RAWTHROW',
+    '--error-name=raw throw statement',
+    """--error-description=\
+        Do not use a raw throw in C++. Kineto cannot depend on c10, so raise \
+        exceptions through the KINETO_THROW macro in src/ThrowUtil.h, which \
+        preserves the exception type. For a re-throw (throw;), restructure the \
+        code to avoid try/catch/throw.\
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]
+
+[[linter]]
+code = 'CMAKE'
+include_patterns = [
+    'libkineto/**/*.cmake',
+    'libkineto/**/*.cmake.in',
+    'libkineto/**/CMakeLists.txt',
+]
+exclude_patterns = [
+    'libkineto/third_party/**',
+    'libkineto/build/**',
+]
+command = [
+    'uv',
+    'run',
+    '--python',
+    '3.10',
+    '--script',
+    'tools/linter/adapters/cmake_linter.py',
+    '--config=.cmakelintrc',
+    '--',
+    '@{{PATHSFILE}}',
+]

--- a/libkineto/src/AbstractConfig.cpp
+++ b/libkineto/src/AbstractConfig.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "AbstractConfig.h"
+#include "ThrowUtil.h"
 
 #include <fmt/format.h>
 #include <array>
@@ -97,10 +98,13 @@ int64_t AbstractConfig::toIntRange(const string& val, int64_t min, int64_t max)
   char* invalid = nullptr;
   int64_t res = strtoll(val.c_str(), &invalid, 10);
   if (val.empty() || *invalid) {
-    throw std::invalid_argument(fmt::format("Invalid integer: {}", val));
+    KINETO_THROW(
+        std::invalid_argument, fmt::format("Invalid integer: {}", val));
   } else if (res < min || res > max) {
-    throw std::invalid_argument(fmt::format(
-        "Invalid argument: {} - expected range [{}, {}]", res, min, max));
+    KINETO_THROW(
+        std::invalid_argument,
+        fmt::format(
+            "Invalid argument: {} - expected range [{}, {}]", res, min, max));
   }
   return res;
 }
@@ -123,7 +127,8 @@ bool AbstractConfig::toBool(string& val) const {
       return i % 2;
     }
   }
-  throw std::invalid_argument(fmt::format("Invalid bool argument: {}", val));
+  KINETO_THROW(
+      std::invalid_argument, fmt::format("Invalid bool argument: {}", val));
 }
 
 bool AbstractConfig::parse(const string& conf) {

--- a/libkineto/src/ActivityLoggerFactory.h
+++ b/libkineto/src/ActivityLoggerFactory.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "ThrowUtil.h"
+
 #include <fmt/format.h>
 #include <algorithm>
 #include <cctype>
@@ -52,8 +54,10 @@ class ActivityLoggerFactory {
     if (factory) {
       return factory(stripProtocol(url));
     }
-    throw std::invalid_argument(fmt::format(
-        "No logger registered for the {} protocol prefix", protocol));
+    KINETO_THROW(
+        std::invalid_argument,
+        fmt::format(
+            "No logger registered for the {} protocol prefix", protocol));
   }
 
  private:

--- a/libkineto/src/ActivityType.cpp
+++ b/libkineto/src/ActivityType.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ActivityType.h"
+#include "ThrowUtil.h"
 
 #include <fmt/format.h>
 
@@ -25,7 +26,8 @@ ActivityType toActivityType(const std::string& str) {
       return _activityTypeNames[i].type;
     }
   }
-  throw std::invalid_argument(fmt::format("Invalid activity type: {}", str));
+  KINETO_THROW(
+      std::invalid_argument, fmt::format("Invalid activity type: {}", str));
 }
 
 std::array<ActivityType, activityTypeCount> activityTypes() {

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "Config.h"
+#include "ThrowUtil.h"
 
 #include <cstdlib>
 
@@ -298,11 +299,13 @@ static time_point<system_clock> handleProfileStartTime(int64_t start_time_ms) {
   // But we can still check that the start time is not in the past.
   auto now = system_clock::now();
   if ((now - t) > kMaxRequestAge) {
-    throw std::invalid_argument(fmt::format(
-        "Invalid {}: {} - start time is more than {}s in the past",
-        kProfileStartTimeKey,
-        getTimeStr(t),
-        kMaxRequestAge.count()));
+    KINETO_THROW(
+        std::invalid_argument,
+        fmt::format(
+            "Invalid {}: {} - start time is more than {}s in the past",
+            kProfileStartTimeKey,
+            getTimeStr(t),
+            kMaxRequestAge.count()));
   }
   return t;
 }

--- a/libkineto/src/CuptiCbidRegistry.cpp
+++ b/libkineto/src/CuptiCbidRegistry.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "CuptiCbidRegistry.h"
+#include "ThrowUtil.h"
 
 #include <stdexcept>
 
@@ -25,7 +26,7 @@ CuptiCbidRegistry::getMapForDomain(CallbackDomain domain) {
     case CallbackDomain::DRIVER:
       return driverCallbacks_;
     default:
-      throw std::invalid_argument("Unknown CallbackDomain");
+      KINETO_THROW(std::invalid_argument, "Unknown CallbackDomain");
   }
 }
 

--- a/libkineto/src/ILoggerObserver.cpp
+++ b/libkineto/src/ILoggerObserver.cpp
@@ -15,6 +15,8 @@
 #include <fmt/format.h>
 #include <array>
 
+#include "ThrowUtil.h"
+
 namespace libkineto {
 
 struct LoggerTypeName {
@@ -52,7 +54,8 @@ LoggerOutputType toLoggerOutputType(const std::string& str) {
       return LoggerMap[i].type;
     }
   }
-  throw std::invalid_argument(fmt::format("Invalid activity type: {}", str));
+  KINETO_THROW(
+      std::invalid_argument, fmt::format("Invalid activity type: {}", str));
 }
 
 } // namespace libkineto

--- a/libkineto/src/RocprofLogger.cpp
+++ b/libkineto/src/RocprofLogger.cpp
@@ -25,6 +25,7 @@
 #include "Demangle.h"
 #include "Logger.h"
 #include "ThreadUtil.h"
+#include "ThrowUtil.h"
 
 using namespace libkineto;
 using namespace std::chrono;
@@ -295,7 +296,8 @@ std::vector<rocprofiler_agent_v0_t> get_gpu_device_agents() {
          size_t num_agents,
          void* udata) {
         if (agents_ver != ROCPROFILER_AGENT_INFO_VERSION_0)
-          throw std::runtime_error{"unexpected rocprofiler agent version"};
+          KINETO_THROW(
+              std::runtime_error, "unexpected rocprofiler agent version");
         auto* agents_v =
             static_cast<std::vector<rocprofiler_agent_v0_t>*>(udata);
         for (size_t i = 0; i < num_agents; ++i) {

--- a/libkineto/src/ThrowUtil.h
+++ b/libkineto/src/ThrowUtil.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Kineto is a standalone library and cannot depend on c10's error-reporting
+// macros (TORCH_CHECK, C10_THROW_ERROR), so it raises std exceptions directly.
+// KINETO_THROW centralizes those throws: it forwards the caller's exception
+// type and constructor arguments to a single raw throw. Routing every throw
+// through this macro keeps the one raw throw statement in this audited header,
+// which is why only this file carries the RAWTHROW linter's allow annotation;
+// call sites read as KINETO_THROW(...) and never contain a bare throw.
+//
+// ExceptionType is the exception to raise (e.g. std::invalid_argument); the
+// remaining arguments are forwarded to its constructor, so any existing message
+// expression -- a string literal, a std::string, a concatenation, or a
+// fmt::format(...) call -- carries over unchanged and the thrown type is
+// preserved. Callers keep whatever headers those arguments require.
+#define KINETO_THROW(ExceptionType, ...) \
+  throw ExceptionType(__VA_ARGS__) // @allow-raw-throw

--- a/libkineto/src/WeakSymbols.cpp
+++ b/libkineto/src/WeakSymbols.cpp
@@ -8,13 +8,16 @@
 
 #include <stdexcept>
 
+#include "ThrowUtil.h"
+
 #ifndef _MSC_VER
 extern "C" {
 // This function is needed to avoid superfluous dependency on GNU OpenMP library
 // when cuPTI is linked statically For more details see
 // https://github.com/pytorch/pytorch/issues/51026
 __attribute__((weak)) int acc_get_device_type() {
-  throw std::runtime_error(
+  KINETO_THROW(
+      std::runtime_error,
       "Dummy implementation of acc_get_device_type is not supposed to be called!");
 }
 

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -142,7 +142,7 @@ ChromeTraceBaseTime& ChromeTraceBaseTime::singleton() {
 // Use the program loading time as the baseline time.
 int64_t transToRelativeTime(int64_t time) {
   // Sometimes after converting to relative time, it can be a few nanoseconds
-  // negative. Since Chrome trace and json processing will throw a parser error,
+  // negative. Since Chrome trace and json processing will raise a parser error,
   // guard this.
   int64_t res = time - ChromeTraceBaseTime::singleton().get();
   if (res < 0) {

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "XpuptiActivityProfiler.h"
+#include "ThrowUtil.h"
 #include "XpuptiScopeProfilerApi.h"
 #include "XpuptiScopeProfilerSession.h"
 
@@ -57,7 +58,8 @@ std::string getXpuDeviceProperties() {
 
 [[noreturn]] const std::set<ActivityType>& XPUActivityProfiler::
     availableActivities() const {
-  throw std::runtime_error(
+  KINETO_THROW(
+      std::runtime_error,
       "The availableActivities is legacy method and should not be called by kineto");
 }
 

--- a/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "XpuptiProfilerMacros.h"
+#include "ThrowUtil.h"
 
 #include <stdexcept>
 #include <string_view>
@@ -35,11 +36,11 @@ namespace {
       error_code);
 
   if (message.empty())
-    throw std::runtime_error(error);
+    KINETO_THROW(std::runtime_error, error);
   else {
     const std::string error_with_message =
         fmt::format("{}. Message: {}", error, message);
-    throw std::runtime_error(error_with_message);
+    KINETO_THROW(std::runtime_error, error_with_message);
   }
 }
 } // namespace

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.cpp
@@ -13,6 +13,8 @@
 #include "XpuptiScopeProfilerApi.h"
 #include "XpuptiScopeProfilerConfig.h"
 
+#include "ThrowUtil.h"
+
 namespace KINETO_NAMESPACE {
 
 XpuptiScopeProfilerApi::safe_pti_scope_collection_handle_t::
@@ -35,7 +37,7 @@ void XpuptiScopeProfilerApi::enableScopeProfiler(const Config& cfg) {
   XPUPTI_CALL(ptiMetricsGetDevices(nullptr, &deviceCount));
 
   if (deviceCount == 0) {
-    throw std::runtime_error("No XPU devices available");
+    KINETO_THROW(std::runtime_error, "No XPU devices available");
   }
 
   auto devices = std::make_unique<pti_device_properties_t[]>(deviceCount);
@@ -62,7 +64,8 @@ void XpuptiScopeProfilerApi::enableScopeProfiler(const Config& cfg) {
       : PTI_METRICS_SCOPE_USER;
 
   if (collectionMode == PTI_METRICS_SCOPE_USER) {
-    throw std::runtime_error(
+    KINETO_THROW(
+        std::runtime_error,
         "XPUPTI_PROFILER_ENABLE_PER_KERNEL has to be set to 1. Other variants are currently not supported.");
   }
 

--- a/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
+++ b/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
@@ -23,6 +23,7 @@
 #include "src/GenericActivityProfiler.h"
 
 #include "src/Logger.h"
+#include "src/ThrowUtil.h"
 #include "test/TestUtils.h"
 
 using namespace std::chrono;
@@ -348,7 +349,7 @@ TEST(AsyncActivityProfilerHandler, MetadataJsonFormatingTest) {
   auto logFile = logUrlToPath(cfg.activitiesLogUrl());
   std::ifstream file(logFile);
   if (!file.is_open()) {
-    throw std::runtime_error("Failed to open the trace JSON file.");
+    KINETO_THROW(std::runtime_error, "Failed to open the trace JSON file.");
   }
   std::string jsonStr(
       (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());

--- a/libkineto/test/ConfigLoaderPollThreadExceptionTest.cpp
+++ b/libkineto/test/ConfigLoaderPollThreadExceptionTest.cpp
@@ -10,6 +10,7 @@
 
 #include "src/ConfigLoader.h"
 #include "src/DaemonConfigLoader.h"
+#include "src/ThrowUtil.h"
 
 #include <chrono>
 #include <condition_variable>
@@ -63,12 +64,12 @@ struct ThrowingDaemonConfigLoader final : IDaemonConfigLoader {
       : onDemandReached_(std::move(onDemandReached)) {}
 
   [[noreturn]] std::string readBaseConfig() override {
-    throw std::runtime_error("injected base-config failure");
+    KINETO_THROW(std::runtime_error, "injected base-config failure");
   }
 
   [[noreturn]] std::string readOnDemandConfig(bool /*activities*/) override {
     onDemandReached_->post();
-    throw std::runtime_error("injected on-demand failure");
+    KINETO_THROW(std::runtime_error, "injected on-demand failure");
   }
 
   void setCommunicationFabric(bool /*enabled*/) override {}
@@ -85,7 +86,7 @@ struct ThrowingDaemonConfigLoader final : IDaemonConfigLoader {
 // std::thread, where an escaped exception calls std::terminate() and aborts the
 // whole process -- the fleet SIGABRT this guard fixed. Assert generically that
 // an exception from the config work is swallowed and the loop keeps running,
-// without reproducing any specific throw site.
+// without reproducing any specific failure site.
 TEST(ConfigLoaderPollThreadExceptionTest, ConfigUpdateExceptionDoesNotCrash) {
   // Non-existent path so updateBaseConfig() falls through to the daemon loader.
   ::setenv("KINETO_CONFIG", "/tmp/nonexistent_libkineto_test.conf", 1);

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -112,7 +112,7 @@ TEST(ParseTest, ActivityTypes) {
       cfg2.selectedActivityTypes(),
       std::set<ActivityType>({ActivityType::CUDA_RUNTIME}));
 
-  // Should throw an exception because incorrect activity name
+  // parse() returns false for an unknown activity name
   EXPECT_FALSE(cfg2.parse("ACTIVITY_TYPES = memcopy,cuda_runtime"));
 
   EXPECT_TRUE(cfg2.parse("ACTIVITY_TYPES = cpu_op"));

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -34,6 +34,7 @@
 #include "src/output_membuf.h"
 
 #include "src/Logger.h"
+#include "src/ThrowUtil.h"
 #include "test/MockActivitySubProfiler.h"
 #include "test/MockCpuActivityBuffer.h"
 #include "test/TestUtils.h"
@@ -786,7 +787,7 @@ TEST_F(CuptiActivityProfilerTest, GpuNCCLCollectiveTest) {
   // Check that the saved JSON file can be loaded and deserialized
   std::ifstream file(tmpTrace.path());
   if (!file.is_open()) {
-    throw std::runtime_error("Failed to open the trace JSON file.");
+    KINETO_THROW(std::runtime_error, "Failed to open the trace JSON file.");
   }
   std::string jsonStr(
       (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
@@ -995,7 +996,7 @@ TEST_F(CuptiActivityProfilerTest, JsonGPUIDSortTest) {
   // Check that the saved JSON file can be loaded and deserialized
   std::ifstream file(tmpTrace.path());
   if (!file.is_open()) {
-    throw std::runtime_error("Failed to open the trace JSON file.");
+    KINETO_THROW(std::runtime_error, "Failed to open the trace JSON file.");
   }
   std::string jsonStr(
       (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -44,6 +44,7 @@
 #include "src/output_membuf.h"
 
 #include "src/Logger.h"
+#include "src/ThrowUtil.h"
 #include "test/MockActivitySubProfiler.h"
 #include "test/MockCpuActivityBuffer.h"
 #include "test/TestUtils.h"
@@ -733,7 +734,7 @@ TEST_F(RocmActivityProfilerTest, GpuNCCLCollectiveTest) {
   // Check that the saved JSON file can be loaded and deserialized
   std::ifstream file(tmpTrace.path());
   if (!file.is_open()) {
-    throw std::runtime_error("Failed to open the trace JSON file.");
+    KINETO_THROW(std::runtime_error, "Failed to open the trace JSON file.");
   }
   std::string jsonStr(
       (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
@@ -940,7 +941,7 @@ TEST_F(RocmActivityProfilerTest, JsonGPUIDSortTest) {
   // Check that the saved JSON file can be loaded and deserialized
   std::ifstream file(tmpTrace.path());
   if (!file.is_open()) {
-    throw std::runtime_error("Failed to open the trace JSON file.");
+    KINETO_THROW(std::runtime_error, "Failed to open the trace JSON file.");
   }
   std::string jsonStr(
       (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());

--- a/libkineto/test/TestUtils.cpp
+++ b/libkineto/test/TestUtils.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "test/TestUtils.h"
+#include "src/ThrowUtil.h"
 
 #include <gtest/gtest.h>
 
@@ -34,7 +35,7 @@ TempTraceFile::TempTraceFile(std::string_view prefix, std::string_view suffix) {
 
   const int fd = mkstemps(nameTemplate.data(), static_cast<int>(suffix.size()));
   if (fd < 0) {
-    throw std::runtime_error("mkstemps failed for " + nameTemplate);
+    KINETO_THROW(std::runtime_error, "mkstemps failed for " + nameTemplate);
   }
   close(fd);
   path_ = std::move(nameTemplate);

--- a/libkineto/test/xpupti/XpuptiScopeProfilerTest.cpp
+++ b/libkineto/test/xpupti/XpuptiScopeProfilerTest.cpp
@@ -103,16 +103,10 @@ void RunTest(std::string_view perKernel, unsigned maxScopes) {
 
   if (expectThrow) {
     EXPECT_THROW(
-        try {
+        {
           if (eptr) {
             std::rethrow_exception(eptr);
           }
-        } catch (const std::runtime_error& e) {
-          static bool isVerbose = IsEnvVerbose();
-          if (isVerbose) {
-            std::cout << "std::runtime_error = " << e.what() << std::endl;
-          }
-          throw;
         },
         std::runtime_error);
   } else {

--- a/tools/linter/adapters/cmake_linter.py
+++ b/tools/linter/adapters/cmake_linter.py
@@ -1,0 +1,146 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "cmakelint==1.4.1",
+# ]
+# ///
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import logging
+import os
+import re
+import subprocess
+import time
+from enum import Enum
+from typing import NamedTuple
+
+
+LINTER_CODE = "CMAKE"
+
+
+class LintSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    ADVICE = "advice"
+    DISABLED = "disabled"
+
+
+class LintMessage(NamedTuple):
+    path: str | None
+    line: int | None
+    char: int | None
+    code: str
+    severity: LintSeverity
+    name: str
+    original: str | None
+    replacement: str | None
+    description: str | None
+
+
+# CMakeLists.txt:901: Lines should be <= 80 characters long [linelength]
+RESULTS_RE: re.Pattern[str] = re.compile(
+    r"""(?mx)
+    ^
+    (?P<file>.*?):
+    (?P<line>\d+):
+    \s(?P<message>.*)
+    \s(?P<code>\[.*\])
+    $
+    """
+)
+
+
+def run_command(
+    args: list[str],
+) -> subprocess.CompletedProcess[bytes]:
+    logging.debug("$ %s", " ".join(args))
+    start_time = time.monotonic()
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+        )
+    finally:
+        end_time = time.monotonic()
+        logging.debug("took %dms", (end_time - start_time) * 1000)
+
+
+def check_file(
+    filename: str,
+    config: str,
+) -> list[LintMessage]:
+    try:
+        proc = run_command(
+            ["cmakelint", f"--config={config}", filename],
+        )
+    except OSError as err:
+        return [
+            LintMessage(
+                path=None,
+                line=None,
+                char=None,
+                code=LINTER_CODE,
+                severity=LintSeverity.ERROR,
+                name="command-failed",
+                original=None,
+                replacement=None,
+                description=(f"Failed due to {err.__class__.__name__}:\n{err}"),
+            )
+        ]
+    stdout = str(proc.stdout, "utf-8").strip()
+    return [
+        LintMessage(
+            path=match["file"],
+            name=match["code"],
+            description=match["message"],
+            line=int(match["line"]),
+            char=None,
+            code=LINTER_CODE,
+            severity=LintSeverity.ERROR,
+            original=None,
+            replacement=None,
+        )
+        for match in RESULTS_RE.finditer(stdout)
+    ]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="cmakelint runner",
+        fromfile_prefix_chars="@",
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="location of cmakelint config",
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="+",
+        help="paths to lint",
+    )
+
+    args = parser.parse_args()
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=os.cpu_count(),
+        thread_name_prefix="Thread",
+    ) as executor:
+        futures = {
+            executor.submit(
+                check_file,
+                filename,
+                args.config,
+            ): filename
+            for filename in args.filenames
+        }
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                for lint_message in future.result():
+                    print(json.dumps(lint_message._asdict()), flush=True)
+            except Exception:
+                logging.critical('Failed at "%s".', futures[future])
+                raise


### PR DESCRIPTION
Prep work for upstreaming Kineto into PyTorch; see https://github.com/pytorch/kineto/issues/1478. https://github.com/pytorch/pytorch/pull/191800 revealed that Kineto is not actually linted exactly the same as PyTorch. The formatting is, but we were not applying the policy linters. The one that matters the most is the one that forbids raw `throw` statements in C++. This PR:

1. Adds the relevant policy linters from PyTorch. (Not all of them; some don't make sense for an all C++ repo.)
2. Unifies all throwing into a Kineto util. After upstreaming, we'll replace it with c10's `TORCH_CHECK` or `C10_THROW_ERROR` as appropriate.