### PR TITLE
Let Kineto install its unit test binaries

### DIFF
--- a/libkineto/CMakeLists.txt
+++ b/libkineto/CMakeLists.txt
@@ -29,6 +29,14 @@ option(KINETO_BUILD_TESTS "Build kineto unit tests" ON)
 option(KINETO_BUILD_BENCHMARKS "Build kineto benchmarks" OFF)
 option(KINETO_ENABLE_CUPTI_PM_SAMPLING "Build CUPTI PM sampling support" OFF)
 
+# When Kineto is embedded in a larger project, that project's test runner
+# usually discovers C++ test binaries in the install tree rather than the
+# build tree. Installing the test executables lets it find them without
+# maintaining a hand-written list of Kineto's tests.
+option(KINETO_INSTALL_TESTS "Install kineto unit test binaries" OFF)
+set(KINETO_TEST_INSTALL_DIR "test" CACHE STRING
+  "Install destination for kineto unit test binaries")
+
 set(LIBKINETO_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(LIBKINETO_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(LIBKINETO_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -237,3 +237,12 @@ if(NOT WIN32)
         "${LIBKINETO_DIR}/src")
     gtest_discover_tests(OutputJsonTest)
 endif()
+
+# Every target defined in this directory is a test executable, so the
+# directory's own target list is the set to install. Reading it here, at the
+# end of the file, is what makes a newly added test install itself.
+if(KINETO_INSTALL_TESTS)
+    get_property(KINETO_TEST_TARGETS DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
+    install(TARGETS ${KINETO_TEST_TARGETS}
+        DESTINATION "${KINETO_TEST_INSTALL_DIR}")
+endif()


### PR DESCRIPTION
More preparation for Kineto upstreaming: https://github.com/pytorch/kineto/issues/1478.

After upstreaming, we want PyTorch itself to actually build and run Kineto tests as part of its own CI. Its Windows runner discovers C++ tests by globbing the install tree, so tests that are only ever written to the build tree are invisible to it.

**Fix** — Add KINETO_INSTALL_TESTS, off by default so standalone builds are unchanged, and KINETO_TEST_INSTALL_DIR for the destination. The set of targets to install is read from the test directory's own target list rather than spelled out: every target defined there is a test executable, so a test added later installs itself with no further edit. The property is a snapshot taken where it is read, which is why the block sits at the end of the file.

Verified standalone: default configure emits no install rules, and -DKINETO_INSTALL_TESTS=ON builds and installs all 15 CPU test binaries into <prefix>/test.