### PR TITLE
[Kineto] PM Sampling unit tests: profiler layer

### DIFF
--- a/libkineto/src/CuptiPMSamplingController.cpp
+++ b/libkineto/src/CuptiPMSamplingController.cpp
@@ -42,7 +42,14 @@ constexpr std::chrono::milliseconds kDecodePollInterval{10};
 
 CuptiPMSamplingController::CuptiPMSamplingController(
     CuptiPMSamplingConfig config)
-    : config_(std::move(config)) {}
+    : CuptiPMSamplingController(
+          std::move(config),
+          std::make_unique<CuptiPMSamplingApi>()) {}
+
+CuptiPMSamplingController::CuptiPMSamplingController(
+    CuptiPMSamplingConfig config,
+    std::unique_ptr<CuptiPMSamplingApi> api)
+    : config_(std::move(config)), api_(std::move(api)) {}
 
 CuptiPMSamplingController::~CuptiPMSamplingController() {
   static_cast<void>(stop());
@@ -66,10 +73,10 @@ bool CuptiPMSamplingController::prepare() {
     if (!validateConfig()) {
       return false;
     }
-    api_.configure(config_);
+    api_->configure(config_);
   } catch (...) {
     logCurrentException("Failed to prepare CUPTI PM sampling");
-    api_.disable();
+    api_->disable();
     return false;
   }
   prepared_ = true;
@@ -88,7 +95,7 @@ void CuptiPMSamplingController::start() {
 
   stopRequested_.store(false, std::memory_order_relaxed);
   try {
-    api_.start();
+    api_->start();
     active_ = true;
     // Decode needs to happen on an async thread as it needs to synchronously
     // fetch new samples from the api
@@ -121,7 +128,7 @@ bool CuptiPMSamplingController::stop() {
   if (active_) {
     std::vector<CuptiPMSample> decodedSamples;
     try {
-      api_.stop();
+      api_->stop();
       if (!decodeFailed_.load(std::memory_order_relaxed)) {
         drain(decodedSamples);
       }
@@ -130,7 +137,7 @@ bool CuptiPMSamplingController::stop() {
     }
     active_ = false;
   }
-  api_.disable();
+  api_->disable();
   prepared_ = false;
   return wasActive;
 }
@@ -172,7 +179,7 @@ void CuptiPMSamplingController::decodeLoop() {
 bool CuptiPMSamplingController::decodeBatch(
     std::vector<CuptiPMSample>& decodedSamples) {
   decodedSamples.clear();
-  const bool isBufferDrained = api_.decode(decodedSamples);
+  const bool isBufferDrained = api_->decode(decodedSamples);
   std::lock_guard<std::mutex> lock(samplesMutex_);
   for (auto& sample : decodedSamples) {
     // CUPTI recommends discarding the first sample because it may contain

--- a/libkineto/src/CuptiPMSamplingController.cpp
+++ b/libkineto/src/CuptiPMSamplingController.cpp
@@ -42,14 +42,7 @@ constexpr std::chrono::milliseconds kDecodePollInterval{10};
 
 CuptiPMSamplingController::CuptiPMSamplingController(
     CuptiPMSamplingConfig config)
-    : CuptiPMSamplingController(
-          std::move(config),
-          std::make_unique<CuptiPMSamplingApi>()) {}
-
-CuptiPMSamplingController::CuptiPMSamplingController(
-    CuptiPMSamplingConfig config,
-    std::unique_ptr<CuptiPMSamplingApi> api)
-    : config_(std::move(config)), api_(std::move(api)) {}
+    : config_(std::move(config)) {}
 
 CuptiPMSamplingController::~CuptiPMSamplingController() {
   static_cast<void>(stop());
@@ -73,10 +66,10 @@ bool CuptiPMSamplingController::prepare() {
     if (!validateConfig()) {
       return false;
     }
-    api_->configure(config_);
+    api_.configure(config_);
   } catch (...) {
     logCurrentException("Failed to prepare CUPTI PM sampling");
-    api_->disable();
+    api_.disable();
     return false;
   }
   prepared_ = true;
@@ -95,7 +88,7 @@ void CuptiPMSamplingController::start() {
 
   stopRequested_.store(false, std::memory_order_relaxed);
   try {
-    api_->start();
+    api_.start();
     active_ = true;
     // Decode needs to happen on an async thread as it needs to synchronously
     // fetch new samples from the api
@@ -128,7 +121,7 @@ bool CuptiPMSamplingController::stop() {
   if (active_) {
     std::vector<CuptiPMSample> decodedSamples;
     try {
-      api_->stop();
+      api_.stop();
       if (!decodeFailed_.load(std::memory_order_relaxed)) {
         drain(decodedSamples);
       }
@@ -137,7 +130,7 @@ bool CuptiPMSamplingController::stop() {
     }
     active_ = false;
   }
-  api_->disable();
+  api_.disable();
   prepared_ = false;
   return wasActive;
 }
@@ -179,7 +172,7 @@ void CuptiPMSamplingController::decodeLoop() {
 bool CuptiPMSamplingController::decodeBatch(
     std::vector<CuptiPMSample>& decodedSamples) {
   decodedSamples.clear();
-  const bool isBufferDrained = api_->decode(decodedSamples);
+  const bool isBufferDrained = api_.decode(decodedSamples);
   std::lock_guard<std::mutex> lock(samplesMutex_);
   for (auto& sample : decodedSamples) {
     // CUPTI recommends discarding the first sample because it may contain

--- a/libkineto/src/CuptiPMSamplingController.h
+++ b/libkineto/src/CuptiPMSamplingController.h
@@ -10,7 +10,6 @@
 
 #include <atomic>
 #include <condition_variable>
-#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -20,28 +19,38 @@
 
 namespace KINETO_NAMESPACE {
 
-class CuptiPMSamplingController {
+class ICuptiPMSamplingController {
+ public:
+  virtual ~ICuptiPMSamplingController() = default;
+
+  [[nodiscard]] virtual bool prepare() = 0;
+  virtual void start() = 0;
+  [[nodiscard]] virtual bool stop() = 0;
+
+  [[nodiscard]] virtual int32_t deviceId() const = 0;
+  [[nodiscard]] virtual const std::vector<std::string>& metricNames() const = 0;
+  [[nodiscard]] virtual std::vector<CuptiPMSample> takeSamples() = 0;
+};
+
+class CuptiPMSamplingController final : public ICuptiPMSamplingController {
  public:
   explicit CuptiPMSamplingController(CuptiPMSamplingConfig config);
-  CuptiPMSamplingController(
-      CuptiPMSamplingConfig config,
-      std::unique_ptr<CuptiPMSamplingApi> api);
   CuptiPMSamplingController(const CuptiPMSamplingController&) = delete;
   CuptiPMSamplingController& operator=(const CuptiPMSamplingController&) =
       delete;
   CuptiPMSamplingController(CuptiPMSamplingController&&) = delete;
   CuptiPMSamplingController& operator=(CuptiPMSamplingController&&) = delete;
 
-  ~CuptiPMSamplingController();
+  ~CuptiPMSamplingController() override;
 
-  [[nodiscard]] bool prepare();
-  void start();
+  [[nodiscard]] bool prepare() override;
+  void start() override;
   // Returns whether collection was active when stop() was called.
-  [[nodiscard]] bool stop();
+  [[nodiscard]] bool stop() override;
 
-  [[nodiscard]] int32_t deviceId() const;
-  [[nodiscard]] const std::vector<std::string>& metricNames() const;
-  [[nodiscard]] std::vector<CuptiPMSample> takeSamples();
+  [[nodiscard]] int32_t deviceId() const override;
+  [[nodiscard]] const std::vector<std::string>& metricNames() const override;
+  [[nodiscard]] std::vector<CuptiPMSample> takeSamples() override;
 
  private:
   void decodeLoop();
@@ -52,7 +61,7 @@ class CuptiPMSamplingController {
   void logCurrentException(const char* fallback);
 
   CuptiPMSamplingConfig config_;
-  std::unique_ptr<CuptiPMSamplingApi> api_;
+  CuptiPMSamplingApi api_;
   std::thread decodeThread_;
   std::atomic_bool stopRequested_{false};
   std::atomic_bool decodeFailed_{false};
@@ -62,7 +71,7 @@ class CuptiPMSamplingController {
   std::vector<CuptiPMSample> samples_;
   bool discardFirstSample_{true};
   bool prepared_{false};
-  // True while a collection started by api_->start() is active.
+  // True while a collection started by api_.start() is active.
   bool active_{false};
 };
 

--- a/libkineto/src/CuptiPMSamplingController.h
+++ b/libkineto/src/CuptiPMSamplingController.h
@@ -19,20 +19,7 @@
 
 namespace KINETO_NAMESPACE {
 
-class ICuptiPMSamplingController {
- public:
-  virtual ~ICuptiPMSamplingController() = default;
-
-  [[nodiscard]] virtual bool prepare() = 0;
-  virtual void start() = 0;
-  [[nodiscard]] virtual bool stop() = 0;
-
-  [[nodiscard]] virtual int32_t deviceId() const = 0;
-  [[nodiscard]] virtual const std::vector<std::string>& metricNames() const = 0;
-  [[nodiscard]] virtual std::vector<CuptiPMSample> takeSamples() = 0;
-};
-
-class CuptiPMSamplingController final : public ICuptiPMSamplingController {
+class CuptiPMSamplingController {
  public:
   explicit CuptiPMSamplingController(CuptiPMSamplingConfig config);
   CuptiPMSamplingController(const CuptiPMSamplingController&) = delete;
@@ -41,16 +28,16 @@ class CuptiPMSamplingController final : public ICuptiPMSamplingController {
   CuptiPMSamplingController(CuptiPMSamplingController&&) = delete;
   CuptiPMSamplingController& operator=(CuptiPMSamplingController&&) = delete;
 
-  ~CuptiPMSamplingController() override;
+  virtual ~CuptiPMSamplingController();
 
-  [[nodiscard]] bool prepare() override;
-  void start() override;
+  [[nodiscard]] virtual bool prepare();
+  virtual void start();
   // Returns whether collection was active when stop() was called.
-  [[nodiscard]] bool stop() override;
+  [[nodiscard]] virtual bool stop();
 
-  [[nodiscard]] int32_t deviceId() const override;
-  [[nodiscard]] const std::vector<std::string>& metricNames() const override;
-  [[nodiscard]] std::vector<CuptiPMSample> takeSamples() override;
+  [[nodiscard]] virtual int32_t deviceId() const;
+  [[nodiscard]] virtual const std::vector<std::string>& metricNames() const;
+  [[nodiscard]] virtual std::vector<CuptiPMSample> takeSamples();
 
  private:
   void decodeLoop();

--- a/libkineto/src/CuptiPMSamplingController.h
+++ b/libkineto/src/CuptiPMSamplingController.h
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -22,6 +23,9 @@ namespace KINETO_NAMESPACE {
 class CuptiPMSamplingController {
  public:
   explicit CuptiPMSamplingController(CuptiPMSamplingConfig config);
+  CuptiPMSamplingController(
+      CuptiPMSamplingConfig config,
+      std::unique_ptr<CuptiPMSamplingApi> api);
   CuptiPMSamplingController(const CuptiPMSamplingController&) = delete;
   CuptiPMSamplingController& operator=(const CuptiPMSamplingController&) =
       delete;
@@ -48,7 +52,7 @@ class CuptiPMSamplingController {
   void logCurrentException(const char* fallback);
 
   CuptiPMSamplingConfig config_;
-  CuptiPMSamplingApi api_;
+  std::unique_ptr<CuptiPMSamplingApi> api_;
   std::thread decodeThread_;
   std::atomic_bool stopRequested_{false};
   std::atomic_bool decodeFailed_{false};
@@ -58,7 +62,7 @@ class CuptiPMSamplingController {
   std::vector<CuptiPMSample> samples_;
   bool discardFirstSample_{true};
   bool prepared_{false};
-  // True while a collection started by api_.start() is active.
+  // True while a collection started by api_->start() is active.
   bool active_{false};
 };
 

--- a/libkineto/src/CuptiPMSamplingController.h
+++ b/libkineto/src/CuptiPMSamplingController.h
@@ -19,7 +19,23 @@
 
 namespace KINETO_NAMESPACE {
 
-class CuptiPMSamplingController {
+// Separates session orchestration from the resource-owning controller
+// implementation. This keeps CUPTI and decode-thread state behind the boundary
+// and lets callers substitute the contract without inheriting that state.
+class ICuptiPMSamplingController {
+ public:
+  virtual ~ICuptiPMSamplingController() = default;
+
+  [[nodiscard]] virtual bool prepare() = 0;
+  virtual void start() = 0;
+  [[nodiscard]] virtual bool stop() = 0;
+
+  [[nodiscard]] virtual int32_t deviceId() const = 0;
+  [[nodiscard]] virtual const std::vector<std::string>& metricNames() const = 0;
+  [[nodiscard]] virtual std::vector<CuptiPMSample> takeSamples() = 0;
+};
+
+class CuptiPMSamplingController final : public ICuptiPMSamplingController {
  public:
   explicit CuptiPMSamplingController(CuptiPMSamplingConfig config);
   CuptiPMSamplingController(const CuptiPMSamplingController&) = delete;
@@ -28,16 +44,16 @@ class CuptiPMSamplingController {
   CuptiPMSamplingController(CuptiPMSamplingController&&) = delete;
   CuptiPMSamplingController& operator=(CuptiPMSamplingController&&) = delete;
 
-  virtual ~CuptiPMSamplingController();
+  ~CuptiPMSamplingController() override;
 
-  [[nodiscard]] virtual bool prepare();
-  virtual void start();
+  [[nodiscard]] bool prepare() override;
+  void start() override;
   // Returns whether collection was active when stop() was called.
-  [[nodiscard]] virtual bool stop();
+  [[nodiscard]] bool stop() override;
 
-  [[nodiscard]] virtual int32_t deviceId() const;
-  [[nodiscard]] virtual const std::vector<std::string>& metricNames() const;
-  [[nodiscard]] virtual std::vector<CuptiPMSample> takeSamples();
+  [[nodiscard]] int32_t deviceId() const override;
+  [[nodiscard]] const std::vector<std::string>& metricNames() const override;
+  [[nodiscard]] std::vector<CuptiPMSample> takeSamples() override;
 
  private:
   void decodeLoop();

--- a/libkineto/src/CuptiPMSamplingController.h
+++ b/libkineto/src/CuptiPMSamplingController.h
@@ -19,9 +19,8 @@
 
 namespace KINETO_NAMESPACE {
 
-// Separates session orchestration from the resource-owning controller
-// implementation. This keeps CUPTI and decode-thread state behind the boundary
-// and lets callers substitute the contract without inheriting that state.
+// CuptiPMSamplingSession depends on this interface so unit tests can provide a
+// mock controller instead of constructing the real CUPTI controller.
 class ICuptiPMSamplingController {
  public:
   virtual ~ICuptiPMSamplingController() = default;

--- a/libkineto/src/CuptiPMSamplingProfiler.cpp
+++ b/libkineto/src/CuptiPMSamplingProfiler.cpp
@@ -34,12 +34,12 @@ constexpr std::chrono::milliseconds kSamplingInterval{1};
 
 CuptiPMSamplingSession::CuptiPMSamplingSession(
     const CuptiPMSamplingConfig& config)
-    : controller_(config) {}
+    : CuptiPMSamplingSession(
+          std::make_unique<CuptiPMSamplingController>(config)) {}
 
 CuptiPMSamplingSession::CuptiPMSamplingSession(
-    const CuptiPMSamplingConfig& config,
-    std::unique_ptr<CuptiPMSamplingApi> api)
-    : controller_(config, std::move(api)) {}
+    std::unique_ptr<ICuptiPMSamplingController> controller)
+    : controller_(std::move(controller)) {}
 
 CuptiPMSamplingSession::~CuptiPMSamplingSession() = default;
 
@@ -55,20 +55,20 @@ bool CuptiPMSamplingSession::prepare() {
 
   // prepare() enables CUPTI PM sampling and acquires exclusive access during
   // the parent profiler's warmup phase. Collection itself begins in start().
-  if (!controller_.prepare()) {
+  if (!controller_->prepare()) {
     LOG(WARNING) << "CUPTI PM sampling failed to prepare CUDA device "
-                 << controller_.deviceId();
+                 << controller_->deviceId();
     return false;
   }
   return true;
 }
 
 void CuptiPMSamplingSession::start() {
-  controller_.start();
+  controller_->start();
 }
 
 void CuptiPMSamplingSession::stop() {
-  if (controller_.stop()) {
+  if (controller_->stop()) {
     traceBuffer_ = buildTraceBuffer();
   }
 }
@@ -109,8 +109,8 @@ std::unique_ptr<libkineto::CpuTraceBuffer> CuptiPMSamplingSession::
   auto buffer = std::make_unique<libkineto::CpuTraceBuffer>();
   buffer->span = libkineto::TraceSpan{0, 0, kProfilerName};
 
-  const auto samples = controller_.takeSamples();
-  const auto& metricNames = controller_.metricNames();
+  const auto samples = controller_->takeSamples();
+  const auto& metricNames = controller_->metricNames();
   for (const auto& sample : samples) {
     const auto start = convertCuptiTimestamp(sample.rawStartTimestamp);
     const auto end = convertCuptiTimestamp(sample.rawEndTimestamp);
@@ -130,7 +130,7 @@ std::unique_ptr<libkineto::CpuTraceBuffer> CuptiPMSamplingSession::
     auto& activity = *buffer->activities.back();
     activity.startTime = start;
     activity.endTime = end;
-    activity.device = controller_.deviceId();
+    activity.device = controller_->deviceId();
     for (size_t i = 0; i < metricNames.size(); ++i) {
       activity.addCounterValue(metricNames[i], sample.values[i]);
     }
@@ -138,14 +138,6 @@ std::unique_ptr<libkineto::CpuTraceBuffer> CuptiPMSamplingSession::
 
   return buffer;
 }
-
-CuptiPMSamplingProfiler::CuptiPMSamplingProfiler()
-    : CuptiPMSamplingProfiler(
-          []() { return std::make_unique<CuptiPMSamplingApi>(); }) {}
-
-CuptiPMSamplingProfiler::CuptiPMSamplingProfiler(
-    CuptiPMSamplingApiFactory apiFactory)
-    : apiFactory_(std::move(apiFactory)) {}
 
 const std::string& CuptiPMSamplingProfiler::name() const {
   return kProfilerName;
@@ -180,8 +172,7 @@ std::unique_ptr<libkineto::IActivityProfilerSession> CuptiPMSamplingProfiler::
 
   const CuptiPMSamplingConfig pmConfig{
       deviceId, metricNames, kSamplingInterval};
-  auto session =
-      std::make_unique<CuptiPMSamplingSession>(pmConfig, apiFactory_());
+  auto session = std::make_unique<CuptiPMSamplingSession>(pmConfig);
   if (!session->prepare()) {
     return nullptr;
   }

--- a/libkineto/src/CuptiPMSamplingProfiler.cpp
+++ b/libkineto/src/CuptiPMSamplingProfiler.cpp
@@ -36,6 +36,11 @@ CuptiPMSamplingSession::CuptiPMSamplingSession(
     const CuptiPMSamplingConfig& config)
     : controller_(config) {}
 
+CuptiPMSamplingSession::CuptiPMSamplingSession(
+    const CuptiPMSamplingConfig& config,
+    std::unique_ptr<CuptiPMSamplingApi> api)
+    : controller_(config, std::move(api)) {}
+
 CuptiPMSamplingSession::~CuptiPMSamplingSession() = default;
 
 bool CuptiPMSamplingSession::prepare() {
@@ -134,6 +139,14 @@ std::unique_ptr<libkineto::CpuTraceBuffer> CuptiPMSamplingSession::
   return buffer;
 }
 
+CuptiPMSamplingProfiler::CuptiPMSamplingProfiler()
+    : CuptiPMSamplingProfiler(
+          []() { return std::make_unique<CuptiPMSamplingApi>(); }) {}
+
+CuptiPMSamplingProfiler::CuptiPMSamplingProfiler(
+    CuptiPMSamplingApiFactory apiFactory)
+    : apiFactory_(std::move(apiFactory)) {}
+
 const std::string& CuptiPMSamplingProfiler::name() const {
   return kProfilerName;
 }
@@ -167,7 +180,8 @@ std::unique_ptr<libkineto::IActivityProfilerSession> CuptiPMSamplingProfiler::
 
   const CuptiPMSamplingConfig pmConfig{
       deviceId, metricNames, kSamplingInterval};
-  auto session = std::make_unique<CuptiPMSamplingSession>(pmConfig);
+  auto session =
+      std::make_unique<CuptiPMSamplingSession>(pmConfig, apiFactory_());
   if (!session->prepare()) {
     return nullptr;
   }

--- a/libkineto/src/CuptiPMSamplingProfiler.cpp
+++ b/libkineto/src/CuptiPMSamplingProfiler.cpp
@@ -38,7 +38,7 @@ CuptiPMSamplingSession::CuptiPMSamplingSession(
           std::make_unique<CuptiPMSamplingController>(config)) {}
 
 CuptiPMSamplingSession::CuptiPMSamplingSession(
-    std::unique_ptr<ICuptiPMSamplingController> controller)
+    std::unique_ptr<CuptiPMSamplingController> controller)
     : controller_(std::move(controller)) {}
 
 CuptiPMSamplingSession::~CuptiPMSamplingSession() = default;

--- a/libkineto/src/CuptiPMSamplingProfiler.cpp
+++ b/libkineto/src/CuptiPMSamplingProfiler.cpp
@@ -38,7 +38,7 @@ CuptiPMSamplingSession::CuptiPMSamplingSession(
           std::make_unique<CuptiPMSamplingController>(config)) {}
 
 CuptiPMSamplingSession::CuptiPMSamplingSession(
-    std::unique_ptr<CuptiPMSamplingController> controller)
+    std::unique_ptr<ICuptiPMSamplingController> controller)
     : controller_(std::move(controller)) {}
 
 CuptiPMSamplingSession::~CuptiPMSamplingSession() = default;

--- a/libkineto/src/CuptiPMSamplingProfiler.h
+++ b/libkineto/src/CuptiPMSamplingProfiler.h
@@ -29,7 +29,7 @@ class CuptiPMSamplingSession final
  public:
   explicit CuptiPMSamplingSession(const CuptiPMSamplingConfig& config);
   explicit CuptiPMSamplingSession(
-      std::unique_ptr<ICuptiPMSamplingController> controller);
+      std::unique_ptr<CuptiPMSamplingController> controller);
   ~CuptiPMSamplingSession() override;
 
   [[nodiscard]] bool prepare();
@@ -46,7 +46,7 @@ class CuptiPMSamplingSession final
  private:
   [[nodiscard]] std::unique_ptr<libkineto::CpuTraceBuffer> buildTraceBuffer();
 
-  std::unique_ptr<ICuptiPMSamplingController> controller_;
+  std::unique_ptr<CuptiPMSamplingController> controller_;
   std::unique_ptr<libkineto::CpuTraceBuffer> traceBuffer_;
 };
 

--- a/libkineto/src/CuptiPMSamplingProfiler.h
+++ b/libkineto/src/CuptiPMSamplingProfiler.h
@@ -29,7 +29,7 @@ class CuptiPMSamplingSession final
  public:
   explicit CuptiPMSamplingSession(const CuptiPMSamplingConfig& config);
   explicit CuptiPMSamplingSession(
-      std::unique_ptr<CuptiPMSamplingController> controller);
+      std::unique_ptr<ICuptiPMSamplingController> controller);
   ~CuptiPMSamplingSession() override;
 
   [[nodiscard]] bool prepare();
@@ -46,7 +46,7 @@ class CuptiPMSamplingSession final
  private:
   [[nodiscard]] std::unique_ptr<libkineto::CpuTraceBuffer> buildTraceBuffer();
 
-  std::unique_ptr<CuptiPMSamplingController> controller_;
+  std::unique_ptr<ICuptiPMSamplingController> controller_;
   std::unique_ptr<libkineto::CpuTraceBuffer> traceBuffer_;
 };
 

--- a/libkineto/src/CuptiPMSamplingProfiler.h
+++ b/libkineto/src/CuptiPMSamplingProfiler.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <set>
 #include <string>
@@ -24,17 +23,13 @@ struct CpuTraceBuffer;
 
 namespace KINETO_NAMESPACE {
 
-using CuptiPMSamplingApiFactory =
-    std::function<std::unique_ptr<CuptiPMSamplingApi>()>;
-
 // TODO: Support dynamic collection toggling
 class CuptiPMSamplingSession final
     : public libkineto::IActivityProfilerSession {
  public:
   explicit CuptiPMSamplingSession(const CuptiPMSamplingConfig& config);
-  CuptiPMSamplingSession(
-      const CuptiPMSamplingConfig& config,
-      std::unique_ptr<CuptiPMSamplingApi> api);
+  explicit CuptiPMSamplingSession(
+      std::unique_ptr<ICuptiPMSamplingController> controller);
   ~CuptiPMSamplingSession() override;
 
   [[nodiscard]] bool prepare();
@@ -51,7 +46,7 @@ class CuptiPMSamplingSession final
  private:
   [[nodiscard]] std::unique_ptr<libkineto::CpuTraceBuffer> buildTraceBuffer();
 
-  CuptiPMSamplingController controller_;
+  std::unique_ptr<ICuptiPMSamplingController> controller_;
   std::unique_ptr<libkineto::CpuTraceBuffer> traceBuffer_;
 };
 
@@ -60,9 +55,6 @@ class CuptiPMSamplingSession final
 // IActivityProfiler, so this is the simplest way to introduce a new profiler.
 class CuptiPMSamplingProfiler final : public libkineto::IActivityProfiler {
  public:
-  CuptiPMSamplingProfiler();
-  explicit CuptiPMSamplingProfiler(CuptiPMSamplingApiFactory apiFactory);
-
   [[nodiscard]] const std::string& name() const override;
   [[nodiscard]] const std::set<libkineto::ActivityType>& availableActivities()
       const override;
@@ -74,9 +66,6 @@ class CuptiPMSamplingProfiler final : public libkineto::IActivityProfiler {
       int64_t durationMs,
       const std::set<libkineto::ActivityType>& activityTypes,
       const libkineto::Config& config) override;
-
- private:
-  CuptiPMSamplingApiFactory apiFactory_;
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiPMSamplingProfiler.h
+++ b/libkineto/src/CuptiPMSamplingProfiler.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <set>
 #include <string>
@@ -23,11 +24,17 @@ struct CpuTraceBuffer;
 
 namespace KINETO_NAMESPACE {
 
+using CuptiPMSamplingApiFactory =
+    std::function<std::unique_ptr<CuptiPMSamplingApi>()>;
+
 // TODO: Support dynamic collection toggling
 class CuptiPMSamplingSession final
     : public libkineto::IActivityProfilerSession {
  public:
   explicit CuptiPMSamplingSession(const CuptiPMSamplingConfig& config);
+  CuptiPMSamplingSession(
+      const CuptiPMSamplingConfig& config,
+      std::unique_ptr<CuptiPMSamplingApi> api);
   ~CuptiPMSamplingSession() override;
 
   [[nodiscard]] bool prepare();
@@ -53,6 +60,9 @@ class CuptiPMSamplingSession final
 // IActivityProfiler, so this is the simplest way to introduce a new profiler.
 class CuptiPMSamplingProfiler final : public libkineto::IActivityProfiler {
  public:
+  CuptiPMSamplingProfiler();
+  explicit CuptiPMSamplingProfiler(CuptiPMSamplingApiFactory apiFactory);
+
   [[nodiscard]] const std::string& name() const override;
   [[nodiscard]] const std::set<libkineto::ActivityType>& availableActivities()
       const override;
@@ -64,6 +74,9 @@ class CuptiPMSamplingProfiler final : public libkineto::IActivityProfiler {
       int64_t durationMs,
       const std::set<libkineto::ActivityType>& activityTypes,
       const libkineto::Config& config) override;
+
+ private:
+  CuptiPMSamplingApiFactory apiFactory_;
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -133,6 +133,21 @@ target_include_directories(CuptiActivityProfilerTest PRIVATE
     "${CUDA_SOURCE_DIR}/include"
     "${CUPTI_INCLUDE_DIR}")
 gtest_discover_tests(CuptiActivityProfilerTest)
+
+if(KINETO_ENABLE_CUPTI_PM_SAMPLING)
+# CuptiPMSamplingProfilerTest
+add_executable(CuptiPMSamplingProfilerTest
+    CuptiPMSamplingProfilerTest.cpp)
+target_link_libraries(CuptiPMSamplingProfilerTest PRIVATE
+    gtest_main
+    kineto_base kineto_api)
+target_include_directories(CuptiPMSamplingProfilerTest PRIVATE
+    "${LIBKINETO_DIR}"
+    "${LIBKINETO_DIR}/include"
+    "${LIBKINETO_DIR}/src")
+gtest_discover_tests(CuptiPMSamplingProfilerTest)
+endif()
+
 # CuptiCallbackApiTest
 add_executable(CuptiCallbackApiTest CuptiCallbackApiTest.cpp)
 target_link_libraries(CuptiCallbackApiTest PRIVATE

--- a/libkineto/test/CuptiPMSamplingProfilerTest.cpp
+++ b/libkineto/test/CuptiPMSamplingProfilerTest.cpp
@@ -24,13 +24,14 @@ using namespace KINETO_NAMESPACE;
 
 namespace {
 
-class FakeCuptiPMSamplingController final : public ICuptiPMSamplingController {
+class FakeCuptiPMSamplingController final : public CuptiPMSamplingController {
  public:
   FakeCuptiPMSamplingController(
       int32_t deviceId,
       std::vector<std::string> metricNames,
       std::vector<CuptiPMSample> samples = {})
-      : deviceId_(deviceId),
+      : CuptiPMSamplingController(CuptiPMSamplingConfig{}),
+        deviceId_(deviceId),
         metricNames_(std::move(metricNames)),
         samples_(std::move(samples)) {}
 

--- a/libkineto/test/CuptiPMSamplingProfilerTest.cpp
+++ b/libkineto/test/CuptiPMSamplingProfilerTest.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "include/Config.h"
+#include "src/CuptiPMSamplingProfiler.h"
+#include "src/CuptiTimestamp.h"
+#include "src/ThrowUtil.h"
+#include "src/output_membuf.h"
+
+using namespace KINETO_NAMESPACE;
+using namespace std::chrono_literals;
+
+namespace {
+
+struct FakeApiState {
+  bool waitForFirstDecode() {
+    std::unique_lock<std::mutex> lock(mutex);
+    return decodeCondition.wait_for(
+        lock, 2s, [this]() { return firstDecodeComplete; });
+  }
+
+  std::mutex mutex;
+  std::condition_variable decodeCondition;
+  CuptiPMSamplingConfig configured;
+  std::vector<CuptiPMSample> firstBatch;
+  int configureCalls{0};
+  int startCalls{0};
+  int decodeCalls{0};
+  int stopCalls{0};
+  int disableCalls{0};
+  bool firstDecodeComplete{false};
+  bool failConfigure{false};
+};
+
+class FakeCuptiPMSamplingApi final : public CuptiPMSamplingApi {
+ public:
+  explicit FakeCuptiPMSamplingApi(std::shared_ptr<FakeApiState> state)
+      : state_(std::move(state)) {}
+
+  void configure(const CuptiPMSamplingConfig& config) override {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    ++state_->configureCalls;
+    state_->configured = config;
+    if (state_->failConfigure) {
+      KINETO_THROW(std::runtime_error, "configure failed");
+    }
+  }
+
+  void start() override {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    ++state_->startCalls;
+  }
+
+  bool decode(std::vector<CuptiPMSample>& samples) override {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    ++state_->decodeCalls;
+    if (!state_->firstDecodeComplete) {
+      samples.insert(
+          samples.end(), state_->firstBatch.begin(), state_->firstBatch.end());
+      state_->firstDecodeComplete = true;
+      state_->decodeCondition.notify_all();
+    }
+    return true;
+  }
+
+  void stop() override {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    ++state_->stopCalls;
+  }
+
+  void disable() override {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    ++state_->disableCalls;
+  }
+
+ private:
+  std::shared_ptr<FakeApiState> state_;
+};
+
+CuptiPMSamplingProfiler makeProfiler(
+    const std::shared_ptr<FakeApiState>& state) {
+  return CuptiPMSamplingProfiler(
+      [state]() -> std::unique_ptr<CuptiPMSamplingApi> {
+        return std::make_unique<FakeCuptiPMSamplingApi>(state);
+      });
+}
+
+const std::set<ActivityType> kHardwareCounterActivities{
+    ActivityType::HARDWARE_COUNTERS};
+
+} // namespace
+
+TEST(CuptiPMSamplingProfilerTest, ReportsNameAndSupportedActivity) {
+  CuptiPMSamplingProfiler profiler;
+
+  EXPECT_EQ(profiler.name(), "CUPTI PM Sampling");
+  EXPECT_EQ(profiler.availableActivities(), kHardwareCounterActivities);
+}
+
+TEST(CuptiPMSamplingProfilerTest, RequiresActivityMetricsAndDevice) {
+  auto state = std::make_shared<FakeApiState>();
+  int apiCreations = 0;
+  CuptiPMSamplingProfiler profiler(
+      [state, &apiCreations]() -> std::unique_ptr<CuptiPMSamplingApi> {
+        ++apiCreations;
+        return std::make_unique<FakeCuptiPMSamplingApi>(state);
+      });
+
+  Config validConfig;
+  ASSERT_TRUE(
+      validConfig.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg\n"
+                        "CUPTI_PM_SAMPLING_DEVICE_ID = 0"));
+  EXPECT_EQ(profiler.configure({}, validConfig), nullptr);
+
+  Config missingMetrics;
+  ASSERT_TRUE(missingMetrics.parse("CUPTI_PM_SAMPLING_DEVICE_ID = 0"));
+  EXPECT_EQ(
+      profiler.configure(kHardwareCounterActivities, missingMetrics), nullptr);
+
+  Config missingDevice;
+  ASSERT_TRUE(
+      missingDevice.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg"));
+  EXPECT_EQ(
+      profiler.configure(kHardwareCounterActivities, missingDevice), nullptr);
+
+  EXPECT_EQ(apiCreations, 0);
+}
+
+TEST(CuptiPMSamplingProfilerTest, TimedConfigureForwardsSamplingConfig) {
+  configureCuptiTimestampSource(false);
+  auto state = std::make_shared<FakeApiState>();
+  auto profiler = makeProfiler(state);
+
+  Config config;
+  ASSERT_TRUE(
+      config.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg, "
+                   "dram__bytes_read.sum\n"
+                   "CUPTI_PM_SAMPLING_DEVICE_ID = 3"));
+
+  auto session = profiler.configure(
+      /*startTimeMs=*/123,
+      /*durationMs=*/456,
+      kHardwareCounterActivities,
+      config);
+  ASSERT_NE(session, nullptr);
+
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    EXPECT_EQ(state->configureCalls, 1);
+    EXPECT_EQ(state->configured.deviceId, 3);
+    EXPECT_EQ(
+        state->configured.metricNames,
+        std::vector<std::string>(
+            {"sm__cycles_active.avg", "dram__bytes_read.sum"}));
+    EXPECT_EQ(state->configured.samplingInterval, 1ms);
+  }
+
+  session.reset();
+  std::lock_guard<std::mutex> lock(state->mutex);
+  EXPECT_EQ(state->disableCalls, 1);
+}
+
+TEST(CuptiPMSamplingProfilerTest, ReturnsNullWhenPreparationFails) {
+  configureCuptiTimestampSource(false);
+  auto state = std::make_shared<FakeApiState>();
+  state->failConfigure = true;
+  auto profiler = makeProfiler(state);
+
+  Config config;
+  ASSERT_TRUE(
+      config.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg\n"
+                   "CUPTI_PM_SAMPLING_DEVICE_ID = 0"));
+
+  EXPECT_EQ(profiler.configure(kHardwareCounterActivities, config), nullptr);
+
+  std::lock_guard<std::mutex> lock(state->mutex);
+  EXPECT_EQ(state->configureCalls, 1);
+  EXPECT_EQ(state->disableCalls, 1);
+}
+
+TEST(CuptiPMSamplingProfilerTest, BuildsHardwareCounterActivities) {
+  configureCuptiTimestampSource(false);
+  auto state = std::make_shared<FakeApiState>();
+  state->firstBatch = {
+      CuptiPMSample{10, 20, {999.0, 999.0}},
+      CuptiPMSample{100, 120, {1.25, 2048.0}},
+      CuptiPMSample{130, 170, {2.5, 4096.0}},
+  };
+  auto profiler = makeProfiler(state);
+
+  Config config;
+  ASSERT_TRUE(
+      config.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg, "
+                   "dram__bytes_read.sum\n"
+                   "CUPTI_PM_SAMPLING_DEVICE_ID = 2"));
+
+  auto session = profiler.configure(kHardwareCounterActivities, config);
+  ASSERT_NE(session, nullptr);
+  session->start();
+  ASSERT_TRUE(state->waitForFirstDecode());
+  session->stop();
+
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    EXPECT_EQ(state->startCalls, 1);
+    EXPECT_GE(state->decodeCalls, 2);
+    EXPECT_EQ(state->stopCalls, 1);
+    EXPECT_EQ(state->disableCalls, 1);
+  }
+
+  MemoryTraceLogger logger(config);
+  session->processTrace(logger);
+  const auto* loggedActivities = logger.traceActivities();
+  ASSERT_EQ(loggedActivities->size(), 2);
+
+  const auto& first = *loggedActivities->at(0);
+  EXPECT_EQ(first.type(), ActivityType::HARDWARE_COUNTERS);
+  EXPECT_EQ(first.name(), "CUPTI PM Sampling");
+  EXPECT_EQ(first.deviceId(), 2);
+  EXPECT_EQ(first.timestamp(), 100);
+  EXPECT_EQ(first.duration(), 20);
+  ASSERT_EQ(first.counterValues().size(), 2);
+  EXPECT_EQ(first.counterValues()[0].first, "sm__cycles_active.avg");
+  EXPECT_DOUBLE_EQ(first.counterValues()[0].second, 1.25);
+  EXPECT_EQ(first.counterValues()[1].first, "dram__bytes_read.sum");
+  EXPECT_DOUBLE_EQ(first.counterValues()[1].second, 2048.0);
+
+  const auto& second = *loggedActivities->at(1);
+  EXPECT_EQ(second.timestamp(), 130);
+  EXPECT_EQ(second.duration(), 40);
+  ASSERT_EQ(second.counterValues().size(), 2);
+  EXPECT_DOUBLE_EQ(second.counterValues()[0].second, 2.5);
+  EXPECT_DOUBLE_EQ(second.counterValues()[1].second, 4096.0);
+
+  auto buffer = session->getTraceBuffer();
+  ASSERT_NE(buffer, nullptr);
+  EXPECT_EQ(buffer->span.name, "CUPTI PM Sampling");
+  EXPECT_EQ(buffer->span.startTime, 100);
+  EXPECT_EQ(buffer->span.endTime, 170);
+  EXPECT_EQ(buffer->activities.size(), 2);
+  EXPECT_EQ(session->getTraceBuffer().get(), nullptr);
+}

--- a/libkineto/test/CuptiPMSamplingProfilerTest.cpp
+++ b/libkineto/test/CuptiPMSamplingProfilerTest.cpp
@@ -8,12 +8,9 @@
 
 #include <gtest/gtest.h>
 
-#include <chrono>
-#include <condition_variable>
+#include <cstdint>
 #include <memory>
-#include <mutex>
 #include <set>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -21,86 +18,61 @@
 #include "include/Config.h"
 #include "src/CuptiPMSamplingProfiler.h"
 #include "src/CuptiTimestamp.h"
-#include "src/ThrowUtil.h"
 #include "src/output_membuf.h"
 
 using namespace KINETO_NAMESPACE;
-using namespace std::chrono_literals;
 
 namespace {
 
-struct FakeApiState {
-  bool waitForFirstDecode() {
-    std::unique_lock<std::mutex> lock(mutex);
-    return decodeCondition.wait_for(
-        lock, 2s, [this]() { return firstDecodeComplete; });
-  }
-
-  std::mutex mutex;
-  std::condition_variable decodeCondition;
-  CuptiPMSamplingConfig configured;
-  std::vector<CuptiPMSample> firstBatch;
-  int configureCalls{0};
-  int startCalls{0};
-  int decodeCalls{0};
-  int stopCalls{0};
-  int disableCalls{0};
-  bool firstDecodeComplete{false};
-  bool failConfigure{false};
-};
-
-class FakeCuptiPMSamplingApi final : public CuptiPMSamplingApi {
+class FakeCuptiPMSamplingController final : public ICuptiPMSamplingController {
  public:
-  explicit FakeCuptiPMSamplingApi(std::shared_ptr<FakeApiState> state)
-      : state_(std::move(state)) {}
+  FakeCuptiPMSamplingController(
+      int32_t deviceId,
+      std::vector<std::string> metricNames,
+      std::vector<CuptiPMSample> samples = {})
+      : deviceId_(deviceId),
+        metricNames_(std::move(metricNames)),
+        samples_(std::move(samples)) {}
 
-  void configure(const CuptiPMSamplingConfig& config) override {
-    std::lock_guard<std::mutex> lock(state_->mutex);
-    ++state_->configureCalls;
-    state_->configured = config;
-    if (state_->failConfigure) {
-      KINETO_THROW(std::runtime_error, "configure failed");
-    }
+  bool prepare() override {
+    ++prepareCalls;
+    return prepareResult;
   }
 
   void start() override {
-    std::lock_guard<std::mutex> lock(state_->mutex);
-    ++state_->startCalls;
+    ++startCalls;
   }
 
-  bool decode(std::vector<CuptiPMSample>& samples) override {
-    std::lock_guard<std::mutex> lock(state_->mutex);
-    ++state_->decodeCalls;
-    if (!state_->firstDecodeComplete) {
-      samples.insert(
-          samples.end(), state_->firstBatch.begin(), state_->firstBatch.end());
-      state_->firstDecodeComplete = true;
-      state_->decodeCondition.notify_all();
-    }
-    return true;
+  bool stop() override {
+    ++stopCalls;
+    return stopResult;
   }
 
-  void stop() override {
-    std::lock_guard<std::mutex> lock(state_->mutex);
-    ++state_->stopCalls;
+  int32_t deviceId() const override {
+    return deviceId_;
   }
 
-  void disable() override {
-    std::lock_guard<std::mutex> lock(state_->mutex);
-    ++state_->disableCalls;
+  const std::vector<std::string>& metricNames() const override {
+    return metricNames_;
   }
+
+  std::vector<CuptiPMSample> takeSamples() override {
+    ++takeSamplesCalls;
+    return std::exchange(samples_, {});
+  }
+
+  bool prepareResult{true};
+  bool stopResult{true};
+  int prepareCalls{0};
+  int startCalls{0};
+  int stopCalls{0};
+  int takeSamplesCalls{0};
 
  private:
-  std::shared_ptr<FakeApiState> state_;
+  int32_t deviceId_;
+  std::vector<std::string> metricNames_;
+  std::vector<CuptiPMSample> samples_;
 };
-
-CuptiPMSamplingProfiler makeProfiler(
-    const std::shared_ptr<FakeApiState>& state) {
-  return CuptiPMSamplingProfiler(
-      [state]() -> std::unique_ptr<CuptiPMSamplingApi> {
-        return std::make_unique<FakeCuptiPMSamplingApi>(state);
-      });
-}
 
 const std::set<ActivityType> kHardwareCounterActivities{
     ActivityType::HARDWARE_COUNTERS};
@@ -115,13 +87,7 @@ TEST(CuptiPMSamplingProfilerTest, ReportsNameAndSupportedActivity) {
 }
 
 TEST(CuptiPMSamplingProfilerTest, RequiresActivityMetricsAndDevice) {
-  auto state = std::make_shared<FakeApiState>();
-  int apiCreations = 0;
-  CuptiPMSamplingProfiler profiler(
-      [state, &apiCreations]() -> std::unique_ptr<CuptiPMSamplingApi> {
-        ++apiCreations;
-        return std::make_unique<FakeCuptiPMSamplingApi>(state);
-      });
+  CuptiPMSamplingProfiler profiler;
 
   Config validConfig;
   ASSERT_TRUE(
@@ -139,94 +105,43 @@ TEST(CuptiPMSamplingProfilerTest, RequiresActivityMetricsAndDevice) {
       missingDevice.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg"));
   EXPECT_EQ(
       profiler.configure(kHardwareCounterActivities, missingDevice), nullptr);
-
-  EXPECT_EQ(apiCreations, 0);
 }
 
-TEST(CuptiPMSamplingProfilerTest, TimedConfigureForwardsSamplingConfig) {
+TEST(CuptiPMSamplingSessionTest, ReportsPreparationFailure) {
   configureCuptiTimestampSource(false);
-  auto state = std::make_shared<FakeApiState>();
-  auto profiler = makeProfiler(state);
+  auto controller = std::make_unique<FakeCuptiPMSamplingController>(
+      0, std::vector<std::string>{"sm__cycles_active.avg"});
+  controller->prepareResult = false;
+  auto* controllerPtr = controller.get();
+  CuptiPMSamplingSession session(std::move(controller));
 
-  Config config;
-  ASSERT_TRUE(
-      config.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg, "
-                   "dram__bytes_read.sum\n"
-                   "CUPTI_PM_SAMPLING_DEVICE_ID = 3"));
-
-  auto session = profiler.configure(
-      /*startTimeMs=*/123,
-      /*durationMs=*/456,
-      kHardwareCounterActivities,
-      config);
-  ASSERT_NE(session, nullptr);
-
-  {
-    std::lock_guard<std::mutex> lock(state->mutex);
-    EXPECT_EQ(state->configureCalls, 1);
-    EXPECT_EQ(state->configured.deviceId, 3);
-    EXPECT_EQ(
-        state->configured.metricNames,
-        std::vector<std::string>(
-            {"sm__cycles_active.avg", "dram__bytes_read.sum"}));
-    EXPECT_EQ(state->configured.samplingInterval, 1ms);
-  }
-
-  session.reset();
-  std::lock_guard<std::mutex> lock(state->mutex);
-  EXPECT_EQ(state->disableCalls, 1);
+  EXPECT_FALSE(session.prepare());
+  EXPECT_EQ(controllerPtr->prepareCalls, 1);
 }
 
-TEST(CuptiPMSamplingProfilerTest, ReturnsNullWhenPreparationFails) {
+TEST(CuptiPMSamplingSessionTest, BuildsHardwareCounterActivities) {
   configureCuptiTimestampSource(false);
-  auto state = std::make_shared<FakeApiState>();
-  state->failConfigure = true;
-  auto profiler = makeProfiler(state);
+  auto controller = std::make_unique<FakeCuptiPMSamplingController>(
+      2,
+      std::vector<std::string>{"sm__cycles_active.avg", "dram__bytes_read.sum"},
+      std::vector<CuptiPMSample>{
+          CuptiPMSample{100, 120, {1.25, 2048.0}},
+          CuptiPMSample{130, 170, {2.5, 4096.0}},
+      });
+  auto* controllerPtr = controller.get();
+  CuptiPMSamplingSession session(std::move(controller));
+  ASSERT_TRUE(session.prepare());
+  session.start();
+  session.stop();
+
+  EXPECT_EQ(controllerPtr->prepareCalls, 1);
+  EXPECT_EQ(controllerPtr->startCalls, 1);
+  EXPECT_EQ(controllerPtr->stopCalls, 1);
+  EXPECT_EQ(controllerPtr->takeSamplesCalls, 1);
 
   Config config;
-  ASSERT_TRUE(
-      config.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg\n"
-                   "CUPTI_PM_SAMPLING_DEVICE_ID = 0"));
-
-  EXPECT_EQ(profiler.configure(kHardwareCounterActivities, config), nullptr);
-
-  std::lock_guard<std::mutex> lock(state->mutex);
-  EXPECT_EQ(state->configureCalls, 1);
-  EXPECT_EQ(state->disableCalls, 1);
-}
-
-TEST(CuptiPMSamplingProfilerTest, BuildsHardwareCounterActivities) {
-  configureCuptiTimestampSource(false);
-  auto state = std::make_shared<FakeApiState>();
-  state->firstBatch = {
-      CuptiPMSample{10, 20, {999.0, 999.0}},
-      CuptiPMSample{100, 120, {1.25, 2048.0}},
-      CuptiPMSample{130, 170, {2.5, 4096.0}},
-  };
-  auto profiler = makeProfiler(state);
-
-  Config config;
-  ASSERT_TRUE(
-      config.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg, "
-                   "dram__bytes_read.sum\n"
-                   "CUPTI_PM_SAMPLING_DEVICE_ID = 2"));
-
-  auto session = profiler.configure(kHardwareCounterActivities, config);
-  ASSERT_NE(session, nullptr);
-  session->start();
-  ASSERT_TRUE(state->waitForFirstDecode());
-  session->stop();
-
-  {
-    std::lock_guard<std::mutex> lock(state->mutex);
-    EXPECT_EQ(state->startCalls, 1);
-    EXPECT_GE(state->decodeCalls, 2);
-    EXPECT_EQ(state->stopCalls, 1);
-    EXPECT_EQ(state->disableCalls, 1);
-  }
-
   MemoryTraceLogger logger(config);
-  session->processTrace(logger);
+  session.processTrace(logger);
   const auto* loggedActivities = logger.traceActivities();
   ASSERT_EQ(loggedActivities->size(), 2);
 
@@ -249,11 +164,11 @@ TEST(CuptiPMSamplingProfilerTest, BuildsHardwareCounterActivities) {
   EXPECT_DOUBLE_EQ(second.counterValues()[0].second, 2.5);
   EXPECT_DOUBLE_EQ(second.counterValues()[1].second, 4096.0);
 
-  auto buffer = session->getTraceBuffer();
+  auto buffer = session.getTraceBuffer();
   ASSERT_NE(buffer, nullptr);
   EXPECT_EQ(buffer->span.name, "CUPTI PM Sampling");
   EXPECT_EQ(buffer->span.startTime, 100);
   EXPECT_EQ(buffer->span.endTime, 170);
   EXPECT_EQ(buffer->activities.size(), 2);
-  EXPECT_EQ(session->getTraceBuffer().get(), nullptr);
+  EXPECT_EQ(session.getTraceBuffer().get(), nullptr);
 }

--- a/libkineto/test/CuptiPMSamplingProfilerTest.cpp
+++ b/libkineto/test/CuptiPMSamplingProfilerTest.cpp
@@ -93,7 +93,13 @@ TEST(CuptiPMSamplingProfilerTest, RequiresActivityMetricsAndDevice) {
   ASSERT_TRUE(
       validConfig.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg\n"
                         "CUPTI_PM_SAMPLING_DEVICE_ID = 0"));
-  EXPECT_EQ(profiler.configure({}, validConfig), nullptr);
+  EXPECT_EQ(
+      profiler.configure(
+          /*startTimeMs=*/123,
+          /*durationMs=*/456,
+          /*activityTypes=*/{},
+          validConfig),
+      nullptr);
 
   Config missingMetrics;
   ASSERT_TRUE(missingMetrics.parse("CUPTI_PM_SAMPLING_DEVICE_ID = 0"));
@@ -117,6 +123,27 @@ TEST(CuptiPMSamplingSessionTest, ReportsPreparationFailure) {
 
   EXPECT_FALSE(session.prepare());
   EXPECT_EQ(controllerPtr->prepareCalls, 1);
+}
+
+TEST(CuptiPMSamplingSessionTest, InactiveStopDoesNotBuildTrace) {
+  auto controller = std::make_unique<FakeCuptiPMSamplingController>(
+      0,
+      std::vector<std::string>{"sm__cycles_active.avg"},
+      std::vector<CuptiPMSample>{CuptiPMSample{100, 120, {1.25}}});
+  controller->stopResult = false;
+  auto* controllerPtr = controller.get();
+  CuptiPMSamplingSession session(std::move(controller));
+
+  session.stop();
+
+  EXPECT_EQ(controllerPtr->stopCalls, 1);
+  EXPECT_EQ(controllerPtr->takeSamplesCalls, 0);
+  EXPECT_EQ(session.getTraceBuffer(), nullptr);
+
+  Config config;
+  MemoryTraceLogger logger(config);
+  session.processTrace(logger);
+  EXPECT_TRUE(logger.traceActivities()->empty());
 }
 
 TEST(CuptiPMSamplingSessionTest, BuildsHardwareCounterActivities) {

--- a/libkineto/test/CuptiPMSamplingProfilerTest.cpp
+++ b/libkineto/test/CuptiPMSamplingProfilerTest.cpp
@@ -24,14 +24,13 @@ using namespace KINETO_NAMESPACE;
 
 namespace {
 
-class FakeCuptiPMSamplingController final : public CuptiPMSamplingController {
+class FakeCuptiPMSamplingController final : public ICuptiPMSamplingController {
  public:
   FakeCuptiPMSamplingController(
       int32_t deviceId,
       std::vector<std::string> metricNames,
       std::vector<CuptiPMSample> samples = {})
-      : CuptiPMSamplingController(CuptiPMSamplingConfig{}),
-        deviceId_(deviceId),
+      : deviceId_(deviceId),
         metricNames_(std::move(metricNames)),
         samples_(std::move(samples)) {}
 


### PR DESCRIPTION
Adds `ICuptiPMSamplingController` so that we can pass in a dummy controller object to the Profiler for unit testing.