### PR TITLE
Build system_clock time points portably in the profiler tests

### DIFF
--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -344,10 +344,10 @@ TEST_F(CuptiActivityProfilerTest, SyncTrace) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
   libkineto::get_time_converter() = [](approx_time_t t) { return t; };
 
   profiler.recordThreadInfo();
@@ -524,10 +524,10 @@ TEST_F(CuptiActivityProfilerTest, SyncEventCorrIdOutOfOrder) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
   libkineto::get_time_converter() = [](approx_time_t t) { return t; };
 
   profiler.recordThreadInfo();
@@ -657,10 +657,10 @@ TEST_F(CuptiActivityProfilerTest, GpuNCCLCollectiveTest) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
   libkineto::get_time_converter() = [](approx_time_t t) { return t; };
 
   int64_t kernelLaunchTime = start_time_ns + 20;
@@ -830,10 +830,10 @@ TEST_F(CuptiActivityProfilerTest, GpuUserAnnotationTest) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
   libkineto::get_time_converter() = [](approx_time_t t) { return t; };
 
   int64_t kernelLaunchTime = start_time_ns + 20;
@@ -900,7 +900,7 @@ TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 1000;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
 
   std::deque<GenericTraceActivity> test_activities{3, ev};
   test_activities[0].startTime = start_time_ns;
