### PR TITLE
Skip PerKernelScope UT

### DIFF
--- a/libkineto/test/xpupti/XpuptiScopeProfilerTest.cpp
+++ b/libkineto/test/xpupti/XpuptiScopeProfilerTest.cpp
@@ -119,6 +119,9 @@ void RunTest(std::string_view perKernel, unsigned maxScopes) {
 /////////////////////////////////////////////////////////////////////
 
 TEST_F(XpuptiScopeProfilerTest, PerKernelScope) {
+  GTEST_SKIP() << "PTI reports success but returns no scope metric records, "
+                  "so the expected metric activities are absent: "
+                  "https://github.com/pytorch/kineto/issues/1533";
   RunTest("true", 314);
 }
 


### PR DESCRIPTION
Temporarily skip `XpuptiScopeProfilerTest.PerKernelScope`, which has failed every XPU CI run since it first executed. Tracked by #1533.

The root cause is silent PTI failure on one of the devices:
`PTI:[13:07][-warning-]2170:2170 pti_metrics_scope_helper.h:953 CreateProfilerForDevice: StartProfiling failed for device 0x2209d238 (105); skipping metrics for this device (likely held by another process)`
This silent failure communicated with only a warning causes the test to fail with a value mismatch not an error hiding real cause. Despite that every call to `ptiMetricsScope*` returns `PTI_SUCCESS` making Kineto activity count come up short of what is expected. As far as I know there is no public PTI API that exposes that silent failure making it impossible to detect / report this in Kineto.
