### PR TITLE
kineto: Store native names in thread resources

### DIFF
--- a/libkineto/include/IActivityProfiler.h
+++ b/libkineto/include/IActivityProfiler.h
@@ -52,6 +52,11 @@ struct DeviceInfo {
   const std::string label; // device label
 };
 
+enum class ResourceType {
+  UNKNOWN = 0,
+  HOST_THREAD = 1,
+};
+
 /* ResourceInfo:
  *   Can be used to specify resource inside device
  */
@@ -61,6 +66,7 @@ struct ResourceInfo {
   int64_t deviceId; // id of device which owns this resource (specified in
                     // DeviceInfo.id)
   const std::string name; // resource name
+  ResourceType resourceType{ResourceType::UNKNOWN};
 };
 
 using getLinkedActivityCallback = std::function<const ITraceActivity*(int32_t)>;

--- a/libkineto/src/GenericActivityProfiler.h
+++ b/libkineto/src/GenericActivityProfiler.h
@@ -261,7 +261,8 @@ class GenericActivityProfiler {
               .id = sysTid,
               .sortIndex = sysTid,
               .deviceId = pid,
-              .name = fmt::format("thread {} ({})", sysTid, getThreadName())});
+              .name = getThreadName(),
+              .resourceType = ResourceType::HOST_THREAD});
     }
   }
 

--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -17,6 +17,7 @@
 #include <string_view>
 #include "Config.h"
 #include "EnvMetadata.h"
+#include "ThreadUtil.h"
 #include "TraceSpan.h"
 
 #include "Logger.h"
@@ -547,7 +548,13 @@ void ChromeTraceLogger::handleResourceInfo(
     return;
   }
 
+  // GenericActivityProfiler stores the native pthread name in ResourceInfo.
+  // Preserve Chrome JSON's legacy display format for host CPU threads while
+  // leaving GPU streams and other synthetic resources unchanged.
   std::string name = info.name;
+  if (info.resourceType == ResourceType::HOST_THREAD) {
+    name = fmt::format("thread {} ({})", info.id, info.name);
+  }
   sanitizeStrForJSON(name);
   escapeQuotesForJSON(name);
 

--- a/libkineto/test/OutputJsonTest.cpp
+++ b/libkineto/test/OutputJsonTest.cpp
@@ -16,6 +16,7 @@
 #include <string_view>
 
 #include "include/GenericTraceActivity.h"
+#include "include/ThreadUtil.h"
 #include "include/TraceSpan.h"
 #include "src/output_json.h"
 #include "test/TestUtils.h"
@@ -148,6 +149,33 @@ TEST(OutputJsonTest, EventNameWithQuotesProducesValidJson) {
 
 TEST(OutputJsonTest, PlainEventNameIsUnchanged) {
   expectEventNameRoundTrips("aten::addmm");
+}
+
+TEST(OutputJsonTest, DisplayContainsThreadNameAndTID) {
+  const auto traceFile =
+      libkineto::test::createTempTraceFile("OutputJsonTest.", ".json");
+  TestableChromeTraceLogger logger(traceFile.path());
+  logger.handleTraceStart({}, "");
+  logger.handleResourceInfo(
+      ResourceInfo{
+          /*id=*/12345,
+          /*sortIndex=*/0,
+          /*deviceId=*/processId(),
+          /*name=*/"worker",
+          /*resourceType=*/ResourceType::HOST_THREAD},
+      /*time=*/100);
+  logger.finalizeTrace(/*endTime=*/300);
+
+  const auto trace = nlohmann::json::parse(readFile(traceFile.path()));
+  bool found = false;
+  for (const auto& event : trace["traceEvents"]) {
+    if (event.value("name", "") == "thread_name" &&
+        event["args"].value("name", "") == "thread 12345 (worker)") {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found);
 }
 
 // Collective strings arrive quoted from the legacy RawJson path and unquoted


### PR DESCRIPTION
Summary: Store only the native pthread name in ResourceInfo because the TID is already carried separately. Reconstruct the legacy thread <tid> (<name>) display string only in Chrome JSON output for compatibility; native Perfetto receives the resource name unchanged.

Reviewed By: ryanzhang22

Differential Revision: D115112030