@@ -922,7 +922,7 @@ TEST_F(CuptiActivityProfilerTest, SubActivityProfilers) {
 
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
 
   auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
   LOG(INFO) << "Logging to tmp file " << tmpTrace.path();
@@ -956,10 +956,10 @@ TEST_F(CuptiActivityProfilerTest, JsonGPUIDSortTest) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 500;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
   libkineto::get_time_converter() = [](approx_time_t t) { return t; };
   profiler.recordThreadInfo();
 
@@ -1040,10 +1040,10 @@ TEST_F(CuptiActivityProfilerTest, StreamWaitEventFutureCorrelation) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 500;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
   libkineto::get_time_converter() = [](approx_time_t t) { return t; };
   profiler.recordThreadInfo();
 
@@ -1101,14 +1101,14 @@ TEST_F(CuptiActivityProfilerTest, WaitEventMapClearedOnReset) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 500;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
 
   // Session 1: record eventId=42 with corrId=100, then reset.
   {
     CuptiActivityProfiler profiler(cuptiActivities_, /*cpu only*/ false);
     profiler.configure(*cfg_, start_time);
     profiler.startTrace(start_time);
-    profiler.stopTrace(start_time + nanoseconds(duration_ns));
+    profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
     libkineto::get_time_converter() = [](approx_time_t t) { return t; };
     profiler.recordThreadInfo();
 
@@ -1133,14 +1133,14 @@ TEST_F(CuptiActivityProfilerTest, WaitEventMapClearedOnReset) {
   {
     CuptiActivityProfiler profiler2(cuptiActivities_, /*cpu only*/ false);
     int64_t start_time_ns2 = start_time_ns + 10000;
-    auto start_time2 = time_point<system_clock>(nanoseconds(start_time_ns2));
+    auto start_time2 = timePointFromNs(start_time_ns2);
 
     auto cfg2 = std::make_unique<Config>();
     cfg2->validate(std::chrono::system_clock::now());
 
     profiler2.configure(*cfg2, start_time2);
     profiler2.startTrace(start_time2);
-    profiler2.stopTrace(start_time2 + nanoseconds(duration_ns));
+    profiler2.stopTrace(timePointFromNs(start_time_ns2 + duration_ns));
     libkineto::get_time_converter() = [](approx_time_t t) { return t; };
     profiler2.recordThreadInfo();
 

--- a/libkineto/test/RocmActivityProfilerTest.cpp
+++ b/libkineto/test/RocmActivityProfilerTest.cpp
@@ -322,10 +322,10 @@ TEST_F(RocmActivityProfilerTest, SyncTrace) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
 
   profiler.recordThreadInfo();
 
@@ -408,10 +408,10 @@ TEST_F(RocmActivityProfilerTest, GpuTypedMetadataMatchesLegacyStreamMetadata) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
 
   auto gpuOps = std::make_unique<MockRocLogger>();
   gpuOps->addMemcpyH2DActivity(start_time_ns + 10, start_time_ns + 20, 1, 42);
@@ -448,10 +448,10 @@ TEST_F(
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
 
   auto gpuOps = std::make_unique<MockRocLogger>();
   gpuOps->addRuntimeKernelActivity(
@@ -511,10 +511,10 @@ TEST_F(RocmActivityProfilerTest, HtoDMemcpyPrefersRuntimeStreamOverAsyncQueue) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
 
   auto gpuOps = std::make_unique<MockRocLogger>();
   gpuOps->addRuntimeKernelActivity(
@@ -561,10 +561,10 @@ TEST_F(
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
 
   auto gpuOps = std::make_unique<MockRocLogger>();
   gpuOps->addRuntimeKernelActivity(
@@ -614,10 +614,10 @@ TEST_F(RocmActivityProfilerTest, GpuNCCLCollectiveTest) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
 
   int64_t kernelLaunchTime = start_time_ns + 20;
   profiler.recordThreadInfo();
@@ -774,10 +774,10 @@ TEST_F(RocmActivityProfilerTest, GpuUserAnnotationTest) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 300;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
 
   int64_t kernelLaunchTime = start_time_ns + 20;
   profiler.recordThreadInfo();
@@ -844,7 +844,7 @@ TEST_F(RocmActivityProfilerTest, SubActivityProfilers) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 1000;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
 
   std::deque<GenericTraceActivity> test_activities{3, ev};
   test_activities[0].startTime = start_time_ns;
@@ -867,7 +867,7 @@ TEST_F(RocmActivityProfilerTest, SubActivityProfilers) {
 
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
 
   auto tmpTrace = createTempTraceFile("libkineto_test", ".json");
   LOG(INFO) << "Logging to tmp file " << tmpTrace.path();
@@ -901,10 +901,10 @@ TEST_F(RocmActivityProfilerTest, JsonGPUIDSortTest) {
   int64_t start_time_ns =
       libkineto::timeSinceEpoch(std::chrono::system_clock::now());
   int64_t duration_ns = 500;
-  auto start_time = time_point<system_clock>(nanoseconds(start_time_ns));
+  auto start_time = timePointFromNs(start_time_ns);
   profiler.configure(*cfg_, start_time);
   profiler.startTrace(start_time);
-  profiler.stopTrace(start_time + nanoseconds(duration_ns));
+  profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));
   profiler.recordThreadInfo();
 
   // Set up CPU events

--- a/libkineto/test/TestUtils.cpp
+++ b/libkineto/test/TestUtils.cpp
@@ -179,4 +179,10 @@ void checkTracefile(const char* path) {
 #endif
 }
 
+std::chrono::system_clock::time_point timePointFromNs(int64_t ns) {
+  return std::chrono::system_clock::time_point(
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(
+          std::chrono::nanoseconds(ns)));
+}
+
 } // namespace libkineto::test

--- a/libkineto/test/TestUtils.h
+++ b/libkineto/test/TestUtils.h
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <string_view>
 
@@ -62,5 +64,15 @@ size_t countSubstrings(const std::string& source, const std::string& substring);
 // Asserts (via gtest) that the file at path exists and holds more than 100
 // bytes. No-op on non-Linux platforms.
 void checkTracefile(const char* path);
+
+// Builds a system_clock time point from a count of nanoseconds since the
+// epoch, the inverse of timeSinceEpoch().
+//
+// system_clock measures in nanoseconds under libstdc++ but in 100-nanosecond
+// ticks under MSVC, so a nanosecond count is not implicitly convertible to the
+// clock's own duration everywhere: MSVC rejects it as narrowing. Converting
+// explicitly works on both. Nothing is lost in practice, because MSVC's
+// system_clock has no finer resolution than those ticks to begin with.
+[[nodiscard]] std::chrono::system_clock::time_point timePointFromNs(int64_t ns);
 
 } // namespace libkineto::test


### PR DESCRIPTION
**Problem** — The Windows CUDA build fails compiling `CuptiActivityProfilerTest` with a wall of C2440 and C2664 errors: it cannot convert `std::chrono::nanoseconds` to a `system_clock` time point. The tests build one with

    time_point<system_clock>(nanoseconds(start_time_ns))

which works only because libstdc++ happens to measure `system_clock` in nanoseconds, making that an exact match. MSVC measures it in 100-nanosecond ticks, so the same expression is a narrowing conversion and `std::chrono` refuses it implicitly. The follow-on arithmetic, `start_time + nanoseconds(duration_ns)`, has the same problem: it yields a nanosecond-resolution time point that will not convert back to the one the profiler API takes.

The test only started building on Windows once #1529 removed the guard around it, so nothing caught this before.

**Fix** — Add `timePointFromNs()` to `TestUtils`, the inverse of `timeSinceEpoch()`, which converts through `duration_cast` to whatever duration the clock actually uses. Call sites take a nanosecond count and convert once, which also removes the mixed-resolution arithmetic:

    profiler.stopTrace(timePointFromNs(start_time_ns + duration_ns));

Nothing is lost on Windows. Every duration these tests use is a multiple of 100ns (300, 500, 1000), and `start_time_ns` comes from `system_clock::now()`, which on MSVC has no resolution finer than its own ticks to begin with.

`RocmActivityProfilerTest` carries the identical pattern in nine more places. It is not built on Windows -- the rocm backend needs rocprofiler-sdk -- but it shares the helper, so it is converted too rather than left as the one copy still relying on libstdc++'s choice of tick.