### PR TITLE
Discard completed CUPTI buffers when nothing is in flight

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -253,6 +253,10 @@ void CuptiActivityApi::clearActivities() {
   {
     std::lock_guard<std::mutex> guard(mutex_);
     if (allocatedGpuTraceBuffers_.empty()) {
+      // Nothing is in flight, so there is nothing to flush - but CUPTI may have
+      // already handed back completed buffers, and callers ask us to clear so
+      // that those records do not reach the trace.
+      readyGpuTraceBuffers_.reset();
       return;
     }
   }
@@ -265,7 +269,7 @@ void CuptiActivityApi::clearActivities() {
   // for active tracing during warmup.
   std::lock_guard<std::mutex> guard(mutex_);
   // Throw away ready buffers as a result of above flush
-  readyGpuTraceBuffers_ = nullptr;
+  readyGpuTraceBuffers_.reset();
 }
 
 void CUPTIAPI CuptiActivityApi::bufferCompletedTrampoline(

--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -285,6 +285,19 @@ struct MockCuptiActivityBuffer {
   std::vector<CUpti_Activity*> activities;
 };
 
+// Drives the real buffer callbacks so tests can check the bookkeeping without a
+// CUDA context. Two preconditions keep that from reaching into live CUPTI, and
+// both are easy to break.
+//
+// First, the completed buffer carries a null context. At verbosity 1 and above
+// bufferCompleted asks CUPTI for its dropped-record count, so a run at that
+// verbosity makes a real CUPTI call with that null context. Only the paths that
+// discard a buffer outright return before reaching it.
+//
+// Second, every test drains the allocated buffers before calling
+// activityBuffers or clearActivities, both of which short-circuit when nothing
+// is in flight. A test that leaves a buffer allocated will instead ask CUPTI to
+// flush for real.
 class CallbackCuptiActivityApi : public CuptiActivityApi {
  public:
   using CuptiActivityApi::canRejectBuffer_;
@@ -377,6 +390,23 @@ TEST(CuptiActivityApiTest, RejectsBuffersWhenSupported) {
   EXPECT_EQ(thirdBuffer, nullptr);
   EXPECT_EQ(thirdSize, 0);
   EXPECT_NE(cupti.activityBuffers(), nullptr);
+}
+
+TEST(CuptiActivityApiTest, ClearsCompletedBuffers) {
+  CallbackCuptiActivityApi cupti;
+  cupti.canRejectBuffer_ = true;
+  cupti.setMaxBufferSize(0);
+
+  auto [buffer, size] = cupti.requestBuffer();
+  ASSERT_NE(buffer, nullptr);
+  ASSERT_GT(size, 0);
+  cupti.completeBuffer(buffer, size);
+  ASSERT_FALSE(cupti.stopCollection);
+
+  // The completion left nothing in flight, so this takes the path that has no
+  // buffers to flush. It still has to drop the completed one.
+  cupti.clearActivities();
+  EXPECT_EQ(cupti.activityBuffers(), nullptr);
 }
 
 // Common setup / teardown and helper functions


### PR DESCRIPTION
**Problem**

Kineto drops activities recorded during the warmup period so it does not show up in the collected trace, and it drops leftover activitoes when resetting between sessions. Both go through `clearActivities()`, which gives up early whenever no buffers are in flight with CUPTI.

But having nothing in flight means there is nothing to ask CUPTI to flush; it says nothing about whether CUPTI has **already handed back completed buffers**. In the common case CUPTI returns buffers promptly, and the warmup flush runs on a runloop tick after everything has come back - the early return fires and the warmup records survive. They either land in the trace the user collects or carry over into the next session.

This problem is increased with #1534, where we still give back valid buffers after crossing the size limit for certain CUPTI versions.

**Fix**

Release the completed buffers before returning. This mirrors what #1362 did one function down in `activityBuffers()`. This also mitigates the harm of giving back valid buffers when we've hit the size limit, as we're actually clearing them out on the other side.

The new `ClearsCompletedBuffers` case fails without the fix. It also documents the two preconditions that keep the buffer tests away from live CUPTI - a null `CUcontext` that reaches `cuptiActivityGetNumDroppedRecords` when run at verbosity 1, and the drained allocated-buffer map that lets `activityBuffers()` and `clearActivities()` short-circuit instead of asking CUPTI to flush.