### PR TITLE
(bugfix): CUPTI buffer rejection on v27+

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -56,9 +56,6 @@ inline void reenableCuptiCallbacks_(CuptiCallbackApi& cbapi) {
   }
 }
 
-CuptiActivityApi::CuptiActivityApi(uint32_t cuptiVersion)
-    : canRejectBuffer_(cuptiVersion >= kCuptiBufferRejectionMinVersion) {}
-
 CuptiActivityApi& CuptiActivityApi::singleton() {
   static auto* instance = new CuptiActivityApi();
   return *instance;
@@ -152,22 +149,21 @@ void CuptiActivityApi::bufferRequested(
   std::lock_guard<std::mutex> guard(mutex_);
   LOG(VERBOSE) << "CUPTI buffer requested";
 
-  *buffer = nullptr;
-  *size = 0;
-  *maxNumRecords = 0;
-
-  const auto retainedBufferCount = allocatedGpuTraceBuffers_.size() +
-      (readyGpuTraceBuffers_ ? readyGpuTraceBuffers_->size() : 0);
   if (!stopCollection &&
-      static_cast<int64_t>(retainedBufferCount) >= maxGpuBufferCount_) {
+      static_cast<int64_t>(allocatedGpuTraceBuffers_.size()) >=
+          maxGpuBufferCount_) {
     stopCollection = true;
-    LOG(WARNING) << "Exceeded max GPU buffer count (" << retainedBufferCount
+    LOG(WARNING) << "Exceeded max GPU buffer count ("
+                 << allocatedGpuTraceBuffers_.size()
                  << " >= " << maxGpuBufferCount_ << ") - terminating tracing";
   }
   // CUPTI fixed a crash when clients reject a buffer request in API v27
   // (CUDA 12.9). Older or unknown versions must receive a valid buffer while
   // the controller observes stopCollection and terminates tracing.
   if (stopCollection && canRejectBuffer_) {
+    *buffer = nullptr;
+    *size = 0;
+    *maxNumRecords = 0;
     return;
   }
 
@@ -176,6 +172,8 @@ void CuptiActivityApi::bufferRequested(
   *size = kBufSize;
 
   allocatedGpuTraceBuffers_[*buffer] = std::move(buf);
+
+  *maxNumRecords = 0;
 }
 
 std::unique_ptr<CuptiActivityBufferMap> CuptiActivityApi::activityBuffers() {
@@ -251,7 +249,6 @@ void CuptiActivityApi::clearActivities() {
   {
     std::lock_guard<std::mutex> guard(mutex_);
     if (allocatedGpuTraceBuffers_.empty()) {
-      readyGpuTraceBuffers_ = nullptr;
       return;
     }
   }

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -56,12 +56,8 @@ inline void reenableCuptiCallbacks_(CuptiCallbackApi& cbapi) {
   }
 }
 
-CuptiActivityApi::CuptiActivityApi() {
-  CUPTI_CALL(cuptiGetVersion(&cuptiVersion_));
-}
-
 CuptiActivityApi::CuptiActivityApi(uint32_t cuptiVersion)
-    : cuptiVersion_(cuptiVersion) {}
+    : canRejectBuffer_(cuptiVersion >= kCuptiBufferRejectionMinVersion) {}
 
 CuptiActivityApi& CuptiActivityApi::singleton() {
   static auto* instance = new CuptiActivityApi();
@@ -155,21 +151,24 @@ void CuptiActivityApi::bufferRequested(
     size_t* maxNumRecords) {
   std::lock_guard<std::mutex> guard(mutex_);
   LOG(VERBOSE) << "CUPTI buffer requested";
-  if (static_cast<int64_t>(allocatedGpuTraceBuffers_.size()) >=
-      maxGpuBufferCount_) {
+
+  *buffer = nullptr;
+  *size = 0;
+  *maxNumRecords = 0;
+
+  const auto retainedBufferCount = allocatedGpuTraceBuffers_.size() +
+      (readyGpuTraceBuffers_ ? readyGpuTraceBuffers_->size() : 0);
+  if (!stopCollection &&
+      static_cast<int64_t>(retainedBufferCount) >= maxGpuBufferCount_) {
     stopCollection = true;
-    LOG(WARNING) << "Exceeded max GPU buffer count ("
-                 << allocatedGpuTraceBuffers_.size()
+    LOG(WARNING) << "Exceeded max GPU buffer count (" << retainedBufferCount
                  << " >= " << maxGpuBufferCount_ << ") - terminating tracing";
-    // CUPTI fixed a crash when clients reject a buffer request in API v27
-    // (CUDA 12.9). Older or unknown versions must receive a valid buffer while
-    // the controller observes stopCollection and terminates tracing.
-    if (cuptiVersion_ >= kCuptiBufferRejectionMinVersion) {
-      *buffer = nullptr;
-      *size = 0;
-      *maxNumRecords = 0;
-      return;
-    }
+  }
+  // CUPTI fixed a crash when clients reject a buffer request in API v27
+  // (CUDA 12.9). Older or unknown versions must receive a valid buffer while
+  // the controller observes stopCollection and terminates tracing.
+  if (stopCollection && canRejectBuffer_) {
+    return;
   }
 
   auto buf = std::make_unique<CuptiActivityBuffer>(kBufSize);
@@ -177,8 +176,6 @@ void CuptiActivityApi::bufferRequested(
   *size = kBufSize;
 
   allocatedGpuTraceBuffers_[*buffer] = std::move(buf);
-
-  *maxNumRecords = 0;
 }
 
 std::unique_ptr<CuptiActivityBufferMap> CuptiActivityApi::activityBuffers() {
@@ -254,6 +251,7 @@ void CuptiActivityApi::clearActivities() {
   {
     std::lock_guard<std::mutex> guard(mutex_);
     if (allocatedGpuTraceBuffers_.empty()) {
+      readyGpuTraceBuffers_ = nullptr;
       return;
     }
   }
@@ -293,6 +291,12 @@ void CuptiActivityApi::bufferCompleted(
       return;
     }
 
+    if (stopCollection) {
+      // Discard returned buffers once tracing is terminating.
+      allocatedGpuTraceBuffers_.erase(it);
+      return;
+    }
+
     if (!readyGpuTraceBuffers_) {
       readyGpuTraceBuffers_ = std::make_unique<CuptiActivityBufferMap>();
     }
@@ -326,6 +330,15 @@ void CuptiActivityApi::enableCuptiActivities(
   auto& cbapi = CuptiCallbackApi::singleton();
   if ((tracingEnabled_ == 0u) && !cbapi.initSuccess() && cuptiLazyInit_()) {
     reenableCuptiCallbacks_(cbapi);
+  }
+
+  uint32_t cuptiVersion = 0;
+  CUPTI_CALL(cuptiGetVersion(&cuptiVersion));
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    canRejectBuffer_ = cuptiVersion >= kCuptiBufferRejectionMinVersion;
+    // Reset before callbacks can run for the new trace.
+    stopCollection = false;
   }
 
   if (enablePerThreadBuffers) {
@@ -391,9 +404,6 @@ void CuptiActivityApi::enableCuptiActivities(
   }
 
   tracingEnabled_ = 1;
-
-  // Explicitly enabled, so reset this flag if set
-  stopCollection = false;
 }
 
 void CuptiActivityApi::disableCuptiActivities(

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -25,6 +25,7 @@ namespace KINETO_NAMESPACE {
 // Given the kDefaultActivitiesMaxGpuBufferSize is around 128MB, in the worst
 // case, there will be 32 buffers contending for the mutex.
 constexpr size_t kBufSize(4 * 1024 * 1024);
+constexpr uint32_t kCuptiBufferRejectionMinVersion = 27;
 
 inline bool cuptiTearDown_() {
   auto teardown_env = getenv("TEARDOWN_CUPTI");
@@ -54,6 +55,13 @@ inline void reenableCuptiCallbacks_(CuptiCallbackApi& cbapi) {
         << "Re-enable previous CUPTI callbacks - Failed to initCallbackApi";
   }
 }
+
+CuptiActivityApi::CuptiActivityApi() {
+  CUPTI_CALL(cuptiGetVersion(&cuptiVersion_));
+}
+
+CuptiActivityApi::CuptiActivityApi(uint32_t cuptiVersion)
+    : cuptiVersion_(cuptiVersion) {}
 
 CuptiActivityApi& CuptiActivityApi::singleton() {
   static auto* instance = new CuptiActivityApi();
@@ -153,14 +161,15 @@ void CuptiActivityApi::bufferRequested(
     LOG(WARNING) << "Exceeded max GPU buffer count ("
                  << allocatedGpuTraceBuffers_.size()
                  << " >= " << maxGpuBufferCount_ << ") - terminating tracing";
-    // Return null buffer to CUPTI. Per the CUPTI documentation for
-    // CUpti_BuffersCallbackRequestFunc: "If set to NULL then no buffer is
-    // returned." CUPTI will drop activity records, which are counted by
-    // cuptiActivityGetNumDroppedRecords.
-    *buffer = nullptr;
-    *size = 0;
-    *maxNumRecords = 0;
-    return;
+    // CUPTI fixed a crash when clients reject a buffer request in API v27
+    // (CUDA 12.9). Older or unknown versions must receive a valid buffer while
+    // the controller observes stopCollection and terminates tracing.
+    if (cuptiVersion_ >= kCuptiBufferRejectionMinVersion) {
+      *buffer = nullptr;
+      *size = 0;
+      *maxNumRecords = 0;
+      return;
+    }
   }
 
   auto buf = std::make_unique<CuptiActivityBuffer>(kBufSize);

--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -157,9 +157,8 @@ void CuptiActivityApi::bufferRequested(
                  << allocatedGpuTraceBuffers_.size()
                  << " >= " << maxGpuBufferCount_ << ") - terminating tracing";
   }
-  // CUPTI fixed a crash when clients reject a buffer request in API v27
-  // (CUDA 12.9). Older or unknown versions must receive a valid buffer while
-  // the controller observes stopCollection and terminates tracing.
+  // Rejecting buffers can crash CUPTI before API v27 (CUDA 12.9), so older or
+  // unknown versions must receive valid buffers until tracing terminates.
   if (stopCollection && canRejectBuffer_) {
     *buffer = nullptr;
     *size = 0;
@@ -288,8 +287,8 @@ void CuptiActivityApi::bufferCompleted(
       return;
     }
 
-    if (stopCollection) {
-      // Discard returned buffers once tracing is terminating.
+    if (stopCollection && !canRejectBuffer_) {
+      // Prevent buffers from accumulating when CUPTI cannot reject them.
       allocatedGpuTraceBuffers_.erase(it);
       return;
     }

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -35,7 +35,7 @@ class CuptiActivityApi {
   std::mutex finalizeMutex_;
   std::condition_variable finalizeCond_;
 
-  CuptiActivityApi();
+  CuptiActivityApi() = default;
   CuptiActivityApi(const CuptiActivityApi&) = delete;
   CuptiActivityApi& operator=(const CuptiActivityApi&) = delete;
 
@@ -74,7 +74,7 @@ class CuptiActivityApi {
   static void preConfigureCUPTI();
 
  private:
-  uint32_t cuptiVersion_{0};
+  bool canRejectBuffer_{false};
   int64_t maxGpuBufferCount_{0};
   CuptiActivityBufferMap allocatedGpuTraceBuffers_;
   std::unique_ptr<CuptiActivityBufferMap> readyGpuTraceBuffers_;

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -74,7 +74,6 @@ class CuptiActivityApi {
   static void preConfigureCUPTI();
 
  private:
-  bool canRejectBuffer_{false};
   int64_t maxGpuBufferCount_{0};
   CuptiActivityBufferMap allocatedGpuTraceBuffers_;
   std::unique_ptr<CuptiActivityBufferMap> readyGpuTraceBuffers_;
@@ -99,7 +98,7 @@ class CuptiActivityApi {
       size_t validSize);
 
  protected:
-  explicit CuptiActivityApi(uint32_t cuptiVersion);
+  bool canRejectBuffer_{false};
   void bufferRequested(uint8_t** buffer, size_t* size, size_t* maxNumRecords);
   void bufferCompleted(
       CUcontext ctx,

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -35,7 +35,7 @@ class CuptiActivityApi {
   std::mutex finalizeMutex_;
   std::condition_variable finalizeCond_;
 
-  CuptiActivityApi() = default;
+  CuptiActivityApi();
   CuptiActivityApi(const CuptiActivityApi&) = delete;
   CuptiActivityApi& operator=(const CuptiActivityApi&) = delete;
 
@@ -74,6 +74,7 @@ class CuptiActivityApi {
   static void preConfigureCUPTI();
 
  private:
+  uint32_t cuptiVersion_{0};
   int64_t maxGpuBufferCount_{0};
   CuptiActivityBufferMap allocatedGpuTraceBuffers_;
   std::unique_ptr<CuptiActivityBufferMap> readyGpuTraceBuffers_;
@@ -98,6 +99,7 @@ class CuptiActivityApi {
       size_t validSize);
 
  protected:
+  explicit CuptiActivityApi(uint32_t cuptiVersion);
   void bufferRequested(uint8_t** buffer, size_t* size, size_t* maxNumRecords);
   void bufferCompleted(
       CUcontext ctx,

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -76,7 +76,7 @@ CuptiActivityProfiler::CuptiActivityProfiler(
     CuptiActivityApi& cupti,
     bool cpuOnly)
     : GenericActivityProfiler(cpuOnly), cupti_(cupti) {
-  if (!cpuOnly && isGpuAvailable()) {
+  if (isGpuAvailable()) {
     logGpuVersions();
   }
 }

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -76,7 +76,7 @@ CuptiActivityProfiler::CuptiActivityProfiler(
     CuptiActivityApi& cupti,
     bool cpuOnly)
     : GenericActivityProfiler(cpuOnly), cupti_(cupti) {
-  if (isGpuAvailable()) {
+  if (!cpuOnly && isGpuAvailable()) {
     logGpuVersions();
   }
 }

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -285,13 +285,28 @@ struct MockCuptiActivityBuffer {
   std::vector<CUpti_Activity*> activities;
 };
 
+class CallbackCuptiActivityApi : public CuptiActivityApi {
+ public:
+  explicit CallbackCuptiActivityApi(uint32_t cuptiVersion)
+      : CuptiActivityApi(cuptiVersion) {}
+
+  std::pair<uint8_t*, size_t> requestBuffer(
+      uint8_t* buffer = nullptr,
+      size_t size = 0) {
+    size_t maxNumRecords = 1;
+    bufferRequested(&buffer, &size, &maxNumRecords);
+    EXPECT_EQ(maxNumRecords, 0);
+    return {buffer, size};
+  }
+
+  void completeBuffer(uint8_t* buffer, size_t size) {
+    bufferCompleted(nullptr, 0, buffer, 0, size);
+  }
+};
+
 // Mock parts of the CuptiActivityApi
 class MockCuptiActivities : public CuptiActivityApi {
  public:
-  MockCuptiActivities() : CuptiActivityApi(0) {}
-  explicit MockCuptiActivities(uint32_t cuptiVersion)
-      : CuptiActivityApi(cuptiVersion) {}
-
   const std::pair<int, size_t> processActivities(
       [[maybe_unused]] CuptiActivityBufferMap& bufferMap,
       const std::function<void(const CUpti_Activity*)>& handler) override {
@@ -309,61 +324,74 @@ class MockCuptiActivities : public CuptiActivityApi {
     return map;
   }
 
-  void bufferRequestedOverride(
-      uint8_t** buffer,
-      size_t* size,
-      size_t* maxNumRecords) {
-    this->bufferRequested(buffer, size, maxNumRecords);
-  }
-
   std::unique_ptr<MockCuptiActivityBuffer> activityBuffer;
 };
 
 TEST(CuptiActivityApiTest, KeepsReturningValidBuffersBeforeVersion27) {
-  MockCuptiActivities cupti(26);
+  CallbackCuptiActivityApi cupti(26);
   cupti.setMaxBufferSize(0);
 
-  uint8_t* firstBuffer = nullptr;
-  size_t firstSize = 0;
-  size_t firstMaxRecords = 1;
-  cupti.bufferRequestedOverride(&firstBuffer, &firstSize, &firstMaxRecords);
+  auto [firstBuffer, firstSize] = cupti.requestBuffer();
   ASSERT_NE(firstBuffer, nullptr);
   ASSERT_GT(firstSize, 0);
-  EXPECT_EQ(firstMaxRecords, 0);
   EXPECT_FALSE(cupti.stopCollection);
+  cupti.completeBuffer(firstBuffer, firstSize);
 
-  uint8_t* secondBuffer = nullptr;
-  size_t secondSize = 0;
-  size_t secondMaxRecords = 1;
-  cupti.bufferRequestedOverride(&secondBuffer, &secondSize, &secondMaxRecords);
-  EXPECT_NE(secondBuffer, nullptr);
-  EXPECT_NE(secondBuffer, firstBuffer);
-  EXPECT_GT(secondSize, 0);
-  EXPECT_EQ(secondMaxRecords, 0);
+  auto [fallbackBuffer, fallbackSize] = cupti.requestBuffer();
+  ASSERT_NE(fallbackBuffer, nullptr);
+  ASSERT_GT(fallbackSize, 0);
   EXPECT_TRUE(cupti.stopCollection);
+
+  auto [nextFallbackBuffer, nextFallbackSize] = cupti.requestBuffer();
+  ASSERT_NE(nextFallbackBuffer, nullptr);
+  EXPECT_NE(nextFallbackBuffer, fallbackBuffer);
+  cupti.completeBuffer(fallbackBuffer, fallbackSize);
+  cupti.completeBuffer(nextFallbackBuffer, nextFallbackSize);
+
+  for (int i = 0; i < 2; ++i) {
+    auto [buffer, size] = cupti.requestBuffer();
+    ASSERT_NE(buffer, nullptr);
+    cupti.completeBuffer(buffer, size);
+  }
+  auto readyBuffers = cupti.activityBuffers();
+  ASSERT_NE(readyBuffers, nullptr);
+  ASSERT_EQ(readyBuffers->size(), 1);
+  EXPECT_EQ(readyBuffers->count(firstBuffer), 1);
 }
 
 TEST(CuptiActivityApiTest, RejectsBuffersStartingWithVersion27) {
-  MockCuptiActivities cupti(27);
+  CallbackCuptiActivityApi cupti(27);
   cupti.setMaxBufferSize(0);
 
-  uint8_t* firstBuffer = nullptr;
-  size_t firstSize = 0;
-  size_t firstMaxRecords = 1;
-  cupti.bufferRequestedOverride(&firstBuffer, &firstSize, &firstMaxRecords);
+  auto [firstBuffer, firstSize] = cupti.requestBuffer();
   ASSERT_NE(firstBuffer, nullptr);
   ASSERT_GT(firstSize, 0);
-  EXPECT_EQ(firstMaxRecords, 0);
   EXPECT_FALSE(cupti.stopCollection);
 
-  uint8_t* secondBuffer = firstBuffer;
-  size_t secondSize = firstSize;
-  size_t secondMaxRecords = 1;
-  cupti.bufferRequestedOverride(&secondBuffer, &secondSize, &secondMaxRecords);
+  auto [secondBuffer, secondSize] = cupti.requestBuffer(firstBuffer, firstSize);
   EXPECT_EQ(secondBuffer, nullptr);
   EXPECT_EQ(secondSize, 0);
-  EXPECT_EQ(secondMaxRecords, 0);
   EXPECT_TRUE(cupti.stopCollection);
+
+  cupti.completeBuffer(firstBuffer, firstSize);
+  auto [thirdBuffer, thirdSize] = cupti.requestBuffer(firstBuffer, firstSize);
+  EXPECT_EQ(thirdBuffer, nullptr);
+  EXPECT_EQ(thirdSize, 0);
+  EXPECT_EQ(cupti.activityBuffers(), nullptr);
+}
+
+TEST(CuptiActivityApiTest, ClearsCompletedBuffers) {
+  CallbackCuptiActivityApi cupti(27);
+  cupti.setMaxBufferSize(0);
+
+  auto [buffer, size] = cupti.requestBuffer();
+  cupti.completeBuffer(buffer, size);
+  cupti.clearActivities();
+
+  auto [nextBuffer, nextSize] = cupti.requestBuffer();
+  EXPECT_NE(nextBuffer, nullptr);
+  EXPECT_GT(nextSize, 0);
+  EXPECT_FALSE(cupti.stopCollection);
 }
 
 // Common setup / teardown and helper functions

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -288,6 +288,10 @@ struct MockCuptiActivityBuffer {
 // Mock parts of the CuptiActivityApi
 class MockCuptiActivities : public CuptiActivityApi {
  public:
+  MockCuptiActivities() : CuptiActivityApi(0) {}
+  explicit MockCuptiActivities(uint32_t cuptiVersion)
+      : CuptiActivityApi(cuptiVersion) {}
+
   const std::pair<int, size_t> processActivities(
       [[maybe_unused]] CuptiActivityBufferMap& bufferMap,
       const std::function<void(const CUpti_Activity*)>& handler) override {
@@ -314,6 +318,53 @@ class MockCuptiActivities : public CuptiActivityApi {
 
   std::unique_ptr<MockCuptiActivityBuffer> activityBuffer;
 };
+
+TEST(CuptiActivityApiTest, KeepsReturningValidBuffersBeforeVersion27) {
+  MockCuptiActivities cupti(26);
+  cupti.setMaxBufferSize(0);
+
+  uint8_t* firstBuffer = nullptr;
+  size_t firstSize = 0;
+  size_t firstMaxRecords = 1;
+  cupti.bufferRequestedOverride(&firstBuffer, &firstSize, &firstMaxRecords);
+  ASSERT_NE(firstBuffer, nullptr);
+  ASSERT_GT(firstSize, 0);
+  EXPECT_EQ(firstMaxRecords, 0);
+  EXPECT_FALSE(cupti.stopCollection);
+
+  uint8_t* secondBuffer = nullptr;
+  size_t secondSize = 0;
+  size_t secondMaxRecords = 1;
+  cupti.bufferRequestedOverride(&secondBuffer, &secondSize, &secondMaxRecords);
+  EXPECT_NE(secondBuffer, nullptr);
+  EXPECT_NE(secondBuffer, firstBuffer);
+  EXPECT_GT(secondSize, 0);
+  EXPECT_EQ(secondMaxRecords, 0);
+  EXPECT_TRUE(cupti.stopCollection);
+}
+
+TEST(CuptiActivityApiTest, RejectsBuffersStartingWithVersion27) {
+  MockCuptiActivities cupti(27);
+  cupti.setMaxBufferSize(0);
+
+  uint8_t* firstBuffer = nullptr;
+  size_t firstSize = 0;
+  size_t firstMaxRecords = 1;
+  cupti.bufferRequestedOverride(&firstBuffer, &firstSize, &firstMaxRecords);
+  ASSERT_NE(firstBuffer, nullptr);
+  ASSERT_GT(firstSize, 0);
+  EXPECT_EQ(firstMaxRecords, 0);
+  EXPECT_FALSE(cupti.stopCollection);
+
+  uint8_t* secondBuffer = firstBuffer;
+  size_t secondSize = firstSize;
+  size_t secondMaxRecords = 1;
+  cupti.bufferRequestedOverride(&secondBuffer, &secondSize, &secondMaxRecords);
+  EXPECT_EQ(secondBuffer, nullptr);
+  EXPECT_EQ(secondSize, 0);
+  EXPECT_EQ(secondMaxRecords, 0);
+  EXPECT_TRUE(cupti.stopCollection);
+}
 
 // Common setup / teardown and helper functions
 class CuptiActivityProfilerTest : public ::testing::Test {

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -287,8 +287,7 @@ struct MockCuptiActivityBuffer {
 
 class CallbackCuptiActivityApi : public CuptiActivityApi {
  public:
-  explicit CallbackCuptiActivityApi(uint32_t cuptiVersion)
-      : CuptiActivityApi(cuptiVersion) {}
+  using CuptiActivityApi::canRejectBuffer_;
 
   std::pair<uint8_t*, size_t> requestBuffer(
       uint8_t* buffer = nullptr,
@@ -327,40 +326,34 @@ class MockCuptiActivities : public CuptiActivityApi {
   std::unique_ptr<MockCuptiActivityBuffer> activityBuffer;
 };
 
-TEST(CuptiActivityApiTest, KeepsReturningValidBuffersBeforeVersion27) {
-  CallbackCuptiActivityApi cupti(26);
+TEST(CuptiActivityApiTest, KeepsReturningValidBuffersWhenRejectionUnsupported) {
+  CallbackCuptiActivityApi cupti;
+  cupti.canRejectBuffer_ = false;
   cupti.setMaxBufferSize(0);
 
   auto [firstBuffer, firstSize] = cupti.requestBuffer();
   ASSERT_NE(firstBuffer, nullptr);
   ASSERT_GT(firstSize, 0);
   EXPECT_FALSE(cupti.stopCollection);
-  cupti.completeBuffer(firstBuffer, firstSize);
-
-  auto [fallbackBuffer, fallbackSize] = cupti.requestBuffer();
-  ASSERT_NE(fallbackBuffer, nullptr);
-  ASSERT_GT(fallbackSize, 0);
+  auto [secondBuffer, secondSize] = cupti.requestBuffer(firstBuffer, firstSize);
   EXPECT_TRUE(cupti.stopCollection);
 
-  auto [nextFallbackBuffer, nextFallbackSize] = cupti.requestBuffer();
-  ASSERT_NE(nextFallbackBuffer, nullptr);
-  EXPECT_NE(nextFallbackBuffer, fallbackBuffer);
-  cupti.completeBuffer(fallbackBuffer, fallbackSize);
-  cupti.completeBuffer(nextFallbackBuffer, nextFallbackSize);
+  ASSERT_NE(secondBuffer, nullptr);
+  ASSERT_GT(secondSize, 0);
 
-  for (int i = 0; i < 2; ++i) {
-    auto [buffer, size] = cupti.requestBuffer();
-    ASSERT_NE(buffer, nullptr);
-    cupti.completeBuffer(buffer, size);
-  }
-  auto readyBuffers = cupti.activityBuffers();
-  ASSERT_NE(readyBuffers, nullptr);
-  ASSERT_EQ(readyBuffers->size(), 1);
-  EXPECT_EQ(readyBuffers->count(firstBuffer), 1);
+  auto [thirdBuffer, thirdSize] = cupti.requestBuffer();
+  ASSERT_NE(thirdBuffer, nullptr);
+  EXPECT_NE(thirdBuffer, secondBuffer);
+
+  cupti.completeBuffer(firstBuffer, firstSize);
+  cupti.completeBuffer(secondBuffer, secondSize);
+  cupti.completeBuffer(thirdBuffer, thirdSize);
+  EXPECT_EQ(cupti.activityBuffers(), nullptr);
 }
 
-TEST(CuptiActivityApiTest, RejectsBuffersStartingWithVersion27) {
-  CallbackCuptiActivityApi cupti(27);
+TEST(CuptiActivityApiTest, RejectsBuffersWhenSupported) {
+  CallbackCuptiActivityApi cupti;
+  cupti.canRejectBuffer_ = true;
   cupti.setMaxBufferSize(0);
 
   auto [firstBuffer, firstSize] = cupti.requestBuffer();
@@ -369,29 +362,19 @@ TEST(CuptiActivityApiTest, RejectsBuffersStartingWithVersion27) {
   EXPECT_FALSE(cupti.stopCollection);
 
   auto [secondBuffer, secondSize] = cupti.requestBuffer(firstBuffer, firstSize);
+  EXPECT_TRUE(cupti.stopCollection);
   EXPECT_EQ(secondBuffer, nullptr);
   EXPECT_EQ(secondSize, 0);
-  EXPECT_TRUE(cupti.stopCollection);
 
-  cupti.completeBuffer(firstBuffer, firstSize);
   auto [thirdBuffer, thirdSize] = cupti.requestBuffer(firstBuffer, firstSize);
   EXPECT_EQ(thirdBuffer, nullptr);
   EXPECT_EQ(thirdSize, 0);
+
+  cupti.completeBuffer(firstBuffer, firstSize);
+  auto [fourthBuffer, fourthSize] = cupti.requestBuffer(firstBuffer, firstSize);
+  EXPECT_EQ(fourthBuffer, nullptr);
+  EXPECT_EQ(fourthSize, 0);
   EXPECT_EQ(cupti.activityBuffers(), nullptr);
-}
-
-TEST(CuptiActivityApiTest, ClearsCompletedBuffers) {
-  CallbackCuptiActivityApi cupti(27);
-  cupti.setMaxBufferSize(0);
-
-  auto [buffer, size] = cupti.requestBuffer();
-  cupti.completeBuffer(buffer, size);
-  cupti.clearActivities();
-
-  auto [nextBuffer, nextSize] = cupti.requestBuffer();
-  EXPECT_NE(nextBuffer, nullptr);
-  EXPECT_GT(nextSize, 0);
-  EXPECT_FALSE(cupti.stopCollection);
 }
 
 // Common setup / teardown and helper functions

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -366,15 +366,11 @@ TEST(CuptiActivityApiTest, RejectsBuffersWhenSupported) {
   EXPECT_EQ(secondBuffer, nullptr);
   EXPECT_EQ(secondSize, 0);
 
+  cupti.completeBuffer(firstBuffer, firstSize);
   auto [thirdBuffer, thirdSize] = cupti.requestBuffer(firstBuffer, firstSize);
   EXPECT_EQ(thirdBuffer, nullptr);
   EXPECT_EQ(thirdSize, 0);
-
-  cupti.completeBuffer(firstBuffer, firstSize);
-  auto [fourthBuffer, fourthSize] = cupti.requestBuffer(firstBuffer, firstSize);
-  EXPECT_EQ(fourthBuffer, nullptr);
-  EXPECT_EQ(fourthSize, 0);
-  EXPECT_EQ(cupti.activityBuffers(), nullptr);
+  EXPECT_NE(cupti.activityBuffers(), nullptr);
 }
 
 // Common setup / teardown and helper functions


### PR DESCRIPTION
without this gate the buffer lmit in kineto can crash the process on pre-12.9 CUPTI before tracing actually shuts down and finishes.

the pr gates Kineto's null-buffer rejection on CUPTI v27+ with fallback below 27.

References:
- [CUPTI activity-buffer callback contract](https://docs.nvidia.com/cupti/12.9/api/group__CUPTI__ACTIVITY__API.html#_CPPv432CUpti_BuffersCallbackRequestFunc)
- [CUDA 12.9 release notes; missing-buffer crash fix](https://docs.nvidia.com/cupti/release-notes/release-notes.html#updates-in-cuda-12-9)
- [CUPTI version API — v27 maps to CUDA 12.9](https://docs.nvidia.com/cupti/12.9/api/group__CUPTI__VERSION__API.html#c.CUPTI_API_VERSION)

relevant/simialr issue: https://github.com/pytorch/kineto/issues/1275

cc @ryanzhang22 