### PR TITLE
Make TempTraceFile work on Windows

### DIFF
--- a/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
+++ b/libkineto/test/AsyncActivityProfilerHandlerTest.cpp
@@ -287,6 +287,11 @@ TEST(AsyncActivityProfilerHandler, AsyncTraceUsingIter) {
   runIterTest(0, 5, 5);
 }
 
+// Not run on Windows: the job metadata under test is read from the
+// environment, and this sets it with unix setenv. MSVC offers _putenv_s
+// instead, so enabling this case means giving the tests a portable way to set
+// an environment variable.
+#ifndef _WIN32
 TEST(AsyncActivityProfilerHandler, MetadataJsonFormatingTest) {
   std::vector<std::string> log_modules(
       {"CuptiActivityProfiler.cpp", "output_json.cpp"});
@@ -369,6 +374,7 @@ TEST(AsyncActivityProfilerHandler, MetadataJsonFormatingTest) {
   unsetenv("PT_PROFILER_JOB_VERSION");
   unsetenv("PT_PROFILER_JOB_ATTEMPT_INDEX");
 }
+#endif // !_WIN32
 
 TEST(AsyncActivityProfilerHandler, Cancel) {
   GenericActivityProfiler profiler(/*cpu only*/ true);

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -51,6 +51,10 @@ target_link_libraries(ActivityProfilerControllerTest PRIVATE
 gtest_discover_tests(ActivityProfilerControllerTest)
 
 # AsyncActivityProfilerHandlerTest
+# Builds on Windows, but one of its cases does not: MetadataJsonFormatingTest
+# sets the environment with unix setenv, so the source compiles that case out
+# under _WIN32. The exclusion is per test rather than per target here because
+# the other fifteen cases run there fine.
 add_executable(AsyncActivityProfilerHandlerTest
     AsyncActivityProfilerHandlerTest.cpp
     TestUtils.cpp)

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -41,9 +41,29 @@ target_link_libraries(ConfigLoaderTest PRIVATE
 gtest_discover_tests(ConfigLoaderTest)
 
 # ActivityProfilerControllerTest
-# Not supported on Windows, uses unix "unistd.h"
+add_executable(ActivityProfilerControllerTest
+    ActivityProfilerControllerTest.cpp
+    TestUtils.cpp)
+target_link_libraries(ActivityProfilerControllerTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(ActivityProfilerControllerTest)
+
+# AsyncActivityProfilerHandlerTest
+add_executable(AsyncActivityProfilerHandlerTest
+    AsyncActivityProfilerHandlerTest.cpp
+    TestUtils.cpp)
+target_link_libraries(AsyncActivityProfilerHandlerTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    nlohmann_json::nlohmann_json
+    ${XPU_XPUPTI_LIBRARY})
+gtest_discover_tests(AsyncActivityProfilerHandlerTest)
+
+# ConfigLoaderPollThreadExceptionTest
+# Not supported on Windows: sets the environment with unix setenv.
 if(NOT WIN32)
-    # ConfigLoaderPollThreadExceptionTest
     add_executable(ConfigLoaderPollThreadExceptionTest
         ConfigLoaderPollThreadExceptionTest.cpp)
     target_link_libraries(ConfigLoaderPollThreadExceptionTest PRIVATE
@@ -51,28 +71,12 @@ if(NOT WIN32)
         kineto_base kineto_api
         ${XPU_XPUPTI_LIBRARY})
     gtest_discover_tests(ConfigLoaderPollThreadExceptionTest)
+endif()
 
-    add_executable(ActivityProfilerControllerTest
-        ActivityProfilerControllerTest.cpp
-        TestUtils.cpp)
-    target_link_libraries(ActivityProfilerControllerTest PRIVATE
-        gtest_main
-        kineto_base kineto_api
-        ${XPU_XPUPTI_LIBRARY})
-    gtest_discover_tests(ActivityProfilerControllerTest)
-
-    # AsyncActivityProfilerHandlerTest
-    add_executable(AsyncActivityProfilerHandlerTest
-        AsyncActivityProfilerHandlerTest.cpp
-        TestUtils.cpp)
-    target_link_libraries(AsyncActivityProfilerHandlerTest PRIVATE
-        gtest_main
-        kineto_base kineto_api
-        nlohmann_json::nlohmann_json
-        ${XPU_XPUPTI_LIBRARY})
-    gtest_discover_tests(AsyncActivityProfilerHandlerTest)
-
-    # AsyncE2ECpuTraceTest
+# AsyncE2ECpuTraceTest
+# Not supported on Windows: it drives an on-demand config, and Config only
+# accepts on-demand trace files under a directory that defaults to /tmp.
+if(NOT WIN32)
     add_executable(AsyncE2ECpuTraceTest
         AsyncE2ECpuTraceTest.cpp
         MockCpuActivityBuffer.cpp
@@ -83,8 +87,12 @@ if(NOT WIN32)
         nlohmann_json::nlohmann_json
         ${XPU_XPUPTI_LIBRARY})
     gtest_discover_tests(AsyncE2ECpuTraceTest)
+endif()
 
-    # SyncActivityProfilerHandlerTest
+# SyncActivityProfilerHandlerTest and GenericActivityProfilerTeardownTest
+# use nothing unix-specific, but have never been built on Windows. Enabling
+# them is a separate change that needs its own Windows run to confirm.
+if(NOT WIN32)
     add_executable(SyncActivityProfilerHandlerTest
         SyncActivityProfilerHandlerTest.cpp)
     target_link_libraries(SyncActivityProfilerHandlerTest PRIVATE
@@ -93,7 +101,6 @@ if(NOT WIN32)
         ${XPU_XPUPTI_LIBRARY})
     gtest_discover_tests(SyncActivityProfilerHandlerTest)
 
-    # GenericActivityProfilerTeardownTest
     add_executable(GenericActivityProfilerTeardownTest
         GenericActivityProfilerTeardownTest.cpp)
     target_link_libraries(GenericActivityProfilerTeardownTest PRIVATE
@@ -221,19 +228,16 @@ target_include_directories(GenericTraceActivityMetadataTest PRIVATE
 gtest_discover_tests(GenericTraceActivityMetadataTest)
 
 # OutputJsonTest
-# Not supported on Windows, uses unix "unistd.h"
-if(NOT WIN32)
-    add_executable(OutputJsonTest
-        OutputJsonTest.cpp
-        TestUtils.cpp)
-    target_link_libraries(OutputJsonTest PRIVATE
-        gtest_main
-        kineto_base kineto_api
-        nlohmann_json::nlohmann_json
-        ${XPU_XPUPTI_LIBRARY})
-    target_include_directories(OutputJsonTest PRIVATE
-        "${LIBKINETO_DIR}"
-        "${LIBKINETO_DIR}/include"
-        "${LIBKINETO_DIR}/src")
-    gtest_discover_tests(OutputJsonTest)
-endif()
+add_executable(OutputJsonTest
+    OutputJsonTest.cpp
+    TestUtils.cpp)
+target_link_libraries(OutputJsonTest PRIVATE
+    gtest_main
+    kineto_base kineto_api
+    nlohmann_json::nlohmann_json
+    ${XPU_XPUPTI_LIBRARY})
+target_include_directories(OutputJsonTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src")
+gtest_discover_tests(OutputJsonTest)

--- a/libkineto/test/TestUtils.cpp
+++ b/libkineto/test/TestUtils.cpp
@@ -19,13 +19,16 @@
 #include <system_error>
 #include <utility>
 
+// Both platforms take the open flags from fcntl.h and the permission bits from
+// sys/stat.h. What differs is where the call itself lives: _sopen_s and its
+// share mode come from io.h and share.h, POSIX open and close from unistd.h.
+#include <fcntl.h>
+#include <sys/stat.h>
+
 #ifdef _WIN32
 #include <io.h>
 #include <share.h>
-#include <sys/stat.h>
 #else
-#include <fcntl.h>
-#include <sys/stat.h>
 #include <unistd.h>
 #endif
 

--- a/libkineto/test/TestUtils.cpp
+++ b/libkineto/test/TestUtils.cpp
@@ -11,39 +11,111 @@
 
 #include <gtest/gtest.h>
 
-#include <unistd.h>
-#include <cstdlib>
+#include <filesystem>
+#include <random>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <utility>
 
-#ifdef __linux__
+#ifdef _WIN32
+#include <io.h>
+#include <share.h>
+#include <sys/stat.h>
+#else
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #endif
 
 namespace libkineto::test {
 
-TempTraceFile::TempTraceFile(std::string_view prefix, std::string_view suffix) {
-  std::string nameTemplate;
-  nameTemplate.reserve(5 + prefix.size() + 6 + suffix.size());
-  nameTemplate += "/tmp/";
-  nameTemplate += prefix;
-  nameTemplate += "XXXXXX";
-  nameTemplate += suffix;
+namespace {
 
-  const int fd = mkstemps(nameTemplate.data(), static_cast<int>(suffix.size()));
-  if (fd < 0) {
-    KINETO_THROW(std::runtime_error, "mkstemps failed for " + nameTemplate);
+// Creates path only if nothing is there yet, which is the property mkstemps
+// provides for the name it settles on. Returns false when the name is already
+// taken so the caller can pick another, and swallows every other failure the
+// same way: the caller reports after exhausting its attempts.
+bool createExclusive(const std::string& path) {
+#ifdef _WIN32
+  int fd = -1;
+  const errno_t err = _sopen_s(
+      &fd,
+      path.c_str(),
+      _O_CREAT | _O_EXCL | _O_RDWR,
+      _SH_DENYNO,
+      _S_IREAD | _S_IWRITE);
+  if (err != 0) {
+    return false;
   }
-  close(fd);
-  path_ = std::move(nameTemplate);
+  _close(fd);
+#else
+  const int fd =
+      ::open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
+  if (fd < 0) {
+    return false;
+  }
+  ::close(fd);
+#endif
+  return true;
+}
+
+// Stands in for the six X characters mkstemps replaces. Uniqueness does not
+// rest on this being unpredictable: exclusive creation is what guarantees the
+// caller owns the file, and this only has to keep collisions rare.
+std::string randomNameComponent() {
+  static constexpr std::string_view kChars =
+      "abcdefghijklmnopqrstuvwxyz0123456789";
+  static thread_local std::mt19937 engine{std::random_device{}()};
+  std::uniform_int_distribution<size_t> pick(0, kChars.size() - 1);
+
+  std::string component(6, '\0');
+  for (char& c : component) {
+    c = kChars[pick(engine)];
+  }
+  return component;
+}
+
+void removeQuietly(const std::string& path) {
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
+} // namespace
+
+TempTraceFile::TempTraceFile(std::string_view prefix, std::string_view suffix) {
+  const std::filesystem::path dir = std::filesystem::temp_directory_path();
+
+  // Bounded so that a temp directory we cannot write to reports that instead
+  // of spinning. Reaching the limit on collisions alone is not realistic.
+  constexpr int kMaxAttempts = 100;
+  for (int attempt = 0; attempt < kMaxAttempts; ++attempt) {
+    std::string name;
+    name.reserve(prefix.size() + 6 + suffix.size());
+    name += prefix;
+    name += randomNameComponent();
+    name += suffix;
+
+    // generic_string keeps forward slashes on Windows, which its file APIs
+    // accept. Callers hand this path to Kineto as a log file and read it back
+    // out of trace JSON, and a separator that needs no escaping travels
+    // through both unchanged.
+    const std::string candidate = (dir / name).generic_string();
+    if (createExclusive(candidate)) {
+      path_ = candidate;
+      return;
+    }
+  }
+
+  KINETO_THROW(
+      std::runtime_error,
+      "could not create a temporary trace file under " + dir.generic_string());
 }
 
 TempTraceFile::~TempTraceFile() {
   if (!path_.empty()) {
-    unlink(path_.c_str());
+    removeQuietly(path_);
   }
 }
 
@@ -55,7 +127,7 @@ TempTraceFile::TempTraceFile(TempTraceFile&& other) noexcept
 TempTraceFile& TempTraceFile::operator=(TempTraceFile&& other) noexcept {
   if (this != &other) {
     if (!path_.empty()) {
-      unlink(path_.c_str());
+      removeQuietly(path_);
     }
     path_ = std::move(other.path_);
     other.path_.clear();

--- a/libkineto/test/TestUtils.h
+++ b/libkineto/test/TestUtils.h
@@ -17,13 +17,14 @@ namespace libkineto::test {
 // Owns a uniquely-named temporary file for a test to write a trace into. The
 // file is created and its descriptor immediately closed on construction, and
 // the file is removed when the owner goes out of scope, so tests never leak
-// files under /tmp.
+// files into the temporary directory.
 class TempTraceFile {
  public:
-  // Creates a file named /tmp/<prefix>XXXXXX<suffix>, where mkstemps replaces
-  // the six X characters with a unique component. suffix is preserved after
-  // that component so callers can keep a .json extension; pass an empty suffix
-  // for a name that ends in the random component.
+  // Creates a file named <prefix><random><suffix> in the system temporary
+  // directory, where random is six characters chosen so the name is free.
+  // suffix is preserved after that component so callers can keep a .json
+  // extension; pass an empty suffix for a name that ends in the random
+  // component. The path uses forward slashes on every platform.
   explicit TempTraceFile(std::string_view prefix, std::string_view suffix);
   ~TempTraceFile();
 


### PR DESCRIPTION
More work in support of upstreaming Kineto to PyTorch: https://github.com/pytorch/kineto/issues/1478

**Problem** — Five tests are excluded from Windows builds for one reason: they compile `TestUtils.cpp`, which creates temporary trace files with mkstemps from unix "unistd.h". MSVC has neither. PyTorch's CI does build C++ tests on Windows, so that exclusion is coverage we would rather not carry over.

**Approach** — Replace mkstemps with the same guarantee assembled from portable pieces: pick a name in `std::filesystem::temp_directory_path`, create it with `O_EXCL` (`_O_EXCL` on Windows), and retry on collision. Exclusive creation is the property that mattered; the random component only has to keep retries rare. Removal moves to `std::filesystem::remove`, so the only conditional code left is the one call that creates a file without racing.

Paths are built with `std::filesystem::path::generic_string()`, so they use forward slashes on Windows too. Callers pass them to Kineto as log files and read them back out of trace JSON, and a separator that needs no escaping survives both.

Four tests come off the Windows exclusion list:
`ActivityProfilerControllerTest`, `AsyncActivityProfilerHandlerTest`, `OutputJsonTest`, and `CuptiActivityProfilerTest`.

Two tests stay excluded for reasons that are not `TestUtils`, and the CMakeLists now says which is which per test rather than attributing all of them to `unistd.h`.
1. `AsyncE2ECpuTraceTest` drives an on-demand config, and `Config` only accepts on-demand trace files under a directory defaulting to `/tmp`.
2. `ConfigLoaderPollThreadExceptionTest` calls `setenv`.
 
Two more, `SyncActivityProfilerHandlerTest` and `GenericActivityProfilerTeardownTest`, use nothing Unix-specific at all but have never been built on Windows; enabling those deserves its own change and its own Windows run.

Because we don't have Windows tests in Kineto, bumping the submodule hash in PyTorch will be the real test.