### PR TITLE
[Kineto] Enable registering CUPTI PM sampling as a child profiler

### DIFF
--- a/libkineto/include/ActivityType.h
+++ b/libkineto/include/ActivityType.h
@@ -55,9 +55,11 @@ enum class ActivityType {
 
   XPU_SCOPE_PROFILER = 26, // XPUPTI Profiler scope for performance metrics
   XPU_SYNC = 27, // XPU synchronization events
+  HARDWARE_COUNTERS =
+      28, // hardware performance counter samples. Only used by CUDA right now.
 
   ENUM_COUNT =
-      28, // This is to add buffer and not used for any profiling logic. Add
+      29, // This is to add buffer and not used for any profiling logic. Add
   // your new type before it.
   OPTIONAL_ACTIVITY_TYPE_START = GLOW_RUNTIME,
 };
@@ -105,6 +107,7 @@ inline constexpr std::array<_ActivityTypeName, activityTypeCount + 1>
         {"privateuse1_driver", ActivityType::PRIVATEUSE1_DRIVER},
         {"xpu_scope_profiler", ActivityType::XPU_SCOPE_PROFILER},
         {"xpu_sync", ActivityType::XPU_SYNC},
+        {"hardware_counters", ActivityType::HARDWARE_COUNTERS},
         {"ENUM_COUNT", ActivityType::ENUM_COUNT},
     }};
 

