### PR TITLE
[Kineto] Add a couple of PM Sampling API fixes

### DIFF
--- a/libkineto/src/CuptiPMSamplingApi.cpp
+++ b/libkineto/src/CuptiPMSamplingApi.cpp
@@ -13,6 +13,7 @@
 #include <cuda_runtime_api.h>
 #include <cupti_pmsampling.h>
 #include <cupti_profiler_host.h>
+#include <cupti_profiler_target.h>
 #include <cupti_target.h>
 
 #include "DeviceUtil.h"
@@ -88,14 +89,16 @@ constexpr uint32_t kMaxSamplesPerDecode = 1024;
 
 CuptiPMSamplingApi::~CuptiPMSamplingApi() {
   disable();
-  if (samplingObject_ != nullptr || hostObject_ != nullptr) {
+  if (samplingObject_ != nullptr || hostObject_ != nullptr ||
+      profilerInitialized_) {
     LOG(WARNING) << "CUPTI PM sampling cleanup failed during destruction; "
                     "CUPTI resources may leak";
   }
 }
 
 void CuptiPMSamplingApi::configure(const CuptiPMSamplingConfig& config) {
-  if (samplingObject_ != nullptr || hostObject_ != nullptr) {
+  if (samplingObject_ != nullptr || hostObject_ != nullptr ||
+      profilerInitialized_) {
     KINETO_THROW(
         std::runtime_error,
         "Cannot configure CUPTI PM sampling after cleanup failed");
@@ -126,6 +129,11 @@ void CuptiPMSamplingApi::ensureConfigured() const {
 }
 
 void CuptiPMSamplingApi::configureCupti() {
+  CUpti_Profiler_Initialize_Params params{
+      CUpti_Profiler_Initialize_Params_STRUCT_SIZE};
+  CUPTI_CALL_THROW(cuptiProfilerInitialize(&params));
+  profilerInitialized_ = true;
+
   // CUpti_Device_GetChipName_Params stores device info used in other CUPTI
   // calls.
   CUpti_Device_GetChipName_Params chip{
@@ -203,12 +211,12 @@ void CuptiPMSamplingApi::configureCupti() {
   size.pHostObject = hostObject_;
   CUPTI_CALL_THROW(cuptiProfilerHostGetConfigImageSize(&size));
 
-  std::vector<uint8_t> configImage(size.configImageSize);
+  configImage_.resize(size.configImageSize);
   CUpti_Profiler_Host_GetConfigImage_Params image{
       CUpti_Profiler_Host_GetConfigImage_Params_STRUCT_SIZE};
   image.pHostObject = hostObject_;
-  image.configImageSize = configImage.size();
-  image.pConfigImage = configImage.data();
+  image.configImageSize = configImage_.size();
+  image.pConfigImage = configImage_.data();
   CUPTI_CALL_THROW(cuptiProfilerHostGetConfigImage(&image));
 
   // Asking CUPTI how many passes it will take to fetch the requested metrics.
@@ -216,8 +224,8 @@ void CuptiPMSamplingApi::configureCupti() {
   // case.
   CUpti_Profiler_Host_GetNumOfPasses_Params passes{
       CUpti_Profiler_Host_GetNumOfPasses_Params_STRUCT_SIZE};
-  passes.configImageSize = configImage.size();
-  passes.pConfigImage = configImage.data();
+  passes.configImageSize = configImage_.size();
+  passes.pConfigImage = configImage_.data();
   CUPTI_CALL_THROW(cuptiProfilerHostGetNumOfPasses(&passes));
   if (passes.numOfPasses != 1) {
     KINETO_THROW(
@@ -236,8 +244,8 @@ void CuptiPMSamplingApi::configureCupti() {
   CUpti_PmSampling_SetConfig_Params setConfig{
       CUpti_PmSampling_SetConfig_Params_STRUCT_SIZE};
   setConfig.pPmSamplingObject = samplingObject_;
-  setConfig.configSize = configImage.size();
-  setConfig.pConfig = configImage.data();
+  setConfig.configSize = configImage_.size();
+  setConfig.pConfig = configImage_.data();
   setConfig.hardwareBufferSize = kHardwareBufferSizeBytes;
   setConfig.samplingInterval =
       static_cast<uint64_t>(config_.samplingInterval.count());
@@ -324,15 +332,19 @@ bool CuptiPMSamplingApi::decode(std::vector<CuptiPMSample>& samples) {
 
   const auto reason = decode.decodeStopReason;
   bool isBufferDrained;
-  if (reason == CUPTI_PM_SAMPLING_DECODE_STOP_REASON_END_OF_RECORDS) {
-    isBufferDrained = true;
-  } else if (reason == CUPTI_PM_SAMPLING_DECODE_STOP_REASON_COUNTER_DATA_FULL) {
-    isBufferDrained = false;
-  } else {
-    KINETO_THROW(
-        std::runtime_error,
-        "cuptiPmSamplingDecodeData returned unexpected stop reason " +
-            std::to_string(static_cast<int>(reason)));
+  switch (reason) {
+    case CUPTI_PM_SAMPLING_DECODE_STOP_REASON_OTHER:
+    case CUPTI_PM_SAMPLING_DECODE_STOP_REASON_COUNTER_DATA_FULL:
+      isBufferDrained = false;
+      break;
+    case CUPTI_PM_SAMPLING_DECODE_STOP_REASON_END_OF_RECORDS:
+      isBufferDrained = true;
+      break;
+    default:
+      KINETO_THROW(
+          std::runtime_error,
+          "cuptiPmSamplingDecodeData returned unexpected stop reason " +
+              std::to_string(static_cast<int>(reason)));
   }
 
   CUpti_PmSampling_GetCounterDataInfo_Params info{
@@ -363,23 +375,30 @@ void CuptiPMSamplingApi::disable() {
     CUpti_PmSampling_Disable_Params params{
         CUpti_PmSampling_Disable_Params_STRUCT_SIZE};
     params.pPmSamplingObject = samplingObject_;
-    if (CUPTI_CALL(cuptiPmSamplingDisable(&params)) == CUPTI_SUCCESS) {
-      samplingObject_ = nullptr;
+    if (CUPTI_CALL(cuptiPmSamplingDisable(&params)) != CUPTI_SUCCESS) {
+      return;
     }
+    samplingObject_ = nullptr;
   }
   if (hostObject_ != nullptr) {
     CUpti_Profiler_Host_Deinitialize_Params params{
         CUpti_Profiler_Host_Deinitialize_Params_STRUCT_SIZE};
     params.pHostObject = hostObject_;
-    if (CUPTI_CALL(cuptiProfilerHostDeinitialize(&params)) == CUPTI_SUCCESS) {
-      hostObject_ = nullptr;
+    if (CUPTI_CALL(cuptiProfilerHostDeinitialize(&params)) != CUPTI_SUCCESS) {
+      return;
     }
+    hostObject_ = nullptr;
+  }
+  if (profilerInitialized_) {
+    CUpti_Profiler_DeInitialize_Params params{
+        CUpti_Profiler_DeInitialize_Params_STRUCT_SIZE};
+    if (CUPTI_CALL(cuptiProfilerDeInitialize(&params)) != CUPTI_SUCCESS) {
+      return;
+    }
+    profilerInitialized_ = false;
   }
 
-  // Retain handles on failure so cleanup can be retried
-  if (samplingObject_ != nullptr || hostObject_ != nullptr) {
-    return;
-  }
+  configImage_.clear();
   counterDataImage_.clear();
   config_.deviceId = -1;
   metricNamePtrs_.clear();

--- a/libkineto/src/CuptiPMSamplingApi.cpp
+++ b/libkineto/src/CuptiPMSamplingApi.cpp
@@ -101,7 +101,8 @@ void CuptiPMSamplingApi::configure(const CuptiPMSamplingConfig& config) {
       profilerInitialized_) {
     KINETO_THROW(
         std::runtime_error,
-        "Cannot configure CUPTI PM sampling after cleanup failed");
+        "Cannot configure CUPTI PM sampling before the previous "
+        "configuration is fully disabled");
   }
   config_ = config;
 
@@ -371,6 +372,9 @@ void CuptiPMSamplingApi::stop() {
 }
 
 void CuptiPMSamplingApi::disable() {
+  // When releasing resources, stop at the first failure to avoid
+  // a partially torn-down configuration and preserve the remaining
+  // state for a later disable() retry.
   if (samplingObject_ != nullptr) {
     CUpti_PmSampling_Disable_Params params{
         CUpti_PmSampling_Disable_Params_STRUCT_SIZE};

--- a/libkineto/src/CuptiPMSamplingApi.h
+++ b/libkineto/src/CuptiPMSamplingApi.h
@@ -64,6 +64,9 @@ class CuptiPMSamplingApi {
   // lifetimes.
   CUpti_Profiler_Host_Object* hostObject_{nullptr};
   CUpti_PmSampling_Object* samplingObject_{nullptr};
+  bool profilerInitialized_{false};
+  // CUPTI retains this buffer until PM sampling is disabled.
+  std::vector<uint8_t> configImage_;
   std::vector<uint8_t> counterDataImage_;
 };
 


### PR DESCRIPTION
A couple of things came up during my e2e test of PM Sampling that need to be fixed:
1. We didn't call `cuptiProfilerInitialize` and `cuptiProfilerDeInitialize`. Originally I thought since we're hooking onto Activity profiling these come for free, but PM sampling uses the Profiler Target API which is not initialized when the Activity API is initialized.
2. We need to retain the counter config image as a class member and be careful about the destroy order, because CUPTI keeps the `pConfig` pointer and so freeing early or re-writing it would hang/segfault.
3. Accept `CUPTI_PM_SAMPLING_DECODE_STOP_REASON_OTHER` as a valid decode result. During testing we also found that an OTHER result still contains plenty of completed samples, but I can't find any docs on what exactly is encapsulated in an "OTHER" return result.

And we now have e2e runs that I can paste
<img width="1728" height="799" alt="image" src="https://github.com/user-attachments/assets/3b18e455-0b53-4fa6-9ea0-6c21649f91c2" />

Zooming in to show that the nvlink metrics seem to correlate well with the memcpy events:
<img width="1728" height="809" alt="image" src="https://github.com/user-attachments/assets/426174b1-f314-46a6-ae43-a26e67a34749" />

