### PR TITLE
[ROCm][CI] Switch ROCm CI runner label from gfx942 to ecosystem.mi350

### DIFF
--- a/.github/workflows/linux_rocm_kineto.yml
+++ b/.github/workflows/linux_rocm_kineto.yml
@@ -20,7 +20,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       job-name: linux-rocm-kineto-build-and-test
-      runner: linux.rocm.gpu.gfx942.1
+      runner: linux.rocm.gpu.ecosystem.mi350.1
       timeout: 180
       # Checkout the Kineto repo at the PR ref with submodules
       repository: ${{ github.repository }}

--- a/.github/workflows/linux_rocm_pytorch.yml
+++ b/.github/workflows/linux_rocm_pytorch.yml
@@ -20,7 +20,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       job-name: linux-rocm-pytorch-build-and-test
-      runner: linux.rocm.gpu.gfx942.1
+      runner: linux.rocm.gpu.ecosystem.mi350.1
       timeout: 180
       # Checkout the Kineto repo at the PR ref with submodules
       repository: ${{ github.repository }}


### PR DESCRIPTION
This PR replaces gfx942 label with ecosystem.mi350 label.