### PR TITLE
[ROCm][CI] Restrict PyTorch build to MI350 to reduce CI build time

### DIFF
--- a/.github/scripts/config_rocm.sh
+++ b/.github/scripts/config_rocm.sh
@@ -29,6 +29,7 @@ KINETO_CMAKE_FLAGS=(
 export USE_ROCM=1
 export BUILD_TEST=1
 export PYTORCH_TEST_WITH_ROCM=1
+export PYTORCH_ROCM_ARCH="gfx950"
 
 # Cap parallel compile jobs. PyTorch's build otherwise spawns one compile per
 # core, and ROCm never reaches the sccache bucket (see below), so every build


### PR DESCRIPTION
Without increasing the timeout, this PR increases restrict PyTorch build to MI350 to reduce CI build time. This will fix the timeout issue.
**Future work:** In a separate PR, we will separate ROCm build and test workflows. The build workflow will run on a CPU only runner that is sccache enabled which will set KINETO_USE_SCCACHE=1. 