### PR TITLE
[Kineto] Used typed metadata in Kineto's XPU plugin

### DIFF
--- a/libkineto/include/MetadataFieldCatalog.h
+++ b/libkineto/include/MetadataFieldCatalog.h
@@ -76,18 +76,6 @@ namespace libkineto::DevicePropertyMetadataFields {
 inline constexpr MetadataField<uint64_t> kId{"id"};
 inline constexpr MetadataField<std::string> kName{"name"};
 inline constexpr MetadataField<uint64_t> kTotalGlobalMem{"totalGlobalMem"};
-
-// XPU-only device properties.
-inline constexpr MetadataField<uint64_t> kMaxComputeUnits{"maxComputeUnits"};
-inline constexpr MetadataField<uint64_t> kMaxWorkGroupSize{
-    "maxWorkGroupSize"};
-inline constexpr MetadataField<uint64_t> kMaxClockFrequency{
-    "maxClockFrequency"};
-inline constexpr MetadataField<uint64_t> kMaxMemAllocSize{"maxMemAllocSize"};
-inline constexpr MetadataField<uint64_t> kLocalMemSize{"localMemSize"};
-inline constexpr MetadataField<std::string> kVendor{"vendor"};
-inline constexpr MetadataField<std::string> kDriverVersion{"driverVersion"};
-
 inline constexpr MetadataField<int64_t> kComputeMajor{"computeMajor"};
 inline constexpr MetadataField<int64_t> kComputeMinor{"computeMinor"};
 inline constexpr MetadataField<int64_t> kMaxThreadsPerBlock{
@@ -107,6 +95,17 @@ inline constexpr MetadataField<uint64_t> kSharedMemPerMultiprocessor{
     "sharedMemPerMultiprocessor"};
 inline constexpr MetadataField<uint64_t> kMaxSharedMemoryPerMultiProcessor{
     "maxSharedMemoryPerMultiProcessor"};
+
+// XPU-only device properties.
+inline constexpr MetadataField<uint64_t> kMaxComputeUnits{"maxComputeUnits"};
+inline constexpr MetadataField<uint64_t> kMaxWorkGroupSize{
+    "maxWorkGroupSize"};
+inline constexpr MetadataField<uint64_t> kMaxClockFrequency{
+    "maxClockFrequency"};
+inline constexpr MetadataField<uint64_t> kMaxMemAllocSize{"maxMemAllocSize"};
+inline constexpr MetadataField<uint64_t> kLocalMemSize{"localMemSize"};
+inline constexpr MetadataField<std::string> kVendor{"vendor"};
+inline constexpr MetadataField<std::string> kDriverVersion{"driverVersion"};
 } // namespace libkineto::DevicePropertyMetadataFields
 
 namespace libkineto::CudaMetadataFields {

--- a/libkineto/include/MetadataFieldCatalog.h
+++ b/libkineto/include/MetadataFieldCatalog.h
@@ -76,6 +76,15 @@ namespace libkineto::DevicePropertyMetadataFields {
 inline constexpr MetadataField<uint64_t> kId{"id"};
 inline constexpr MetadataField<std::string> kName{"name"};
 inline constexpr MetadataField<uint64_t> kTotalGlobalMem{"totalGlobalMem"};
+inline constexpr MetadataField<uint64_t> kMaxComputeUnits{"maxComputeUnits"};
+inline constexpr MetadataField<uint64_t> kMaxWorkGroupSize{
+    "maxWorkGroupSize"};
+inline constexpr MetadataField<uint64_t> kMaxClockFrequency{
+    "maxClockFrequency"};
+inline constexpr MetadataField<uint64_t> kMaxMemAllocSize{"maxMemAllocSize"};
+inline constexpr MetadataField<uint64_t> kLocalMemSize{"localMemSize"};
+inline constexpr MetadataField<std::string> kVendor{"vendor"};
+inline constexpr MetadataField<std::string> kDriverVersion{"driverVersion"};
 inline constexpr MetadataField<int64_t> kComputeMajor{"computeMajor"};
 inline constexpr MetadataField<int64_t> kComputeMinor{"computeMinor"};
 inline constexpr MetadataField<int64_t> kMaxThreadsPerBlock{
@@ -169,3 +178,47 @@ inline constexpr MetadataField<uint64_t> kSharedMemory{"shared memory"};
 inline constexpr MetadataField<std::string> kSrc{"src"};
 inline constexpr MetadataField<int64_t> kStream{"stream"};
 } // namespace libkineto::RocmMetadataFields
+
+namespace libkineto::XpuMetadataFields {
+inline constexpr MetadataField<std::string> kAppended{"appended"};
+inline constexpr MetadataField<std::string> kAppendedRelToStart{
+    "appended_rel_to_start"};
+inline constexpr MetadataField<uint64_t> kBytes{"bytes"};
+inline constexpr MetadataField<uint64_t> kCommunicatorId{"Communicator_id"};
+inline constexpr MetadataField<std::string> kContext{"context"};
+inline constexpr MetadataField<std::string> kContextHandle{"Context_handle"};
+inline constexpr MetadataField<uint64_t> kCorrelation{"correlation"};
+inline constexpr MetadataField<int64_t> kDevice{"device"};
+inline constexpr MetadataField<std::string> kEventHandle{"Event_handle"};
+inline constexpr MetadataField<uint64_t> kKernelId{"kernel_id"};
+inline constexpr MetadataField<std::string> kL0Call{"l0 call"};
+inline constexpr MetadataField<std::string> kL0Queue{"l0 queue"};
+inline constexpr MetadataField<double> kMemoryBandwidthGbps{
+    "memory bandwidth (GB/s)"};
+inline constexpr MetadataField<uint64_t> kMemoryOperationId{
+    "memory opration id"};
+inline constexpr MetadataField<uint64_t> kNumberWaitEvents{
+    "Number_wait_events"};
+inline constexpr MetadataField<uint64_t> kOverheadCost{"overhead cost"};
+inline constexpr MetadataField<uint64_t> kOverheadCount{"overhead count"};
+inline constexpr MetadataField<std::string> kOverheadOccupancy{
+    "overhead occupancy"};
+inline constexpr MetadataField<std::string> kQueue{"queue"};
+inline constexpr MetadataField<std::string> kQueueHandle{"Queue_handle"};
+inline constexpr MetadataField<int64_t> kReturnCode{"Return_code"};
+inline constexpr MetadataField<std::string> kSourceFileName{"source_file_name"};
+inline constexpr MetadataField<uint64_t> kSourceLineNumber{"source_line_number"};
+inline constexpr MetadataField<std::string> kSubmitted{"submitted"};
+inline constexpr MetadataField<std::string> kSubmittedRelToStart{
+    "submitted_rel_to_start"};
+inline constexpr MetadataField<std::string> kSyclEnqkBegin{"sycl_enqk_begin"};
+inline constexpr MetadataField<std::string> kSyclEnqkBeginRelToStart{
+    "sycl_enqk_begin_rel_to_start"};
+inline constexpr MetadataField<uint64_t> kSyclInvocationId{"sycl_invocation_id"};
+inline constexpr MetadataField<uint64_t> kSyclNodeId{"sycl_node_id"};
+inline constexpr MetadataField<uint64_t> kSyclQueue{"sycl queue"};
+inline constexpr MetadataField<std::string> kSyclTaskBegin{"sycl_task_begin"};
+inline constexpr MetadataField<std::string> kSyclTaskBeginRelToStart{
+    "sycl_task_begin_rel_to_start"};
+inline constexpr MetadataField<std::string> kType{"Type"};
+} // namespace libkineto::XpuMetadataFields

--- a/libkineto/include/MetadataFieldCatalog.h
+++ b/libkineto/include/MetadataFieldCatalog.h
@@ -76,6 +76,8 @@ namespace libkineto::DevicePropertyMetadataFields {
 inline constexpr MetadataField<uint64_t> kId{"id"};
 inline constexpr MetadataField<std::string> kName{"name"};
 inline constexpr MetadataField<uint64_t> kTotalGlobalMem{"totalGlobalMem"};
+
+// XPU-only device properties.
 inline constexpr MetadataField<uint64_t> kMaxComputeUnits{"maxComputeUnits"};
 inline constexpr MetadataField<uint64_t> kMaxWorkGroupSize{
     "maxWorkGroupSize"};
@@ -85,6 +87,7 @@ inline constexpr MetadataField<uint64_t> kMaxMemAllocSize{"maxMemAllocSize"};
 inline constexpr MetadataField<uint64_t> kLocalMemSize{"localMemSize"};
 inline constexpr MetadataField<std::string> kVendor{"vendor"};
 inline constexpr MetadataField<std::string> kDriverVersion{"driverVersion"};
+
 inline constexpr MetadataField<int64_t> kComputeMajor{"computeMajor"};
 inline constexpr MetadataField<int64_t> kComputeMinor{"computeMinor"};
 inline constexpr MetadataField<int64_t> kMaxThreadsPerBlock{
@@ -180,19 +183,11 @@ inline constexpr MetadataField<int64_t> kStream{"stream"};
 } // namespace libkineto::RocmMetadataFields
 
 namespace libkineto::XpuMetadataFields {
-inline constexpr MetadataField<std::string> kAppended{"appended"};
-inline constexpr MetadataField<std::string> kAppendedRelToStart{
-    "appended_rel_to_start"};
 inline constexpr MetadataField<uint64_t> kBytes{"bytes"};
 inline constexpr MetadataField<uint64_t> kCommunicatorId{"Communicator_id"};
-inline constexpr MetadataField<std::string> kContext{"context"};
-inline constexpr MetadataField<std::string> kContextHandle{"Context_handle"};
 inline constexpr MetadataField<uint64_t> kCorrelation{"correlation"};
 inline constexpr MetadataField<int64_t> kDevice{"device"};
-inline constexpr MetadataField<std::string> kEventHandle{"Event_handle"};
 inline constexpr MetadataField<uint64_t> kKernelId{"kernel_id"};
-inline constexpr MetadataField<std::string> kL0Call{"l0 call"};
-inline constexpr MetadataField<std::string> kL0Queue{"l0 queue"};
 inline constexpr MetadataField<double> kMemoryBandwidthGbps{
     "memory bandwidth (GB/s)"};
 inline constexpr MetadataField<uint64_t> kMemoryOperationId{
@@ -201,24 +196,9 @@ inline constexpr MetadataField<uint64_t> kNumberWaitEvents{
     "Number_wait_events"};
 inline constexpr MetadataField<uint64_t> kOverheadCost{"overhead cost"};
 inline constexpr MetadataField<uint64_t> kOverheadCount{"overhead count"};
-inline constexpr MetadataField<std::string> kOverheadOccupancy{
-    "overhead occupancy"};
-inline constexpr MetadataField<std::string> kQueue{"queue"};
-inline constexpr MetadataField<std::string> kQueueHandle{"Queue_handle"};
 inline constexpr MetadataField<int64_t> kReturnCode{"Return_code"};
-inline constexpr MetadataField<std::string> kSourceFileName{"source_file_name"};
 inline constexpr MetadataField<uint64_t> kSourceLineNumber{"source_line_number"};
-inline constexpr MetadataField<std::string> kSubmitted{"submitted"};
-inline constexpr MetadataField<std::string> kSubmittedRelToStart{
-    "submitted_rel_to_start"};
-inline constexpr MetadataField<std::string> kSyclEnqkBegin{"sycl_enqk_begin"};
-inline constexpr MetadataField<std::string> kSyclEnqkBeginRelToStart{
-    "sycl_enqk_begin_rel_to_start"};
 inline constexpr MetadataField<uint64_t> kSyclInvocationId{"sycl_invocation_id"};
 inline constexpr MetadataField<uint64_t> kSyclNodeId{"sycl_node_id"};
 inline constexpr MetadataField<uint64_t> kSyclQueue{"sycl queue"};
-inline constexpr MetadataField<std::string> kSyclTaskBegin{"sycl_task_begin"};
-inline constexpr MetadataField<std::string> kSyclTaskBeginRelToStart{
-    "sycl_task_begin_rel_to_start"};
-inline constexpr MetadataField<std::string> kType{"Type"};
 } // namespace libkineto::XpuMetadataFields

--- a/libkineto/include/MetadataFieldCatalog.h
+++ b/libkineto/include/MetadataFieldCatalog.h
@@ -98,8 +98,7 @@ inline constexpr MetadataField<uint64_t> kMaxSharedMemoryPerMultiProcessor{
 
 // XPU-only device properties.
 inline constexpr MetadataField<uint64_t> kMaxComputeUnits{"maxComputeUnits"};
-inline constexpr MetadataField<uint64_t> kMaxWorkGroupSize{
-    "maxWorkGroupSize"};
+inline constexpr MetadataField<uint64_t> kMaxWorkGroupSize{"maxWorkGroupSize"};
 inline constexpr MetadataField<uint64_t> kMaxClockFrequency{
     "maxClockFrequency"};
 inline constexpr MetadataField<uint64_t> kMaxMemAllocSize{"maxMemAllocSize"};
@@ -196,8 +195,10 @@ inline constexpr MetadataField<uint64_t> kNumberWaitEvents{
 inline constexpr MetadataField<uint64_t> kOverheadCost{"overhead cost"};
 inline constexpr MetadataField<uint64_t> kOverheadCount{"overhead count"};
 inline constexpr MetadataField<int64_t> kReturnCode{"Return_code"};
-inline constexpr MetadataField<uint64_t> kSourceLineNumber{"source_line_number"};
-inline constexpr MetadataField<uint64_t> kSyclInvocationId{"sycl_invocation_id"};
+inline constexpr MetadataField<uint64_t> kSourceLineNumber{
+    "source_line_number"};
+inline constexpr MetadataField<uint64_t> kSyclInvocationId{
+    "sycl_invocation_id"};
 inline constexpr MetadataField<uint64_t> kSyclNodeId{"sycl_node_id"};
 inline constexpr MetadataField<uint64_t> kSyclQueue{"sycl queue"};
 } // namespace libkineto::XpuMetadataFields

--- a/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "MetadataFieldCatalog.h"
 #include "XpuptiActivityProfilerSession.h"
 #include "output_json.h"
 
@@ -17,6 +18,8 @@
 #include <fmt/ranges.h>
 
 namespace KINETO_NAMESPACE {
+
+namespace XpuFields = libkineto::XpuMetadataFields;
 
 // =========== Session Private Methods ============= //
 void XpuptiActivityProfilerSession::removeCorrelatedPtiActivities(
@@ -112,10 +115,16 @@ inline std::string memsetName(pti_view_memory_type type, uint64_t val) {
 }
 
 template <class pti_view_memory_record_type>
-inline std::string bandwidth(pti_view_memory_record_type* activity) {
-  auto duration = activity->_end_timestamp - activity->_start_timestamp;
-  auto bytes = activity->_bytes;
-  return duration == 0 ? "\"N/A\"" : fmt::format("{}", bytes * 1.0 / duration);
+inline void addBandwidthMetadata(
+    GenericTraceActivity& traceActivity,
+    const pti_view_memory_record_type& activity) {
+  const auto duration = activity._end_timestamp - activity._start_timestamp;
+  if (duration == 0) {
+    return;
+  }
+  traceActivity.addMetadata(
+      XpuFields::kMemoryBandwidthGbps,
+      static_cast<double>(activity._bytes) / static_cast<double>(duration));
 }
 
 void XpuptiActivityProfilerSession::addResouceInfo(
@@ -145,15 +154,16 @@ inline int64_t signedFromUnsignedDiff(uint64_t time, uint64_t time_ref) {
 }
 
 static void addTimestampMetadata(
-    GenericTraceActivity* trace_activity,
-    std::string&& label,
+    GenericTraceActivity& traceActivity,
+    const MetadataField<std::string>& timestampField,
+    const MetadataField<std::string>& relativeTimestampField,
     uint64_t time,
     uint64_t time_ref) {
-  trace_activity->addMetadataQuoted(
-      label, formatTimeLikeOutputJson(transToRelativeTime(time)));
-  label += "_rel_to_start";
-  trace_activity->addMetadataQuoted(
-      label, formatTimeLikeOutputJson(signedFromUnsignedDiff(time, time_ref)));
+  traceActivity.addMetadata(
+      timestampField, formatTimeLikeOutputJson(transToRelativeTime(time)));
+  traceActivity.addMetadata(
+      relativeTimestampField,
+      formatTimeLikeOutputJson(signedFromUnsignedDiff(time, time_ref)));
 }
 
 template <class pti_view_memory_record_type>
@@ -203,7 +213,9 @@ void XpuptiActivityProfilerSession::handleRuntimeKernelMemcpyMemsetActivities(
   trace_activity->id = activity->_correlation_id;
   trace_activity->linked =
       linkedActivity(activity->_correlation_id, cpuCorrelationMap_);
-  trace_activity->addMetadata("correlation", activity->_correlation_id);
+  trace_activity->addMetadata(
+      XpuFields::kCorrelation,
+      static_cast<uint64_t>(activity->_correlation_id));
 
   if constexpr (handleRuntimeActivities) {
     trace_activity->device = activity->_process_id;
@@ -226,55 +238,68 @@ void XpuptiActivityProfilerSession::handleRuntimeKernelMemcpyMemsetActivities(
   }
 
   if constexpr (handleMemcpyActivities || handleMemsetActivities) {
-    trace_activity->addMetadataQuoted("l0 call", std::string(activity->_name));
+    trace_activity->addMetadata(
+        XpuFields::kL0Call, std::string(activity->_name));
   }
 
   if constexpr (!handleRuntimeActivities) {
     addTimestampMetadata(
-        trace_activity.get(),
-        "appended",
+        *trace_activity,
+        XpuFields::kAppended,
+        XpuFields::kAppendedRelToStart,
         activity->_append_timestamp,
         activity->_start_timestamp);
     addTimestampMetadata(
-        trace_activity.get(),
-        "submitted",
+        *trace_activity,
+        XpuFields::kSubmitted,
+        XpuFields::kSubmittedRelToStart,
         activity->_submit_timestamp,
         activity->_start_timestamp);
     if constexpr (handleKernelActivities) {
       addTimestampMetadata(
-          trace_activity.get(),
-          "sycl_task_begin",
+          *trace_activity,
+          XpuFields::kSyclTaskBegin,
+          XpuFields::kSyclTaskBeginRelToStart,
           activity->_sycl_task_begin_timestamp,
           activity->_start_timestamp);
       addTimestampMetadata(
-          trace_activity.get(),
-          "sycl_enqk_begin",
+          *trace_activity,
+          XpuFields::kSyclEnqkBegin,
+          XpuFields::kSyclEnqkBeginRelToStart,
           activity->_sycl_enqk_begin_timestamp,
           activity->_start_timestamp);
     }
-    trace_activity->addMetadata("device", trace_activity->deviceId());
-    trace_activity->addMetadataQuoted(
-        "context", handleToHexString(activity->_context_handle));
-    trace_activity->addMetadata("sycl queue", activity->_sycl_queue_id);
-    trace_activity->addMetadataQuoted(
-        "l0 queue", handleToHexString(activity->_queue_handle));
+    trace_activity->addMetadata(XpuFields::kDevice, trace_activity->deviceId());
+    trace_activity->addMetadata(
+        XpuFields::kContext, handleToHexString(activity->_context_handle));
+    trace_activity->addMetadata(
+        XpuFields::kSyclQueue, static_cast<uint64_t>(activity->_sycl_queue_id));
+    trace_activity->addMetadata(
+        XpuFields::kL0Queue, handleToHexString(activity->_queue_handle));
   }
 
   if constexpr (handleKernelActivities) {
     if (activity->_source_file_name) {
-      trace_activity->addMetadataQuoted(
-          "source_file_name", activity->_source_file_name);
       trace_activity->addMetadata(
-          "source_line_number", activity->_source_line_number);
+          XpuFields::kSourceFileName, std::string{activity->_source_file_name});
+      trace_activity->addMetadata(
+          XpuFields::kSourceLineNumber,
+          static_cast<uint64_t>(activity->_source_line_number));
     }
-    trace_activity->addMetadata("kernel_id", activity->_kernel_id);
-    trace_activity->addMetadata("sycl_node_id", activity->_sycl_node_id);
     trace_activity->addMetadata(
-        "sycl_invocation_id", activity->_sycl_invocation_id);
+        XpuFields::kKernelId, static_cast<uint64_t>(activity->_kernel_id));
+    trace_activity->addMetadata(
+        XpuFields::kSyclNodeId, static_cast<uint64_t>(activity->_sycl_node_id));
+    trace_activity->addMetadata(
+        XpuFields::kSyclInvocationId,
+        static_cast<uint64_t>(activity->_sycl_invocation_id));
   } else if constexpr (handleMemcpyActivities || handleMemsetActivities) {
-    trace_activity->addMetadata("memory opration id", activity->_mem_op_id);
-    trace_activity->addMetadata("bytes", activity->_bytes);
-    trace_activity->addMetadata("memory bandwidth (GB/s)", bandwidth(activity));
+    trace_activity->addMetadata(
+        XpuFields::kMemoryOperationId,
+        static_cast<uint64_t>(activity->_mem_op_id));
+    trace_activity->addMetadata(
+        XpuFields::kBytes, static_cast<uint64_t>(activity->_bytes));
+    addBandwidthMetadata(*trace_activity, *activity);
   }
 
   checkTimestampOrder(trace_activity.get());
@@ -350,7 +375,8 @@ void XpuptiActivityProfilerSession::handleCommunicationActivity(
   comms_activity.threadId = activity_record._thread_id;
 
   comms_activity.addMetadata(
-      "Communicator_id", activity_record._communicator_id);
+      XpuFields::kCommunicatorId,
+      static_cast<uint64_t>(activity_record._communicator_id));
 
   if (outOfRange(&comms_activity)) {
     traceBuffer_.span.opCount -= 1;
@@ -443,20 +469,27 @@ void XpuptiActivityProfilerSession::handleSynchronizationActivity(
   synchronization_activity.linked =
       linkedActivity(activity->_correlation_id, cpuCorrelationMap_);
   synchronization_activity.addMetadata(
-      "correlation", activity_record._correlation_id);
+      XpuFields::kCorrelation,
+      static_cast<uint64_t>(activity_record._correlation_id));
 
-  synchronization_activity.addMetadataQuoted(
-      "Type", getStringFromSynchronizationType(activity_record._synch_type));
-  synchronization_activity.addMetadataQuoted(
-      "Context_handle", handleToHexString(activity_record._context_handle));
-  synchronization_activity.addMetadataQuoted(
-      "Queue_handle", handleToHexString(activity_record._queue_handle));
-  synchronization_activity.addMetadataQuoted(
-      "Event_handle", handleToHexString(activity_record._event_handle));
   synchronization_activity.addMetadata(
-      "Number_wait_events", activity_record._number_wait_events);
+      XpuFields::kType,
+      getStringFromSynchronizationType(activity_record._synch_type));
   synchronization_activity.addMetadata(
-      "Return_code", activity_record._return_code);
+      XpuFields::kContextHandle,
+      handleToHexString(activity_record._context_handle));
+  synchronization_activity.addMetadata(
+      XpuFields::kQueueHandle,
+      handleToHexString(activity_record._queue_handle));
+  synchronization_activity.addMetadata(
+      XpuFields::kEventHandle,
+      handleToHexString(activity_record._event_handle));
+  synchronization_activity.addMetadata(
+      XpuFields::kNumberWaitEvents,
+      static_cast<uint64_t>(activity_record._number_wait_events));
+  synchronization_activity.addMetadata(
+      XpuFields::kReturnCode,
+      static_cast<int64_t>(activity_record._return_code));
 
   if (outOfRange(&synchronization_activity)) {
     traceBuffer_.span.opCount -= 1;
@@ -485,7 +518,8 @@ void XpuptiActivityProfilerSession::handleOverheadActivity(
   overhead_activity->resource = activity->_overhead_thread_id;
   overhead_activity->threadId = activity->_overhead_thread_id;
   overhead_activity->addMetadata(
-      "overhead cost", activity->_overhead_duration_ns);
+      XpuFields::kOverheadCost,
+      static_cast<uint64_t>(activity->_overhead_duration_ns));
   // Occupancy is the share of the observation window [start, end] that was
   // actually spent in overhead: _overhead_duration_ns is cumulative and may be
   // smaller than the window. Guard on the divisor (duration()) directly so the
@@ -495,9 +529,11 @@ void XpuptiActivityProfilerSession::handleOverheadActivity(
   const auto occupancy = overhead_activity->duration() > 0
       ? activity->_overhead_duration_ns * 100 / overhead_activity->duration()
       : 0;
-  overhead_activity->addMetadataQuoted(
-      "overhead occupancy", fmt::format("{}%", occupancy));
-  overhead_activity->addMetadata("overhead count", activity->_overhead_count);
+  overhead_activity->addMetadata(
+      XpuFields::kOverheadOccupancy, fmt::format("{}%", occupancy));
+  overhead_activity->addMetadata(
+      XpuFields::kOverheadCount,
+      static_cast<uint64_t>(activity->_overhead_count));
 
   if (!outOfRange(overhead_activity.get())) {
     overhead_activity->log(logger);

--- a/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
@@ -115,16 +115,10 @@ inline std::string memsetName(pti_view_memory_type type, uint64_t val) {
 }
 
 template <class pti_view_memory_record_type>
-inline void addBandwidthMetadata(
-    GenericTraceActivity& traceActivity,
-    const pti_view_memory_record_type& activity) {
-  const auto duration = activity._end_timestamp - activity._start_timestamp;
-  if (duration == 0) {
-    return;
-  }
-  traceActivity.addMetadata(
-      XpuFields::kMemoryBandwidthGbps,
-      static_cast<double>(activity._bytes) / static_cast<double>(duration));
+inline double bandwidth(pti_view_memory_record_type* activity) {
+  auto duration = activity->_end_timestamp - activity->_start_timestamp;
+  auto bytes = activity->_bytes;
+  return bytes * 1.0 / duration;
 }
 
 void XpuptiActivityProfilerSession::addResouceInfo(
@@ -154,16 +148,15 @@ inline int64_t signedFromUnsignedDiff(uint64_t time, uint64_t time_ref) {
 }
 
 static void addTimestampMetadata(
-    GenericTraceActivity& traceActivity,
-    const MetadataField<std::string>& timestampField,
-    const MetadataField<std::string>& relativeTimestampField,
+    GenericTraceActivity* trace_activity,
+    std::string&& label,
     uint64_t time,
     uint64_t time_ref) {
-  traceActivity.addMetadata(
-      timestampField, formatTimeLikeOutputJson(transToRelativeTime(time)));
-  traceActivity.addMetadata(
-      relativeTimestampField,
-      formatTimeLikeOutputJson(signedFromUnsignedDiff(time, time_ref)));
+  trace_activity->addMetadataQuoted(
+      label, formatTimeLikeOutputJson(transToRelativeTime(time)));
+  label += "_rel_to_start";
+  trace_activity->addMetadataQuoted(
+      label, formatTimeLikeOutputJson(signedFromUnsignedDiff(time, time_ref)));
 }
 
 template <class pti_view_memory_record_type>
@@ -238,50 +231,45 @@ void XpuptiActivityProfilerSession::handleRuntimeKernelMemcpyMemsetActivities(
   }
 
   if constexpr (handleMemcpyActivities || handleMemsetActivities) {
-    trace_activity->addMetadata(
-        XpuFields::kL0Call, std::string(activity->_name));
+    trace_activity->addMetadataQuoted("l0 call", std::string(activity->_name));
   }
 
   if constexpr (!handleRuntimeActivities) {
     addTimestampMetadata(
-        *trace_activity,
-        XpuFields::kAppended,
-        XpuFields::kAppendedRelToStart,
+        trace_activity.get(),
+        "appended",
         activity->_append_timestamp,
         activity->_start_timestamp);
     addTimestampMetadata(
-        *trace_activity,
-        XpuFields::kSubmitted,
-        XpuFields::kSubmittedRelToStart,
+        trace_activity.get(),
+        "submitted",
         activity->_submit_timestamp,
         activity->_start_timestamp);
     if constexpr (handleKernelActivities) {
       addTimestampMetadata(
-          *trace_activity,
-          XpuFields::kSyclTaskBegin,
-          XpuFields::kSyclTaskBeginRelToStart,
+          trace_activity.get(),
+          "sycl_task_begin",
           activity->_sycl_task_begin_timestamp,
           activity->_start_timestamp);
       addTimestampMetadata(
-          *trace_activity,
-          XpuFields::kSyclEnqkBegin,
-          XpuFields::kSyclEnqkBeginRelToStart,
+          trace_activity.get(),
+          "sycl_enqk_begin",
           activity->_sycl_enqk_begin_timestamp,
           activity->_start_timestamp);
     }
     trace_activity->addMetadata(XpuFields::kDevice, trace_activity->deviceId());
-    trace_activity->addMetadata(
-        XpuFields::kContext, handleToHexString(activity->_context_handle));
+    trace_activity->addMetadataQuoted(
+        "context", handleToHexString(activity->_context_handle));
     trace_activity->addMetadata(
         XpuFields::kSyclQueue, static_cast<uint64_t>(activity->_sycl_queue_id));
-    trace_activity->addMetadata(
-        XpuFields::kL0Queue, handleToHexString(activity->_queue_handle));
+    trace_activity->addMetadataQuoted(
+        "l0 queue", handleToHexString(activity->_queue_handle));
   }
 
   if constexpr (handleKernelActivities) {
     if (activity->_source_file_name) {
-      trace_activity->addMetadata(
-          XpuFields::kSourceFileName, std::string{activity->_source_file_name});
+      trace_activity->addMetadataQuoted(
+          "source_file_name", activity->_source_file_name);
       trace_activity->addMetadata(
           XpuFields::kSourceLineNumber,
           static_cast<uint64_t>(activity->_source_line_number));
@@ -299,7 +287,11 @@ void XpuptiActivityProfilerSession::handleRuntimeKernelMemcpyMemsetActivities(
         static_cast<uint64_t>(activity->_mem_op_id));
     trace_activity->addMetadata(
         XpuFields::kBytes, static_cast<uint64_t>(activity->_bytes));
-    addBandwidthMetadata(*trace_activity, *activity);
+    const auto duration = activity->_end_timestamp - activity->_start_timestamp;
+    if (duration != 0) {
+      trace_activity->addMetadata(
+          XpuFields::kMemoryBandwidthGbps, bandwidth(activity));
+    }
   }
 
   checkTimestampOrder(trace_activity.get());
@@ -472,18 +464,14 @@ void XpuptiActivityProfilerSession::handleSynchronizationActivity(
       XpuFields::kCorrelation,
       static_cast<uint64_t>(activity_record._correlation_id));
 
-  synchronization_activity.addMetadata(
-      XpuFields::kType,
-      getStringFromSynchronizationType(activity_record._synch_type));
-  synchronization_activity.addMetadata(
-      XpuFields::kContextHandle,
-      handleToHexString(activity_record._context_handle));
-  synchronization_activity.addMetadata(
-      XpuFields::kQueueHandle,
-      handleToHexString(activity_record._queue_handle));
-  synchronization_activity.addMetadata(
-      XpuFields::kEventHandle,
-      handleToHexString(activity_record._event_handle));
+  synchronization_activity.addMetadataQuoted(
+      "Type", getStringFromSynchronizationType(activity_record._synch_type));
+  synchronization_activity.addMetadataQuoted(
+      "Context_handle", handleToHexString(activity_record._context_handle));
+  synchronization_activity.addMetadataQuoted(
+      "Queue_handle", handleToHexString(activity_record._queue_handle));
+  synchronization_activity.addMetadataQuoted(
+      "Event_handle", handleToHexString(activity_record._event_handle));
   synchronization_activity.addMetadata(
       XpuFields::kNumberWaitEvents,
       static_cast<uint64_t>(activity_record._number_wait_events));
@@ -529,8 +517,8 @@ void XpuptiActivityProfilerSession::handleOverheadActivity(
   const auto occupancy = overhead_activity->duration() > 0
       ? activity->_overhead_duration_ns * 100 / overhead_activity->duration()
       : 0;
-  overhead_activity->addMetadata(
-      XpuFields::kOverheadOccupancy, fmt::format("{}%", occupancy));
+  overhead_activity->addMetadataQuoted(
+      "overhead occupancy", fmt::format("{}%", occupancy));
   overhead_activity->addMetadata(
       XpuFields::kOverheadCount,
       static_cast<uint64_t>(activity->_overhead_count));

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.cpp
@@ -7,14 +7,62 @@
  */
 
 #include "XpuptiActivityProfiler.h"
+#include "MetadataFieldCatalog.h"
 #include "ThrowUtil.h"
+#include "TypedMetadataJson.h"
 #include "XpuptiScopeProfilerApi.h"
 #include "XpuptiScopeProfilerSession.h"
 
 #include <fmt/ranges.h>
 #include <sycl/sycl.hpp>
+#include <utility>
 
 namespace KINETO_NAMESPACE {
+
+namespace DevicePropertyFields = libkineto::DevicePropertyMetadataFields;
+
+namespace {
+
+void visitXpuDeviceMetadata(
+    size_t id,
+    const sycl::device& device,
+    libkineto::ITypedMetadataVisitor& visitor) {
+  visitor.visit(DevicePropertyFields::kId, static_cast<uint64_t>(id));
+  visitor.visit(
+      DevicePropertyFields::kName, device.get_info<sycl::info::device::name>());
+  visitor.visit(
+      DevicePropertyFields::kTotalGlobalMem,
+      static_cast<uint64_t>(
+          device.get_info<sycl::info::device::global_mem_size>()));
+  visitor.visit(
+      DevicePropertyFields::kMaxComputeUnits,
+      static_cast<uint64_t>(
+          device.get_info<sycl::info::device::max_compute_units>()));
+  visitor.visit(
+      DevicePropertyFields::kMaxWorkGroupSize,
+      static_cast<uint64_t>(
+          device.get_info<sycl::info::device::max_work_group_size>()));
+  visitor.visit(
+      DevicePropertyFields::kMaxClockFrequency,
+      static_cast<uint64_t>(
+          device.get_info<sycl::info::device::max_clock_frequency>()));
+  visitor.visit(
+      DevicePropertyFields::kMaxMemAllocSize,
+      static_cast<uint64_t>(
+          device.get_info<sycl::info::device::max_mem_alloc_size>()));
+  visitor.visit(
+      DevicePropertyFields::kLocalMemSize,
+      static_cast<uint64_t>(
+          device.get_info<sycl::info::device::local_mem_size>()));
+  visitor.visit(
+      DevicePropertyFields::kVendor,
+      device.get_info<sycl::info::device::vendor>());
+  visitor.visit(
+      DevicePropertyFields::kDriverVersion,
+      device.get_info<sycl::info::device::driver_version>());
+}
+
+} // namespace
 
 std::string getXpuDeviceProperties() {
   std::vector<std::string> jsonProps;
@@ -26,30 +74,9 @@ std::string getXpuDeviceProperties() {
     const auto& device_list = platform.get_devices();
     for (size_t i = 0; i < device_list.size(); i++) {
       const auto& device = device_list[i];
-      jsonProps.push_back(fmt::format(
-          R"JSON(
-    {{
-      "id": {},
-      "name": "{}",
-      "totalGlobalMem": {},
-      "maxComputeUnits": {},
-      "maxWorkGroupSize": {},
-      "maxClockFrequency": {},
-      "maxMemAllocSize": {},
-      "localMemSize": {},
-      "vendor": "{}",
-      "driverVersion": "{}"
-    }})JSON",
-          i,
-          device.get_info<sycl::info::device::name>(),
-          device.get_info<sycl::info::device::global_mem_size>(),
-          device.get_info<sycl::info::device::max_compute_units>(),
-          device.get_info<sycl::info::device::max_work_group_size>(),
-          device.get_info<sycl::info::device::max_clock_frequency>(),
-          device.get_info<sycl::info::device::max_mem_alloc_size>(),
-          device.get_info<sycl::info::device::local_mem_size>(),
-          device.get_info<sycl::info::device::vendor>(),
-          device.get_info<sycl::info::device::driver_version>()));
+      libkineto::internal::JsonTypedMetadataVisitor visitor;
+      visitXpuDeviceMetadata(i, device, visitor);
+      jsonProps.push_back("{" + std::move(visitor).json() + "}");
     }
   }
 

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerHandlers.cpp
@@ -6,10 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "MetadataFieldCatalog.h"
 #include "XpuptiProfilerMacros.h"
 #include "XpuptiScopeProfilerSession.h"
 
 namespace KINETO_NAMESPACE {
+
+namespace XpuFields = libkineto::XpuMetadataFields;
 
 enum class MetadataOrCounterValue {
   Metadata = 0,
@@ -17,33 +20,36 @@ enum class MetadataOrCounterValue {
 };
 
 static void AddPtiValueToMetadataOrCounterValue(
-    GenericTraceActivity* scopeActivity,
+    GenericTraceActivity& scopeActivity,
     MetadataOrCounterValue metadataOrCounterValue,
     const std::string& metricName,
     pti_metric_value_type valueType,
     const pti_value_t& value) {
   switch (valueType) {
-#define CASE(T, FIELD)                                                \
+#define CASE(T, FIELD, TYPE)                                          \
   case PTI_METRIC_VALUE_TYPE_##T:                                     \
     if (metadataOrCounterValue == MetadataOrCounterValue::Metadata) { \
-      scopeActivity->addMetadata(metricName, value.FIELD);            \
+      scopeActivity.addTypedMetadata(                                 \
+          metricName, TypedValue{static_cast<TYPE>(value.FIELD)});    \
     } else {                                                          \
-      scopeActivity->addCounterValue(metricName, value.FIELD);        \
+      scopeActivity.addCounterValue(                                  \
+          metricName, static_cast<double>(value.FIELD));              \
     }                                                                 \
     return;
 
-    CASE(UINT32, ui32);
-    CASE(UINT64, ui64);
-    CASE(FLOAT32, fp32);
-    CASE(FLOAT64, fp64);
+    CASE(UINT32, ui32, uint64_t);
+    CASE(UINT64, ui64, uint64_t);
+    CASE(FLOAT32, fp32, double);
+    CASE(FLOAT64, fp64, double);
 
 #undef CASE
 
     case PTI_METRIC_VALUE_TYPE_BOOL8:
       if (metadataOrCounterValue == MetadataOrCounterValue::Metadata) {
-        scopeActivity->addMetadata(metricName, value.b8 ? "true" : "false ");
+        scopeActivity.addTypedMetadata(metricName, TypedValue{value.b8 != 0});
       } else {
-        scopeActivity->addCounterValue(metricName, value.b8);
+        scopeActivity.addCounterValue(
+            metricName, static_cast<double>(value.b8));
       }
       return;
 
@@ -102,9 +108,10 @@ void XpuptiScopeProfilerSession::handleScopeRecord(
   }
   lastKernelActivityEndTime_ = scopeActivities[0]->endTime;
 
-  scopeActivities[0]->addMetadata("kernel_id", record->_kernel_id);
-  scopeActivities[0]->addMetadataQuoted(
-      "queue", fmt::format("{}", record->_queue));
+  scopeActivities[0]->addMetadata(
+      XpuFields::kKernelId, static_cast<uint64_t>(record->_kernel_id));
+  scopeActivities[0]->addMetadata(
+      XpuFields::kQueue, fmt::format("{}", record->_queue));
 
   for (uint32_t m = 0; m < metadata._metrics_count; ++m) {
     const auto& unit = metadata._metric_units[m];
@@ -113,14 +120,14 @@ void XpuptiScopeProfilerSession::handleScopeRecord(
         fmt::format("{}{}", metadata._metric_names[m], unitSuffix);
 
     AddPtiValueToMetadataOrCounterValue(
-        scopeActivities[0],
+        *scopeActivities[0],
         MetadataOrCounterValue::Metadata,
         metricNameWithUnit,
         metadata._value_types[m],
         record->_metrics_values[m]);
 
     AddPtiValueToMetadataOrCounterValue(
-        scopeActivities[1],
+        *scopeActivities[1],
         MetadataOrCounterValue::CounterValue,
         metadata._metric_names[m],
         metadata._value_types[m],

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerHandlers.cpp
@@ -20,7 +20,7 @@ enum class MetadataOrCounterValue {
 };
 
 static void AddPtiValueToMetadataOrCounterValue(
-    GenericTraceActivity& scopeActivity,
+    GenericTraceActivity* scopeActivity,
     MetadataOrCounterValue metadataOrCounterValue,
     const std::string& metricName,
     pti_metric_value_type valueType,
@@ -29,11 +29,10 @@ static void AddPtiValueToMetadataOrCounterValue(
 #define CASE(T, FIELD, TYPE)                                          \
   case PTI_METRIC_VALUE_TYPE_##T:                                     \
     if (metadataOrCounterValue == MetadataOrCounterValue::Metadata) { \
-      scopeActivity.addTypedMetadata(                                 \
+      scopeActivity->addTypedMetadata(                                \
           metricName, TypedValue{static_cast<TYPE>(value.FIELD)});    \
     } else {                                                          \
-      scopeActivity.addCounterValue(                                  \
-          metricName, static_cast<double>(value.FIELD));              \
+      scopeActivity->addCounterValue(metricName, value.FIELD);        \
     }                                                                 \
     return;
 
@@ -46,10 +45,9 @@ static void AddPtiValueToMetadataOrCounterValue(
 
     case PTI_METRIC_VALUE_TYPE_BOOL8:
       if (metadataOrCounterValue == MetadataOrCounterValue::Metadata) {
-        scopeActivity.addTypedMetadata(metricName, TypedValue{value.b8 != 0});
+        scopeActivity->addTypedMetadata(metricName, TypedValue{value.b8 != 0});
       } else {
-        scopeActivity.addCounterValue(
-            metricName, static_cast<double>(value.b8));
+        scopeActivity->addCounterValue(metricName, value.b8);
       }
       return;
 
@@ -110,8 +108,8 @@ void XpuptiScopeProfilerSession::handleScopeRecord(
 
   scopeActivities[0]->addMetadata(
       XpuFields::kKernelId, static_cast<uint64_t>(record->_kernel_id));
-  scopeActivities[0]->addMetadata(
-      XpuFields::kQueue, fmt::format("{}", record->_queue));
+  scopeActivities[0]->addMetadataQuoted(
+      "queue", fmt::format("{}", record->_queue));
 
   for (uint32_t m = 0; m < metadata._metrics_count; ++m) {
     const auto& unit = metadata._metric_units[m];
@@ -120,14 +118,14 @@ void XpuptiScopeProfilerSession::handleScopeRecord(
         fmt::format("{}{}", metadata._metric_names[m], unitSuffix);
 
     AddPtiValueToMetadataOrCounterValue(
-        *scopeActivities[0],
+        scopeActivities[0],
         MetadataOrCounterValue::Metadata,
         metricNameWithUnit,
         metadata._value_types[m],
         record->_metrics_values[m]);
 
     AddPtiValueToMetadataOrCounterValue(
-        *scopeActivities[1],
+        scopeActivities[1],
         MetadataOrCounterValue::CounterValue,
         metadata._metric_names[m],
         metadata._value_types[m],

--- a/libkineto/test/xpupti/CMakeLists.txt
+++ b/libkineto/test/xpupti/CMakeLists.txt
@@ -96,4 +96,5 @@ function(add_sycl_test test_file)
 endfunction()
 
 add_sycl_test(XpuptiProfilerTest.cpp)
+target_link_libraries(XpuptiProfilerTest PRIVATE nlohmann_json::nlohmann_json)
 add_sycl_test(XpuptiScopeProfilerTest.cpp PROPERTIES ENVIRONMENT "ZET_ENABLE_METRICS=1")

--- a/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
+++ b/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
@@ -230,9 +230,6 @@ TEST_F(XpuptiActivityHandlersTest, SynchronizationActivityMetadata) {
   EXPECT_EQ(activity.getMetadataValue("Return_code"), "0");
   EXPECT_EQ(activity.getMetadataValue("correlation"), "5");
   EXPECT_EQ(
-      activity.getMetadataValue(XpuMetadataFields::kType),
-      std::optional<std::string>{"HOST_FENCE"});
-  EXPECT_EQ(
       activity.getMetadataValue(XpuMetadataFields::kNumberWaitEvents),
       std::optional<uint64_t>{3});
   EXPECT_EQ(

--- a/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
+++ b/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "include/MetadataFieldCatalog.h"
 #include "include/output_base.h"
 #include "src/ActivityBuffers.h"
 #include "src/plugin/xpupti/XpuptiActivityApi.h"
@@ -14,6 +15,8 @@
 #include "src/plugin/xpupti/XpuptiProfilerMacros.h"
 
 #include <gtest/gtest.h>
+
+#include <optional>
 
 namespace KN = KINETO_NAMESPACE;
 using namespace libkineto;
@@ -148,6 +151,9 @@ TEST_F(XpuptiActivityHandlersTest, CommunicationActivityFields) {
   EXPECT_EQ(activity.resourceId(), 77);
   EXPECT_EQ(activity.getThreadId(), 77);
   EXPECT_EQ(activity.getMetadataValue("Communicator_id"), "99");
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kCommunicatorId),
+      std::optional<uint64_t>{99});
 }
 
 TEST_F(XpuptiActivityHandlersTest, CommunicationActivityOutOfRange) {
@@ -223,6 +229,49 @@ TEST_F(XpuptiActivityHandlersTest, SynchronizationActivityMetadata) {
   EXPECT_EQ(activity.getMetadataValue("Number_wait_events"), "3");
   EXPECT_EQ(activity.getMetadataValue("Return_code"), "0");
   EXPECT_EQ(activity.getMetadataValue("correlation"), "5");
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kType),
+      std::optional<std::string>{"HOST_FENCE"});
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kNumberWaitEvents),
+      std::optional<uint64_t>{3});
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kReturnCode),
+      std::optional<int64_t>{0});
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kCorrelation),
+      std::optional<uint64_t>{5});
+}
+
+TEST_F(XpuptiActivityHandlersTest, ZeroDurationMemoryCopyOmitsBandwidth) {
+  pti_view_record_memory_copy memory_record{};
+  memory_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_MEM_COPY;
+  memory_record._name = "zeCommandListAppendMemoryCopy";
+  memory_record._start_timestamp = 100;
+  memory_record._end_timestamp = 100;
+  memory_record._thread_id = 7;
+  memory_record._correlation_id = 11;
+  memory_record._sycl_queue_id = 3;
+  memory_record._mem_op_id = 4;
+  memory_record._bytes = 1024;
+
+  mockApi_.records.push_back(
+      reinterpret_cast<const pti_view_record_base*>(&memory_record));
+
+  auto traceBuffer = processAndGetTrace();
+  ASSERT_EQ(traceBuffer->activities.size(), 1);
+
+  auto& activity = *traceBuffer->activities[0];
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kBytes),
+      std::optional<uint64_t>{1024});
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kMemoryBandwidthGbps),
+      std::nullopt);
+  EXPECT_EQ(
+      activity.metadataJson().find(
+          XpuMetadataFields::kMemoryBandwidthGbps.name),
+      std::string::npos);
 }
 
 TEST_F(XpuptiActivityHandlersTest, SynchronizationAllTypes) {

--- a/libkineto/test/xpupti/XpuptiProfilerTest.cpp
+++ b/libkineto/test/xpupti/XpuptiProfilerTest.cpp
@@ -10,8 +10,10 @@
 
 #include "include/GenericTraceActivity.h"
 #include "include/libkineto.h"
+#include "src/plugin/xpupti/XpuptiActivityProfiler.h"
 
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 
 #include <set>
 #include <unordered_set>
@@ -127,6 +129,25 @@ void expectTwoUserAnnotations(const KN::CpuTraceBuffer& buffer) {
 }
 
 } // namespace
+
+TEST(XpuptiProfilerTest, DevicePropertiesJsonPreservesLegacyFields) {
+  const auto devices =
+      nlohmann::json::parse("[" + KN::getXpuDeviceProperties() + "]");
+  ASSERT_FALSE(devices.empty());
+
+  for (const auto& device : devices) {
+    EXPECT_TRUE(device.at("id").is_number());
+    EXPECT_TRUE(device.at("name").is_string());
+    EXPECT_TRUE(device.at("totalGlobalMem").is_number());
+    EXPECT_TRUE(device.at("maxComputeUnits").is_number());
+    EXPECT_TRUE(device.at("maxWorkGroupSize").is_number());
+    EXPECT_TRUE(device.at("maxClockFrequency").is_number());
+    EXPECT_TRUE(device.at("maxMemAllocSize").is_number());
+    EXPECT_TRUE(device.at("localMemSize").is_number());
+    EXPECT_TRUE(device.at("vendor").is_string());
+    EXPECT_TRUE(device.at("driverVersion").is_string());
+  }
+}
 
 TEST(XpuptiProfilerTest, XpuDriverEvents) {
   KN::Config cfg;

--- a/libkineto/test/xpupti/XpuptiTestUtilities.cpp
+++ b/libkineto/test/xpupti/XpuptiTestUtilities.cpp
@@ -21,6 +21,49 @@
 
 namespace KN = KINETO_NAMESPACE;
 
+namespace {
+
+class RawJsonFieldVisitor final : public KN::ITypedMetadataVisitor {
+ public:
+  std::vector<std::string> fields;
+
+ private:
+  void visitValue(
+      [[maybe_unused]] const KN::MetadataField<int64_t>& field,
+      [[maybe_unused]] int64_t value) override {}
+  void visitValue(
+      [[maybe_unused]] const KN::MetadataField<uint64_t>& field,
+      [[maybe_unused]] uint64_t value) override {}
+  void visitValue(
+      [[maybe_unused]] const KN::MetadataField<double>& field,
+      [[maybe_unused]] double value) override {}
+  void visitValue(
+      [[maybe_unused]] const KN::MetadataField<bool>& field,
+      [[maybe_unused]] bool value) override {}
+  void visitValue(
+      [[maybe_unused]] const KN::MetadataField<std::string>& field,
+      [[maybe_unused]] std::string_view value) override {}
+  void visitValue(
+      [[maybe_unused]] const KN::MetadataField<std::vector<int64_t>>& field,
+      [[maybe_unused]] const std::vector<int64_t>& value) override {}
+  void visitValue(
+      [[maybe_unused]] const KN::MetadataField<std::vector<std::string>>& field,
+      [[maybe_unused]] const std::vector<std::string>& value) override {}
+  void visitValue(
+      const KN::MetadataField<KN::RawJson>& field,
+      [[maybe_unused]] const KN::RawJson& value) override {
+    fields.emplace_back(field.name);
+  }
+  void visitValue(
+      [[maybe_unused]] const KN::MetadataField<KN::InputShapes>& field,
+      [[maybe_unused]] const KN::InputShapes& value) override {}
+  void visitUnsupported(std::string_view /*name*/) override {}
+  void beginDict(std::string_view /*name*/) override {}
+  void endDict() override {}
+};
+
+} // namespace
+
 bool IsEnvVerbose() {
   auto verboseEnv = getenv("VERBOSE");
   return verboseEnv && (strcmp(verboseEnv, "1") == 0);
@@ -286,6 +329,12 @@ RunProfilerTest(
   unsigned scopeProfilerActCount = 0;
 
   for (auto&& pActivity : pBuffer->activities) {
+    RawJsonFieldVisitor rawJsonVisitor;
+    pActivity->visitTypedMetadata(rawJsonVisitor);
+    EXPECT_TRUE(rawJsonVisitor.fields.empty())
+        << "RawJson metadata fields: "
+        << fmt::format("{}", fmt::join(rawJsonVisitor.fields, ", "));
+
     auto insertResult = stringStorage.insert(pActivity->name());
     activitiesCount[*insertResult.first]++;
     typesCount[pActivity->type()]++;

--- a/libkineto/test/xpupti/XpuptiTestUtilities.cpp
+++ b/libkineto/test/xpupti/XpuptiTestUtilities.cpp
@@ -23,6 +23,8 @@ namespace KN = KINETO_NAMESPACE;
 
 namespace {
 
+// metadataJson() renders typed values and RawJson identically, so inspect the
+// stored variants directly to ensure XPU producers never use JSON fallback.
 class RawJsonFieldVisitor final : public KN::ITypedMetadataVisitor {
  public:
   std::vector<std::string> fields;


### PR DESCRIPTION
Previously, all non-json output formats needed to parse JSON strings and convert them to typed representations before writing, which was super inefficient. In general, using JSON as the canonical Kineto output format is inflexible and leads to people needing to write hacky code to get around its limitations. What's more, when we want to add a new metadata field, it took some annoying work to have it reflect in non-JSON outputs.

Our solution to these problems is a visitor class over typed metadata fields. We have already migrated CUDA and ROCm to this and have gotten nice performance/code quality/quality of life improvements. This PR migrates XPU's `addMetadata` callsites to typed metadata and adds the fields to the catalog so that they can also get the benefits of this migration (and so that we can start to delete our JSON parsing code).