### PR TITLE
[Kineto] Enable TEARDOWN_CUPTI by default

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -29,7 +29,7 @@ constexpr uint32_t kCuptiBufferRejectionMinVersion = 27;
 
 inline bool cuptiTearDown_() {
   auto teardown_env = getenv("TEARDOWN_CUPTI");
-  return teardown_env != nullptr && strcmp(teardown_env, "1") == 0;
+  return teardown_env == nullptr || strcmp(teardown_env, "1") == 0;
 }
 
 inline bool cuptiLazyInit_() {


### PR DESCRIPTION
Enable TEARDOWN_CUPTI by default when the env is not set. Users who run Kineto but do not have this set to tear down CUPTI after profiling can experience performance degradation.