### PR TITLE
[Kineto] Refactor CUPTI timestamp handling

### DIFF
--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -100,6 +100,7 @@ CUPTI_API_SRCS = [
 
 CUPTI_ACTIVITY_PROFILER_SRCS = [
     "src/CuptiActivityProfiler.cpp",
+    "src/CuptiTimestamp.cpp",
 ]
 
 CUPTI_PM_SAMPLING_API_SRCS = [

--- a/libkineto/src/CuptiActivity.h
+++ b/libkineto/src/CuptiActivity.h
@@ -14,8 +14,8 @@
 
 // TODO(T90238193)
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
-#include "ApproximateClock.h"
 #include "CuptiCbidRegistry.h"
+#include "CuptiTimestamp.h"
 #include "Demangle.h"
 #include "DeviceProperties.h"
 #include "GenericTraceActivity.h"
@@ -36,10 +36,6 @@ namespace KINETO_NAMESPACE {
 using namespace libkineto;
 struct TraceSpan;
 
-// This function allows us to activate/deactivate TSC CUPTI callbacks
-// via a killswitch
-bool& use_cupti_tsc();
-
 // These classes wrap the various CUPTI activity types
 // into subclasses of ITraceActivity so that they can all be accessed
 // using the ITraceActivity interface and logged via ActivityLogger.
@@ -49,32 +45,12 @@ template <class T>
 struct CuptiActivity : public ITraceActivity {
   explicit CuptiActivity(const T* activity, const ITraceActivity* linked)
       : activity_(*activity), linked_(linked) {}
-  // If we are running on Windows or are on a CUDA version < 11.6,
-  // we use the default system clock so no conversion needed same for all
-  // ifdefs below
   int64_t timestamp() const override {
-#if defined(_WIN32) || CUDA_VERSION < 11060
-    return activity_.start;
-#else
-    if (use_cupti_tsc()) {
-      return get_time_converter()(activity_.start);
-    } else {
-      return activity_.start;
-    }
-#endif
+    return convertCuptiTimestamp(activity_.start);
   }
 
   int64_t duration() const override {
-#if defined(_WIN32) || CUDA_VERSION < 11060
-    return activity_.end - activity_.start;
-#else
-    if (use_cupti_tsc()) {
-      return get_time_converter()(activity_.end) -
-          get_time_converter()(activity_.start);
-    } else {
-      return activity_.end - activity_.start;
-    }
-#endif
+    return convertCuptiDuration(activity_.start, activity_.end);
   }
   // TODO(T107507796): Deprecate ITraceActivity
   int64_t correlationId() const override {
@@ -173,28 +149,11 @@ struct OverheadActivity : public CuptiActivity<CUpti_ActivityOverhead> {
       : CuptiActivity(activity, linked), threadId_(threadId) {}
 
   int64_t timestamp() const override {
-#if defined(_WIN32) || CUDA_VERSION < 11060
-    return activity_.start;
-#else
-    if (use_cupti_tsc()) {
-      return get_time_converter()(activity_.start);
-    } else {
-      return activity_.start;
-    }
-#endif
+    return convertCuptiTimestamp(activity_.start);
   }
 
   int64_t duration() const override {
-#if defined(_WIN32) || CUDA_VERSION < 11060
-    return activity_.end - activity_.start;
-#else
-    if (use_cupti_tsc()) {
-      return get_time_converter()(activity_.end) -
-          get_time_converter()(activity_.start);
-    } else {
-      return activity_.end - activity_.start;
-    }
-#endif
+    return convertCuptiDuration(activity_.start, activity_.end);
   }
 
   // TODO: Update this with PID ordering
@@ -264,15 +223,7 @@ using CUpti_ActivityCudaEventType = CUpti_ActivityCudaEvent;
 template <>
 inline int64_t CuptiActivity<CUpti_ActivityCudaEventType>::timestamp() const {
 #if CUDA_VERSION >= 12080
-#if defined(_WIN32)
-  return activity_.deviceTimestamp;
-#else
-  if (use_cupti_tsc()) {
-    return get_time_converter()(activity_.deviceTimestamp);
-  } else {
-    return activity_.deviceTimestamp;
-  }
-#endif
+  return convertCuptiTimestamp(activity_.deviceTimestamp);
 #else
   // For CUDA < 12.8, deviceTimestamp doesn't exist, set to 0
   return 0;

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -20,12 +20,12 @@
 #include "CuptiActivity.h"
 #include "CuptiActivityApi.h"
 #include "CuptiCbidRegistry.h"
+#include "CuptiTimestamp.h"
 #include "Demangle.h"
 #include "DeviceUtil.h"
 #include "KernelRegistry.h"
 #include "Logger.h"
 
-using namespace std::chrono;
 using std::string;
 
 namespace {
@@ -72,11 +72,6 @@ std::unordered_map<uint32_t, uint32_t>& ctxToDeviceId() {
 
 namespace KINETO_NAMESPACE {
 
-bool& use_cupti_tsc() {
-  static bool use_cupti_tsc = true;
-  return use_cupti_tsc;
-}
-
 CuptiActivityProfiler::CuptiActivityProfiler(
     CuptiActivityApi& cupti,
     bool cpuOnly)
@@ -114,21 +109,7 @@ void CuptiActivityProfiler::setMaxGpuBufferSize(int64_t size) {
 }
 
 void CuptiActivityProfiler::enableGpuTracing() {
-#ifdef _WIN32
-  CUPTI_CALL(cuptiActivityRegisterTimestampCallback([]() -> uint64_t {
-    auto system = std::chrono::time_point_cast<std::chrono::nanoseconds>(
-        std::chrono::system_clock::now());
-    return system.time_since_epoch().count();
-  }));
-#else
-#if CUDA_VERSION >= 11060
-  use_cupti_tsc() = config().getTSCTimestampFlag();
-  if (use_cupti_tsc()) {
-    CUPTI_CALL(cuptiActivityRegisterTimestampCallback(
-        []() -> uint64_t { return getApproximateTime(); }));
-  }
-#endif // CUDA_VERSION >= 11060
-#endif // _WIN32
+  configureCuptiTimestampSource(config().getTSCTimestampFlag());
   cupti_.enableCuptiActivities(
       derivedConfig_->profileActivityTypes(),
       derivedConfig_->isPerThreadBufferEnabled());

--- a/libkineto/src/CuptiPMSamplingApi.h
+++ b/libkineto/src/CuptiPMSamplingApi.h
@@ -20,7 +20,8 @@ struct CUpti_Profiler_Host_Object;
 namespace KINETO_NAMESPACE {
 
 struct CuptiPMSample {
-  // CUPTI reports these timestamps in the CPU timestamp domain, in nanoseconds.
+  // Raw timestamps produced through the same registered timestamp source as
+  // CUPTI Activity API records.
   uint64_t rawStartTimestamp;
   uint64_t rawEndTimestamp;
   std::vector<double> values; // One value per metric

--- a/libkineto/src/CuptiTimestamp.cpp
+++ b/libkineto/src/CuptiTimestamp.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CuptiTimestamp.h"
+
+#include <chrono>
+
+#include "DeviceUtil.h"
+#include "Logger.h"
+
+namespace KINETO_NAMESPACE {
+namespace {
+
+bool timestampSourceReady{false};
+
+} // namespace
+
+bool& use_cupti_tsc() {
+  static bool use_cupti_tsc = true;
+  return use_cupti_tsc;
+}
+
+void configureCuptiTimestampSource([[maybe_unused]] bool useTsc) {
+  bool configured{true};
+#ifdef _WIN32
+  configured =
+      CUPTI_CALL(cuptiActivityRegisterTimestampCallback([]() -> uint64_t {
+        auto system = std::chrono::time_point_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now());
+        return system.time_since_epoch().count();
+      })) == CUPTI_SUCCESS;
+#else
+#if CUDA_VERSION >= 11060
+  use_cupti_tsc() = useTsc;
+  if (use_cupti_tsc()) {
+    configured =
+        CUPTI_CALL(cuptiActivityRegisterTimestampCallback([]() -> uint64_t {
+          return getApproximateTime();
+        })) == CUPTI_SUCCESS;
+  }
+#endif // CUDA_VERSION >= 11060
+#endif // _WIN32
+  timestampSourceReady = configured;
+}
+
+bool isCuptiTimestampSourceReady() {
+  return timestampSourceReady;
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiTimestamp.h
+++ b/libkineto/src/CuptiTimestamp.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cupti.h>
+
+#include <cstdint>
+
+#include "ApproximateClock.h"
+
+namespace KINETO_NAMESPACE {
+
+// Configure the timestamp source shared by CUPTI Activity and PM Sampling.
+void configureCuptiTimestampSource(bool useTsc);
+bool isCuptiTimestampSourceReady();
+
+// This function allows us to activate/deactivate TSC CUPTI callbacks
+// via a killswitch.
+bool& use_cupti_tsc();
+
+// If we are running on Windows or are on a CUDA version < 11.6,
+// we use the default system clock so no conversion needed.
+inline int64_t convertCuptiTimestamp(uint64_t timestamp) {
+#if defined(_WIN32) || CUDA_VERSION < 11060
+  return timestamp;
+#else
+  if (use_cupti_tsc()) {
+    return get_time_converter()(timestamp);
+  } else {
+    return timestamp;
+  }
+#endif
+}
+
+inline int64_t convertCuptiDuration(uint64_t start, uint64_t end) {
+#if defined(_WIN32) || CUDA_VERSION < 11060
+  return end - start;
+#else
+  if (use_cupti_tsc()) {
+    return get_time_converter()(end) - get_time_converter()(start);
+  } else {
+    return end - start;
+  }
+#endif
+}
+
+} // namespace KINETO_NAMESPACE


### PR DESCRIPTION
According to NVIDIA, "PM Sampling uses the same internal GPU→CPU timestamp conversion path as the Activity API, so if you register a timestamp callback via cuptiActivityRegisterTimestampCallback, it is expected and supported that cuptiPmSamplingDecodeData will invoke that callback."

So both PM sampling and Activity profiling are going to want to share the approximate timestamp callbacks currently registered by the activity profiler in `enableGpuTracing`. To make this cleaner, I pull out the timestamp logic into a shared helper so that both of the profilers can depend on the same logic.