### PR TITLE
Replace bzero with memset in CuptiActivityProfilerTest

### DIFF
--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -11,12 +11,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
-#include <stdlib.h> // NOLINT(modernize-deprecated-headers) required for setenv unsetenv
+#include <stdlib.h> // NOLINT(modernize-deprecated-headers) required for malloc free
 
-#include <strings.h>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <map>
 #include <optional>
 #include <variant>
@@ -261,7 +261,7 @@ struct MockCuptiActivityBuffer {
   template <class T>
   T& createActivity(int64_t start_ns, int64_t end_ns, int64_t correlation) {
     T& act = *static_cast<T*>(malloc(sizeof(T)));
-    bzero(&act, sizeof(act));
+    std::memset(&act, 0, sizeof(act));
     act.start = start_ns;
     act.end = end_ns;
     act.correlationId = correlation;
@@ -271,7 +271,7 @@ struct MockCuptiActivityBuffer {
   template <class T>
   T& createActivity(int64_t correlation) {
     T& act = *static_cast<T*>(malloc(sizeof(T)));
-    bzero(&act, sizeof(act));
+    std::memset(&act, 0, sizeof(act));
     act.correlationId = correlation;
     return act;
   }


### PR DESCRIPTION
Part of upstreaming Kineto: https://github.com/pytorch/kineto/issues/1478

**Problem** — https://github.com/pytorch/pytorch/pull/193223 has failing Windows CUDA tests with `fatal error C1083: Cannot open include file: 'strings.h'`. The test zeroes freshly malloc'd `CUpti_Activity` structs with `bzero`, which lives in the Unix `"strings.h"` that MSVC does not have. The test only started building on Windows once #1529 removed the guard around it, so nothing caught this before.

**Fix** — `bzero(p, n)` is `memset(p, 0, n)`, so use `std::memset` from `cstring`, which is what the rest of Kineto includes for this. Drops the `strings.h` dependency entirely rather than guarding it per platform.