### PR TITLE
Fix a ConfigLoaderTest flake and three poll-thread bugs it uncovered

### DIFF
--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -80,8 +80,10 @@ std::string ConfigLoader::readOnDemandConfigFromDaemon() {
 
 ConfigLoader::ConfigLoader()
     : configUpdateIntervalSecs_(kConfigUpdateIntervalSecs),
-      // on-demand config will be overwritten by the value read from the regular
-      // config so the initial value is not important
+      // Placeholder only. The poll loop replaces this on its first pass, which
+      // always runs the base-config branch, so the value here never governs a
+      // real poll - but keep it a sane duration rather than zero, since it is
+      // what a loop that somehow skipped that branch would fall back to.
       onDemandConfigUpdateIntervalSecs_(kConfigUpdateIntervalSecs),
       stopFlag_(false) {}
 
@@ -139,11 +141,10 @@ bool ConfigLoader::waitForUpdateThreadLoopCountForTesting(
 }
 
 std::chrono::seconds ConfigLoader::onDemandConfigUpdateIntervalForTesting() {
-  std::scoped_lock lock(configLock_);
-  // config_ is the authoritative source; updateConfigThread caches its value
-  // into onDemandConfigUpdateIntervalSecs_ on each base-config refresh.
-  return config_ ? config_->onDemandConfigUpdateIntervalSecs()
-                 : onDemandConfigUpdateIntervalSecs_;
+  // Reports the cached cadence rather than config_'s, because that is the one
+  // the poll loop schedules against. The two agree once the loop has made a
+  // base-config pass.
+  return onDemandConfigUpdateIntervalSecs_.load();
 }
 
 ConfigLoader::~ConfigLoader() {
@@ -247,10 +248,10 @@ void ConfigLoader::updateConfigThread() {
   // This can potentially sleep for long periods of time, so allow
   // the destructor to wake it to avoid a 5-minute long destruct period.
   for (;;) {
-    auto interval =
-        std::min(
-            configUpdateIntervalSecs_ + prev_config_load_time,
-            onDemandConfigUpdateIntervalSecs_ + prev_on_demand_load_time) -
+    auto interval = std::min(
+                        configUpdateIntervalSecs_ + prev_config_load_time,
+                        onDemandConfigUpdateIntervalSecs_.load() +
+                            prev_on_demand_load_time) -
         steady_clock::now();
     if (interval.count() > 0) {
       std::unique_lock<std::mutex> lock(updateThreadMutex_);
@@ -274,15 +275,21 @@ void ConfigLoader::updateConfigThread() {
       prev_config_load_time = now;
       try {
         updateBaseConfig();
-        onDemandConfigUpdateIntervalSecs_ =
-            config_->onDemandConfigUpdateIntervalSecs();
       } catch (const std::exception& e) {
         LOG(ERROR) << "Skipping base config update after error: " << e.what();
       } catch (...) {
         LOG(ERROR) << "Skipping base config update after unknown error";
       }
+      // Outside the guard on purpose. A failed reload leaves the previous
+      // config in force, and its cadence is the one to keep polling at; taking
+      // this refresh with the reload would instead strand the interval at the
+      // placeholder the constructor starts it on, which is the base-config
+      // period and far slower than any on-demand config asks for.
+      onDemandConfigUpdateIntervalSecs_ =
+          config_->onDemandConfigUpdateIntervalSecs();
     }
-    if (now > prev_on_demand_load_time + onDemandConfigUpdateIntervalSecs_) {
+    if (now >
+        prev_on_demand_load_time + onDemandConfigUpdateIntervalSecs_.load()) {
       prev_on_demand_load_time = now;
       onDemandConfig = std::make_unique<Config>();
       try {

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -70,8 +70,7 @@ ConfigLoader& ConfigLoader::instance() {
 }
 
 // return an empty string if polling gets any errors. Otherwise a config string.
-std::string ConfigLoader::readOnDemandConfigFromDaemon(
-    [[maybe_unused]] time_point<system_clock> now) {
+std::string ConfigLoader::readOnDemandConfigFromDaemon() {
   if (!daemonConfigLoader_) {
     return "";
   }
@@ -208,10 +207,8 @@ void ConfigLoader::updateBaseConfig() {
   }
 }
 
-void ConfigLoader::configureFromDaemon(
-    time_point<system_clock> now,
-    Config& config) {
-  const std::string config_str = readOnDemandConfigFromDaemon(now);
+void ConfigLoader::configureFromDaemon(Config& config) {
+  const std::string config_str = readOnDemandConfigFromDaemon();
   if (config_str.empty()) {
     return;
   }
@@ -236,9 +233,14 @@ void ConfigLoader::updateConfigThread() {
   // They have different update intervals (on demand is more frequent).
   // Besides, on-demand update frequency can be configured via base config.
 
+  // Poll cadence is measured on the steady clock. These deadlines are pure
+  // elapsed-time arithmetic, and the wall clock can jump - an NTP correction
+  // that moves it backwards would otherwise hold off the next reload for the
+  // size of the jump.
+  //
   // initialze with some time buffer in the past
   auto prev_config_load_time =
-      system_clock::now() - configUpdateIntervalSecs_ * 2;
+      steady_clock::now() - configUpdateIntervalSecs_ * 2;
   auto prev_on_demand_load_time = prev_config_load_time;
   auto onDemandConfig = std::make_unique<Config>();
 
@@ -249,7 +251,7 @@ void ConfigLoader::updateConfigThread() {
         std::min(
             configUpdateIntervalSecs_ + prev_config_load_time,
             onDemandConfigUpdateIntervalSecs_ + prev_on_demand_load_time) -
-        system_clock::now();
+        steady_clock::now();
     if (interval.count() > 0) {
       std::unique_lock<std::mutex> lock(updateThreadMutex_);
       // Waiting on the stop flag rather than the bare timeout closes a lost
@@ -263,7 +265,7 @@ void ConfigLoader::updateConfigThread() {
     if (stopFlag_) {
       break;
     }
-    auto now = system_clock::now();
+    auto now = steady_clock::now();
     // This runs on a bare background thread: an escaped exception would
     // terminate the process, so config-update failures are caught and skipped.
     // Advance the load timestamps before the guarded work so a persistent
@@ -284,7 +286,7 @@ void ConfigLoader::updateConfigThread() {
       prev_on_demand_load_time = now;
       onDemandConfig = std::make_unique<Config>();
       try {
-        configureFromDaemon(now, *onDemandConfig);
+        configureFromDaemon(*onDemandConfig);
       } catch (const std::exception& e) {
         LOG(ERROR) << "Skipping on-demand config update after error: "
                    << e.what();

--- a/libkineto/src/ConfigLoader.cpp
+++ b/libkineto/src/ConfigLoader.cpp
@@ -252,7 +252,13 @@ void ConfigLoader::updateConfigThread() {
         system_clock::now();
     if (interval.count() > 0) {
       std::unique_lock<std::mutex> lock(updateThreadMutex_);
-      updateThreadCondVar_.wait_for(lock, interval);
+      // Waiting on the stop flag rather than the bare timeout closes a lost
+      // wakeup: stopThread() raises the flag before it notifies, so a notify
+      // that lands while this thread is still on its way into the wait would
+      // otherwise go unheard and hold the join for a full interval - the very
+      // stall the comment above says the notify exists to avoid.
+      updateThreadCondVar_.wait_for(
+          lock, interval, [this] { return stopFlag_.load(); });
     }
     if (stopFlag_) {
       break;

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -146,12 +146,9 @@ class ConfigLoader {
   void updateBaseConfig();
 
   // Create configuration when receiving request from a daemon
-  void configureFromDaemon(
-      std::chrono::time_point<std::chrono::system_clock> now,
-      Config& config);
+  void configureFromDaemon(Config& config);
 
-  std::string readOnDemandConfigFromDaemon(
-      std::chrono::time_point<std::chrono::system_clock> now);
+  std::string readOnDemandConfigFromDaemon();
 
   const char* customConfigFileName();
 

--- a/libkineto/src/ConfigLoader.h
+++ b/libkineto/src/ConfigLoader.h
@@ -130,8 +130,9 @@ class ConfigLoader {
   void resetBaseConfigForTesting();
 
   // Test-only. Returns the on-demand poll interval the background thread is
-  // currently using, taken from the loaded base config. Lets a test size a
-  // timeout to the live cadence instead of assuming the default.
+  // currently scheduling against. Lets a test size a timeout to the live
+  // cadence instead of assuming the default, and lets one check that a failed
+  // base-config reload still leaves a sane cadence behind.
   std::chrono::seconds onDemandConfigUpdateIntervalForTesting();
 
  private:
@@ -158,7 +159,11 @@ class ConfigLoader {
   std::map<ConfigKind, std::vector<ConfigHandler*>> handlers_;
 
   std::chrono::seconds configUpdateIntervalSecs_;
-  std::chrono::seconds onDemandConfigUpdateIntervalSecs_;
+
+  // Cadence the poll loop reads the on-demand config at, refreshed from the
+  // base config on every base-config pass. Atomic so a test can read the live
+  // cadence while the poll thread runs.
+  std::atomic<std::chrono::seconds> onDemandConfigUpdateIntervalSecs_;
   std::unique_ptr<std::thread> updateThread_;
   std::condition_variable updateThreadCondVar_;
   std::mutex updateThreadMutex_;

--- a/libkineto/test/ConfigLoaderPollThreadExceptionTest.cpp
+++ b/libkineto/test/ConfigLoaderPollThreadExceptionTest.cpp
@@ -123,6 +123,16 @@ TEST(ConfigLoaderPollThreadExceptionTest, ConfigUpdateExceptionDoesNotCrash) {
   // (no std::terminate) also shows the on-demand branch caught it.
   ASSERT_TRUE(onDemandReached->waitFor(std::chrono::seconds(30)))
       << "poll thread did not survive the base-config exception";
+
+  // The failed reload leaves the default base config in force, so the loop must
+  // poll at that config's cadence. Refreshing the cadence only on a successful
+  // reload would stand it at the constructor's placeholder -- the base-config
+  // period, minutes rather than seconds -- and quietly throttle on-demand
+  // polling on any host whose base-config reads keep failing.
+  // Compared as counts so a failure reports seconds instead of a byte dump.
+  EXPECT_EQ(
+      ConfigLoader::instance().onDemandConfigUpdateIntervalForTesting().count(),
+      Config().onDemandConfigUpdateIntervalSecs().count());
 }
 
 } // namespace

--- a/libkineto/test/ConfigLoaderTest.cpp
+++ b/libkineto/test/ConfigLoaderTest.cpp
@@ -284,13 +284,14 @@ TEST_F(ConfigLoaderTest, ThreadPollsDaemonAndDispatchesOnDemandConfig) {
 // The thread re-polls the on-demand config on its update cadence, so over a
 // couple of intervals it reads the daemon more than once.
 //
-// This waits on the probe's read count rather than the thread's iteration
-// counter. An iteration can complete without reading: the thread wakes from a
-// wait_for measured against the steady clock, then gates the read on a
-// system_clock deadline, so a spurious wakeup or a small divergence between the
-// two clocks leaves it a hair short of the deadline. It skips the read, bumps
-// the iteration counter, and reads on the following iteration instead. Waiting
-// for two iterations therefore does not mean two reads have happened.
+// This waits on the probe's read count, not the thread's iteration counter:
+// the counter tracks loop passes, and a pass need not read. The loop serves a
+// base-config deadline and an on-demand deadline, sleeping until whichever
+// falls first, so a pass woken for the base config finds the on-demand
+// deadline still ahead and reads nothing. A pass woken for the on-demand
+// deadline can skip it too, since the wait only promises to reach that
+// deadline while the read is gated on having passed it. The counter advances
+// either way, so waiting for two passes would not mean two reads happened.
 //
 // This runs at the real cadence, so it takes a few seconds. It cannot be sped
 // up by injecting a smaller ON_DEMAND_CONFIG_UPDATE_INTERVAL_SECS via the fake

--- a/libkineto/test/ConfigLoaderTest.cpp
+++ b/libkineto/test/ConfigLoaderTest.cpp
@@ -9,8 +9,10 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -50,12 +52,42 @@ struct RecordingConfigHandler : ConfigLoader::ConfigHandler {
 };
 
 // Canned daemon responses and recorded queries. Owned by the test; the fake
-// below holds a reference to it. The poll thread writes the recorded fields, so
-// a test reads them only after stopping (joining) the thread.
+// below holds a reference to it.
+//
+// The poll thread writes the recorded fields under mutex_, which also lets a
+// test block until a given number of reads have happened. Waiting on reads is
+// the only sound way to observe poll cadence: the thread's iteration counter
+// advances once per loop whether or not that loop read the on-demand config, so
+// a test that waits for two iterations may still have seen one read. Fields
+// read after the thread is stopped (joined) need no lock.
 struct DaemonPollProbe {
   std::string onDemandConfig;
   int readOnDemandCalls{0};
   bool lastActivitiesRequested{false};
+
+  // Called by the fake on the poll thread for every on-demand read.
+  void recordRead(bool activities) {
+    {
+      std::scoped_lock lock(mutex_);
+      ++readOnDemandCalls;
+      lastActivitiesRequested = activities;
+    }
+    readCondVar_.notify_all();
+  }
+
+  // Blocks until the daemon has been read at least target times or the timeout
+  // elapses. Returns false on timeout.
+  [[nodiscard]] bool waitForReads(
+      int target,
+      std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return readCondVar_.wait_for(
+        lock, timeout, [this, target] { return readOnDemandCalls >= target; });
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable readCondVar_;
 };
 
 // Stands in for the dynolog IPC config source, so the real background poll
@@ -69,8 +101,7 @@ class FakeDaemonConfigLoader : public IDaemonConfigLoader {
   }
 
   std::string readOnDemandConfig(bool activities) override {
-    ++probe_.readOnDemandCalls;
-    probe_.lastActivitiesRequested = activities;
+    probe_.recordRead(activities);
     return probe_.onDemandConfig;
   }
 
@@ -86,7 +117,9 @@ class FakeDaemonConfigLoader : public IDaemonConfigLoader {
 //     (started by addHandler) reads nothing and never calls the handlers.
 //   * Daemon-poll tests install a FakeDaemonConfigLoader factory, start the
 //     real poll thread, and wait on the thread's iteration counter to observe
-//     real poll iterations deterministically.
+//     real poll iterations deterministically. A test that asserts on poll
+//     cadence waits on DaemonPollProbe::waitForReads instead; see the comment
+//     on startPollingAndWait for where the iteration counter is sound.
 // The singleton persists across tests, so TearDown stops the thread, drops the
 // injected loader, clears the factory, and unregisters handlers.
 class ConfigLoaderTest : public ::testing::Test {
@@ -120,6 +153,13 @@ class ConfigLoaderTest : public ::testing::Test {
   // Registers handler as an ActivityProfiler handler (which starts the poll
   // thread) and blocks until the thread has completed loops iterations.
   // Returns false if that count is not reached before the timeout.
+  //
+  // Callers pass loops=1 and may then assume the daemon was read once: a fresh
+  // thread backdates both load deadlines well into the past, so its first
+  // iteration always reloads the base config and reads the on-demand config
+  // with no wait. That reasoning does not extend to later iterations, which
+  // read only if their deadline has genuinely passed. A test that needs a
+  // second read waits on DaemonPollProbe::waitForReads.
   [[nodiscard]] bool startPollingAndWait(
       RecordingConfigHandler& handler,
       uint64_t loops) {
@@ -244,6 +284,14 @@ TEST_F(ConfigLoaderTest, ThreadPollsDaemonAndDispatchesOnDemandConfig) {
 // The thread re-polls the on-demand config on its update cadence, so over a
 // couple of intervals it reads the daemon more than once.
 //
+// This waits on the probe's read count rather than the thread's iteration
+// counter. An iteration can complete without reading: the thread wakes from a
+// wait_for measured against the steady clock, then gates the read on a
+// system_clock deadline, so a spurious wakeup or a small divergence between the
+// two clocks leaves it a hair short of the deadline. It skips the read, bumps
+// the iteration counter, and reads on the following iteration instead. Waiting
+// for two iterations therefore does not mean two reads have happened.
+//
 // This runs at the real cadence, so it takes a few seconds. It cannot be sped
 // up by injecting a smaller ON_DEMAND_CONFIG_UPDATE_INTERVAL_SECS via the fake
 // daemon's base config: updateBaseConfig reads the local config file first and
@@ -257,21 +305,19 @@ TEST_F(ConfigLoaderTest, ThreadRepeatedlyPollsOnDemandConfig) {
   installFakeDaemon(probe);
 
   RecordingConfigHandler handler;
-  const uint64_t base = loader().updateThreadLoopCountForTesting();
   registerHandler(ConfigLoader::ConfigKind::ActivityProfiler, &handler);
 
-  // The first poll is immediate; after it, the thread's on-demand interval
-  // reflects the loaded base config. Size the wait for the second poll to that
-  // live interval (with slack) so a host that configured a larger interval does
-  // not cause a spurious timeout.
-  ASSERT_TRUE(waitForLoopCount(base + 1));
+  // The first read is immediate; the iteration that performs it loads the base
+  // config first, so once it lands the thread's on-demand interval reflects
+  // that config. Size the wait for the second read to that live interval (with
+  // slack) so a host that configured a larger interval does not cause a
+  // spurious timeout.
+  ASSERT_TRUE(probe.waitForReads(1));
   const auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(
       loader().onDemandConfigUpdateIntervalForTesting() * 3 +
       std::chrono::seconds(5));
-  ASSERT_TRUE(waitForLoopCount(base + 2, timeout));
+  EXPECT_TRUE(probe.waitForReads(2, timeout));
   loader().stopUpdateThread();
-
-  EXPECT_GE(probe.readOnDemandCalls, 2);
 }
 
 // An empty on-demand response (no config posted) dispatches nothing.


### PR DESCRIPTION
Chasing an intermittent `ConfigLoaderTest` failure on Mac CI turned up four real
defects:

### 1. `ConfigLoaderTest.ThreadRepeatedlyPollsOnDemandConfig` flake

**Problem** — The test asserts the poll thread read the on-demand config twice,
but waits on the thread's loop counter to decide when to look. The counter
advances once per iteration whether or not that iteration polled. An iteration
that wakes a hair short of its deadline skips the read, bumps the counter anyway,
and polls on the next pass. The test wakes on the bumped counter, stops the
thread, and finds one read.

**Fix** — Wait on the read count the test actually asserts, using the handshake
pattern `ConfigLoaderPollThreadExceptionTest` already uses.

### 2. Lost wakeup on shutdown

**Problem** — `stopUpdateThread()` can block for the whole poll interval, up to
300 seconds. The stopper raises the flag then notifies, but the loop waits on a
bare timeout and only tests the flag after waking, so a notify that lands while
the thread is still on its way into the wait is dropped. This is the stall the
loop's own comment says the notify exists to prevent. It is intermittent — the
same binary tore down instantly on one run and took 300.01 s on the next.

**Fix** — Give the wait a predicate on the stop flag. Full `ctest` drops from
300 s to 5 s.

### 3. Poll cadence on the wall clock

**Problem** — The loop times its reload deadlines against `system_clock`, which
is not monotonic. A backward NTP step holds off both reloads for the size of the
step. At small scale, the loop sleeps on a condition variable measured against
the steady clock and then compares wall-clock timestamps — the drift between the
two is what produces the flake in 1.

**Fix** — Schedule on `steady_clock`, the clock the condition variable already
uses. An unused `system_clock` parameter on the daemon path goes with it.

### 4. Cadence lost after a failed base-config reload

**Problem** — When a base-config reload throws, on-demand polling drops to once
every 300 seconds instead of every 5, because the cadence refresh sits inside the
same `try` block as the reload. On a host whose base-config reads keep failing,
profiling requests sit unnoticed for minutes.

**Fix** — Refresh the cadence after the guard. A failed reload leaves the
previous config in force, and that config's cadence is the one to keep polling
at.

### Testing

82/82 tests pass, suite wall time 300 s → 5 s. The flaky test survives 30
isolated-process runs and 15 single-process suite runs. Each fix was confirmed to
fail without it: forcing the poll thread to wake at half its interval reproduces
the CI failure exactly against the old test, and the new cadence assertion
reports 300 against the old ordering.
