### PR TITLE
Stop the disabled-IPC-fabric stub from colliding with the real FabricManager (#1541)

### DIFF
--- a/libkineto/src/IpcFabricConfigClient.cpp
+++ b/libkineto/src/IpcFabricConfigClient.cpp
@@ -83,7 +83,7 @@ IpcFabricConfigClient::IpcFabricConfigClient()
   // setup IPC Fabric
   std::string ep_name = "dynoconfigclient" + uuid::generate_uuid_v4();
 
-  fabricManager_ = ::dynolog::ipcfabric::FabricManager::factory(ep_name);
+  fabricManager_ = FabricManagerT::factory(ep_name);
 #ifdef ENABLE_IPC_FABRIC
   LOG(INFO) << "Setting up IPC Fabric at endpoint: " << ep_name << " status = "
             << (fabricManager_ ? "initialized" : "failed (null)");

--- a/libkineto/src/IpcFabricConfigClient.h
+++ b/libkineto/src/IpcFabricConfigClient.h
@@ -26,23 +26,32 @@
 // Include the IPC Fabric
 #include "FabricManager.h"
 
+namespace KINETO_NAMESPACE {
+using FabricManagerT = ::dynolog::ipcfabric::FabricManager;
+} // namespace KINETO_NAMESPACE
+
 #else
 
 // Adds an empty implementation so compilation works.
-namespace dynolog::ipcfabric {
+namespace KINETO_NAMESPACE {
 
-class FabricManager {
+// Deliberately not named dynolog::ipcfabric::FabricManager: the real class can
+// be linked into the same binary, and two definitions of one name is an ODR
+// violation.
+class DisabledFabricManager {
  public:
-  FabricManager(const FabricManager&) = delete;
-  FabricManager& operator=(const FabricManager&) = delete;
+  DisabledFabricManager(const DisabledFabricManager&) = delete;
+  DisabledFabricManager& operator=(const DisabledFabricManager&) = delete;
 
-  static std::unique_ptr<FabricManager> factory(
+  static std::unique_ptr<DisabledFabricManager> factory(
       std::string endpoint_name = "") {
     return nullptr;
   }
 };
 
-} // namespace dynolog::ipcfabric
+using FabricManagerT = DisabledFabricManager;
+
+} // namespace KINETO_NAMESPACE
 
 #endif // ENABLE_IPC_FABRIC
 
@@ -83,7 +92,7 @@ class IpcFabricConfigClient {
   std::vector<int32_t> pids_;
   bool ipcFabricEnabled_;
 
-  std::unique_ptr<dynolog::ipcfabric::FabricManager> fabricManager_;
+  std::unique_ptr<FabricManagerT> fabricManager_;
 };
 
 #endif // __linux__


### PR DESCRIPTION
Summary:

When `ENABLE_IPC_FABRIC` is off, `IpcFabricConfigClient.h` defines its own empty
`dynolog::ipcfabric::FabricManager` so the file still compiles. The CMake build
defines that macro; other builds may not, and then this stub is what kineto
gets.

The real class of that name can still be linked into the same binary -- anything
that also depends on dynolog's ipcfabric library brings it in. Such a binary
then contains two different classes under one name:

    dynolog::ipcfabric::FabricManager   1 byte,   0 members   this stub
    dynolog::ipcfabric::FabricManager   128 bytes, 3 members   the real class

That is an ODR violation, and it was found by auditing a binary that links both.

It is not only a debug-info curiosity. Both sides instantiate
`std::unique_ptr<dynolog::ipcfabric::FabricManager>`, and those instantiations
mangle identically, so the *same* `std::default_delete<...>` and `unique_ptr`
symbols are shared between a TU that thinks the type is 1 byte and trivially
destructible and TUs that think it is 128 bytes holding a `std::mutex`, a
`std::deque` and an `EndPoint`. Whichever definition the linker keeps is wrong
for the other's objects: if the stub's wins, deleting a real FabricManager skips
the member destructors and hands the wrong size to sized `operator delete`.
Several places hold a `unique_ptr` to one, including
`dynolog/src/tracing/IPCMonitor.h`.

Whether that actually bites depends on inlining, so this is not a report of a
live crash. The point is that the guarantee is absent, and it costs three lines
to get it back.

Fix: the placeholder no longer claims the name. It becomes
`KINETO_NAMESPACE::DisabledFabricManager`, and both branches of the `#ifdef`
export a `FabricManagerT` alias that the member declaration and the factory call
use. Nothing else changes -- every other use of `fabricManager_` is already
inside `#ifdef ENABLE_IPC_FABRIC`, where the alias resolves to the real class.

Reviewed By: scotts

Differential Revision: D115868804