--- a/libkineto/libkineto_defs.bzl
+++ b/libkineto/libkineto_defs.bzl
@@ -109,6 +109,7 @@ CUPTI_PM_SAMPLING_API_SRCS = [
 
 CUPTI_PM_SAMPLING_PROFILER_SRCS = [
     "src/CuptiPMSamplingController.cpp",
+    "src/CuptiPMSamplingProfiler.cpp",
 ]
 
 WEAK_SYMBOLS_SRCS = [

--- a/libkineto/src/CuptiPMSamplingController.cpp
+++ b/libkineto/src/CuptiPMSamplingController.cpp
@@ -45,7 +45,7 @@ CuptiPMSamplingController::CuptiPMSamplingController(
     : config_(std::move(config)) {}
 
 CuptiPMSamplingController::~CuptiPMSamplingController() {
-  stop();
+  static_cast<void>(stop());
 }
 
 bool CuptiPMSamplingController::prepare() {
@@ -76,14 +76,14 @@ bool CuptiPMSamplingController::prepare() {
   return true;
 }
 
-bool CuptiPMSamplingController::start() {
+void CuptiPMSamplingController::start() {
   if (!prepared_) {
     LOG(WARNING) << "CUPTI PM sampling is not prepared";
-    return false;
+    return;
   }
   if (active_) {
     LOG(WARNING) << "CUPTI PM sampling is already running";
-    return false;
+    return;
   }
 
   stopRequested_.store(false, std::memory_order_relaxed);
@@ -95,12 +95,11 @@ bool CuptiPMSamplingController::start() {
     decodeThread_ = std::thread(&CuptiPMSamplingController::decodeLoop, this);
   } catch (...) {
     logCurrentException("Failed to start CUPTI PM sampling");
-    stop();
+    static_cast<void>(stop());
   }
-  return active_;
 }
 
-void CuptiPMSamplingController::stop() {
+bool CuptiPMSamplingController::stop() {
   // Notify the decode thread and join it if possible
   if (decodeThread_.joinable()) {
     {
@@ -113,9 +112,10 @@ void CuptiPMSamplingController::stop() {
     decodeThread_.join();
   }
   if (!prepared_) {
-    return;
+    return false;
   }
 
+  const bool wasActive = active_;
   // active_ indicates that the PM Sampling API was primed and collected samples
   // so we need to stop() and drain all remaining items in the hardware buffer.
   if (active_) {
@@ -132,6 +132,11 @@ void CuptiPMSamplingController::stop() {
   }
   api_.disable();
   prepared_ = false;
+  return wasActive;
+}
+
+int32_t CuptiPMSamplingController::deviceId() const {
+  return config_.deviceId;
 }
 
 const std::vector<std::string>& CuptiPMSamplingController::metricNames() const {

--- a/libkineto/src/CuptiPMSamplingController.h
+++ b/libkineto/src/CuptiPMSamplingController.h
@@ -31,9 +31,11 @@ class CuptiPMSamplingController {
   ~CuptiPMSamplingController();
 
   [[nodiscard]] bool prepare();
-  [[nodiscard]] bool start();
-  void stop();
+  void start();
+  // Returns whether collection was active when stop() was called.
+  [[nodiscard]] bool stop();
 
+  [[nodiscard]] int32_t deviceId() const;
   [[nodiscard]] const std::vector<std::string>& metricNames() const;
   [[nodiscard]] std::vector<CuptiPMSample> takeSamples();
 

--- a/libkineto/src/CuptiPMSamplingProfiler.cpp
+++ b/libkineto/src/CuptiPMSamplingProfiler.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CuptiPMSamplingProfiler.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <utility>
+
+#include "ActivityType.h"
+#include "CuptiTimestamp.h"
+#include "Logger.h"
+#include "libkineto.h"
+#include "output_base.h"
+
+namespace KINETO_NAMESPACE {
+namespace {
+
+const std::string kProfilerName{"CUPTI PM Sampling"};
+const std::set<libkineto::ActivityType> kSupportedActivities{
+    libkineto::ActivityType::HARDWARE_COUNTERS};
+
+} // namespace
+
+CuptiPMSamplingSession::CuptiPMSamplingSession(
+    const CuptiPMSamplingConfig& config)
+    : controller_(config) {}
+
+CuptiPMSamplingSession::~CuptiPMSamplingSession() = default;
+
+bool CuptiPMSamplingSession::prepare() {
+  // PM sampling and activity profiling share the same timestamp callbacks.
+  // This can only run after activity profiling enables the callbacks in
+  // enableGpuTracing
+  if (!isCuptiTimestampSourceReady()) {
+    LOG(WARNING) << "CUPTI PM sampling requires timestamp setup from the "
+                    "CUPTI Activity profiler";
+    return false;
+  }
+
+  // prepare() enables CUPTI PM sampling and acquires exclusive access during
+  // the parent profiler's warmup phase. Collection itself begins in start().
+  if (!controller_.prepare()) {
+    LOG(WARNING) << "CUPTI PM sampling failed to prepare CUDA device "
+                 << controller_.deviceId();
+    return false;
+  }
+  return true;
+}
+
+void CuptiPMSamplingSession::start() {
+  controller_.start();
+}
+
+void CuptiPMSamplingSession::stop() {
+  if (controller_.stop()) {
+    traceBuffer_ = buildTraceBuffer();
+  }
+}
+
+std::vector<std::string> CuptiPMSamplingSession::errors() {
+  // GenericActivityProfiler does not consume child profiler status or errors.
+  // The controller logs failures directly for visibility.
+  return {};
+}
+
+// TODO: Override the capture-window processTrace overload and exclude samples
+// collected during shutdown that fall outside the requested trace interval.
+void CuptiPMSamplingSession::processTrace(libkineto::ActivityLogger& logger) {
+  if (!traceBuffer_) {
+    return;
+  }
+  for (const auto& activity : traceBuffer_->activities) {
+    logger.handleActivity(libkineto::CpuTraceBuffer::toRef(activity));
+  }
+}
+
+std::unique_ptr<libkineto::DeviceInfo> CuptiPMSamplingSession::getDeviceInfo() {
+  return nullptr;
+}
+
+std::vector<libkineto::ResourceInfo> CuptiPMSamplingSession::
+    getResourceInfos() {
+  return {};
+}
+
+std::unique_ptr<libkineto::CpuTraceBuffer> CuptiPMSamplingSession::
+    getTraceBuffer() {
+  return std::move(traceBuffer_);
+}
+
+std::unique_ptr<libkineto::CpuTraceBuffer> CuptiPMSamplingSession::
+    buildTraceBuffer() {
+  auto buffer = std::make_unique<libkineto::CpuTraceBuffer>();
+  buffer->span = libkineto::TraceSpan{0, 0, kProfilerName};
+
+  const auto samples = controller_.takeSamples();
+  const auto& metricNames = controller_.metricNames();
+  for (const auto& sample : samples) {
+    const auto start = convertCuptiTimestamp(sample.rawStartTimestamp);
+    const auto end = convertCuptiTimestamp(sample.rawEndTimestamp);
+
+    if (buffer->activities.empty()) {
+      buffer->span.startTime = start;
+      buffer->span.endTime = end;
+    } else {
+      buffer->span.startTime = std::min(buffer->span.startTime, start);
+      buffer->span.endTime = std::max(buffer->span.endTime, end);
+    }
+
+    buffer->emplace_activity(
+        buffer->span,
+        libkineto::ActivityType::HARDWARE_COUNTERS,
+        kProfilerName);
+    auto& activity = *buffer->activities.back();
+    activity.startTime = start;
+    activity.endTime = end;
+    activity.device = controller_.deviceId();
+    for (size_t i = 0; i < metricNames.size(); ++i) {
+      activity.addCounterValue(metricNames[i], sample.values[i]);
+    }
+  }
+
+  return buffer;
+}
+
+CuptiPMSamplingProfiler::CuptiPMSamplingProfiler(CuptiPMSamplingConfig config)
+    : config_(std::move(config)) {}
+
+const std::string& CuptiPMSamplingProfiler::name() const {
+  return kProfilerName;
+}
+
+const std::set<libkineto::ActivityType>& CuptiPMSamplingProfiler::
+    availableActivities() const {
+  return kSupportedActivities;
+}
+
+std::unique_ptr<libkineto::IActivityProfilerSession> CuptiPMSamplingProfiler::
+    configure(
+        const std::set<libkineto::ActivityType>& activityTypes,
+        const libkineto::Config& /*config*/) {
+  if (activityTypes.find(libkineto::ActivityType::HARDWARE_COUNTERS) ==
+      activityTypes.end()) {
+    return nullptr;
+  }
+
+  auto session = std::make_unique<CuptiPMSamplingSession>(config_);
+  if (!session->prepare()) {
+    return nullptr;
+  }
+  return session;
+}
+
+std::unique_ptr<libkineto::IActivityProfilerSession> CuptiPMSamplingProfiler::
+    configure(
+        int64_t /*startTimeMs*/,
+        int64_t /*durationMs*/,
+        const std::set<libkineto::ActivityType>& activityTypes,
+        const libkineto::Config& config) {
+  // GenericActivityProfiler calls this overload for both synchronous and
+  // asynchronous traces. PM sampling does not schedule itself; the parent
+  // drives collection through start() and stop(), so the timing arguments are
+  // intentionally unused.
+  return configure(activityTypes, config);
+}
+
+} // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiPMSamplingProfiler.h
+++ b/libkineto/src/CuptiPMSamplingProfiler.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "CuptiPMSamplingController.h"
+#include "IActivityProfiler.h"
+
+namespace libkineto {
+struct CpuTraceBuffer;
+}
+
+namespace KINETO_NAMESPACE {
+
+// TODO: Support dynamic collection toggling
+class CuptiPMSamplingSession final
+    : public libkineto::IActivityProfilerSession {
+ public:
+  explicit CuptiPMSamplingSession(const CuptiPMSamplingConfig& config);
+  ~CuptiPMSamplingSession() override;
+
+  [[nodiscard]] bool prepare();
+  void start() override;
+  void stop() override;
+  [[nodiscard]] std::vector<std::string> errors() override;
+  void processTrace(libkineto::ActivityLogger& logger) override;
+  [[nodiscard]] std::unique_ptr<libkineto::DeviceInfo> getDeviceInfo() override;
+  [[nodiscard]] std::vector<libkineto::ResourceInfo> getResourceInfos()
+      override;
+  [[nodiscard]] std::unique_ptr<libkineto::CpuTraceBuffer> getTraceBuffer()
+      override;
+
+ private:
+  [[nodiscard]] std::unique_ptr<libkineto::CpuTraceBuffer> buildTraceBuffer();
+
+  CuptiPMSamplingController controller_;
+  std::unique_ptr<libkineto::CpuTraceBuffer> traceBuffer_;
+};
+
+// The naming is unfortunate here, because CUPTI PM sampling is not activity
+// profiling. However, Kineto's registration logic is based on
+// IActivityProfiler, so this is the simplest way to introduce a new profiler.
+class CuptiPMSamplingProfiler final : public libkineto::IActivityProfiler {
+ public:
+  explicit CuptiPMSamplingProfiler(CuptiPMSamplingConfig config);
+
+  [[nodiscard]] const std::string& name() const override;
+  [[nodiscard]] const std::set<libkineto::ActivityType>& availableActivities()
+      const override;
+  [[nodiscard]] std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      const std::set<libkineto::ActivityType>& activityTypes,
+      const libkineto::Config& config) override;
+  [[nodiscard]] std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      int64_t startTimeMs,
+      int64_t durationMs,
+      const std::set<libkineto::ActivityType>& activityTypes,
+      const libkineto::Config& config) override;
+
+ private:
+  CuptiPMSamplingConfig config_;
+};
+
+} // namespace KINETO_NAMESPACE


### PR DESCRIPTION
Adds the PM sampling activity profiler extending the activity profiler interfaces. It's kind of irritating that we have this dependency because PM sampling is not activity profiling, but this is by far the easiest way to implement this without doing a major refactor of how Kineto handles child profilers.

Mostly direct routing logic, except for `buildTraceBuffer`, which performs the same timestamp conversion that activity profiling does and then pushes collected metrics into `GenericTraceActivity`'s counter handling methods. This means that activity profiling must succeed in instantiating the timestamp convertor, or PM sampling will log an error and return early.

Next is handling the output logic.