### PR TITLE
[Kineto] CUPTI PM sampling improvements

### DIFF
--- a/libkineto/src/CuptiPMSamplingApi.cpp
+++ b/libkineto/src/CuptiPMSamplingApi.cpp
@@ -49,6 +49,12 @@ namespace {
 constexpr size_t kHardwareBufferSizeBytes = 64 * 1024 * 1024;
 constexpr uint32_t kMaxSamplesPerDecode = 1024;
 
+// GA100 only supports variable-frequency SYSCLK sampling. One option is to
+// measure hardware clock frequency and estimate the number of cycles needed to
+// fill a certain sampling duration, but clock frequency is not necessarily
+// fixed. This is almost certainly something we'll need to revisit/tune.
+constexpr uint64_t kGa100SamplingIntervalCycles = 1'000'000;
+
 /*
  * ========================== CUPTI PM SAMPLING API ==========================
  *
@@ -146,9 +152,6 @@ void CuptiPMSamplingApi::configureCupti() {
         std::runtime_error, "cuptiDeviceGetChipName returned no chip name");
   }
 
-  // Currently, only CUPTI_PM_SAMPLING_TRIGGER_MODE_GPU_TIME_INTERVAL is used
-  // in this code. According to CUPTI docs, this trigger mode is not supported
-  // on Turing or GA100 and is supported from GA10x onwards.
   cudaDeviceProp deviceProperties{};
   const auto cudaStatus =
       cudaGetDeviceProperties(&deviceProperties, config_.deviceId);
@@ -158,12 +161,27 @@ void CuptiPMSamplingApi::configureCupti() {
         std::string{"cudaGetDeviceProperties failed: "} +
             cudaGetErrorString(cudaStatus));
   }
-  if (deviceProperties.major < 8 ||
-      (deviceProperties.major == 8 && deviceProperties.minor < 6)) {
+  CUpti_PmSampling_TriggerMode triggerMode;
+  uint64_t samplingInterval;
+  // GPU_TIME_INTERVAL is unavailable on GA100. The wall-time duration of this
+  // fixed SYSCLK interval varies with the GPU's clock frequency.
+  if (deviceProperties.major == 8 && deviceProperties.minor == 0) {
+    triggerMode = CUPTI_PM_SAMPLING_TRIGGER_MODE_GPU_SYSCLK_INTERVAL;
+    samplingInterval = kGa100SamplingIntervalCycles;
+  } else if (
+      deviceProperties.major > 8 ||
+      (deviceProperties.major == 8 && deviceProperties.minor >= 6)) {
+    if (config_.samplingInterval.count() <= 0) {
+      KINETO_THROW(
+          std::runtime_error, "CUPTI PM sampling interval must be positive");
+    }
+    triggerMode = CUPTI_PM_SAMPLING_TRIGGER_MODE_GPU_TIME_INTERVAL;
+    samplingInterval = static_cast<uint64_t>(config_.samplingInterval.count());
+  } else {
     KINETO_THROW(
         std::runtime_error,
-        "CUPTI PM sampling requires a GPU that supports "
-        "GPU_TIME_INTERVAL (compute capability 8.6 or newer)");
+        "Minimum supported GPU for CUPTI PM sampling is GA100 (compute "
+        "capability 8.0); other GPUs require compute capability 8.6 or newer");
   }
 
   // Building the availability image. This is a CUPTI byte buffer describing
@@ -248,9 +266,8 @@ void CuptiPMSamplingApi::configureCupti() {
   setConfig.configSize = configImage_.size();
   setConfig.pConfig = configImage_.data();
   setConfig.hardwareBufferSize = kHardwareBufferSizeBytes;
-  setConfig.samplingInterval =
-      static_cast<uint64_t>(config_.samplingInterval.count());
-  setConfig.triggerMode = CUPTI_PM_SAMPLING_TRIGGER_MODE_GPU_TIME_INTERVAL;
+  setConfig.samplingInterval = samplingInterval;
+  setConfig.triggerMode = triggerMode;
   setConfig.hwBufferAppendMode =
       CUPTI_PM_SAMPLING_HARDWARE_BUFFER_APPEND_MODE_KEEP_LATEST;
   CUPTI_CALL_THROW(cuptiPmSamplingSetConfig(&setConfig));

--- a/libkineto/src/CuptiPMSamplingController.cpp
+++ b/libkineto/src/CuptiPMSamplingController.cpp
@@ -214,10 +214,6 @@ bool CuptiPMSamplingController::validateConfig() const {
     LOG(WARNING) << "CUPTI PM sampling metrics must not be empty";
     return false;
   }
-  if (config_.samplingInterval.count() <= 0) {
-    LOG(WARNING) << "CUPTI PM sampling interval must be positive";
-    return false;
-  }
   return true;
 }
 

--- a/libkineto/src/CuptiPMSamplingProfiler.cpp
+++ b/libkineto/src/CuptiPMSamplingProfiler.cpp
@@ -79,8 +79,6 @@ std::vector<std::string> CuptiPMSamplingSession::errors() {
   return {};
 }
 
-// TODO: Override the capture-window processTrace overload and exclude samples
-// collected during shutdown that fall outside the requested trace interval.
 void CuptiPMSamplingSession::processTrace(libkineto::ActivityLogger& logger) {
   if (!traceBuffer_) {
     return;
@@ -88,6 +86,44 @@ void CuptiPMSamplingSession::processTrace(libkineto::ActivityLogger& logger) {
   for (const auto& activity : traceBuffer_->activities) {
     logger.handleActivity(libkineto::CpuTraceBuffer::toRef(activity));
   }
+}
+
+void CuptiPMSamplingSession::processTrace(
+    libkineto::ActivityLogger& logger,
+    libkineto::getLinkedActivityCallback /*getLinkedActivity*/,
+    int64_t startTime,
+    int64_t endTime) {
+  if (!traceBuffer_) {
+    return;
+  }
+
+  // Drop PM samples that are not fully contained in [startTime, endTime].
+  auto& activities = traceBuffer_->activities;
+  activities.erase(
+      std::remove_if(
+          activities.begin(),
+          activities.end(),
+          [startTime, endTime](const auto& activity) {
+            return activity->startTime < startTime ||
+                activity->endTime > endTime;
+          }),
+      activities.end());
+
+  if (activities.empty()) {
+    traceBuffer_->span.startTime = startTime;
+    traceBuffer_->span.endTime = endTime;
+  } else {
+    traceBuffer_->span.startTime = activities.front()->startTime;
+    traceBuffer_->span.endTime = activities.front()->endTime;
+    for (size_t i = 1; i < activities.size(); ++i) {
+      traceBuffer_->span.startTime =
+          std::min(traceBuffer_->span.startTime, activities[i]->startTime);
+      traceBuffer_->span.endTime =
+          std::max(traceBuffer_->span.endTime, activities[i]->endTime);
+    }
+  }
+
+  processTrace(logger);
 }
 
 std::unique_ptr<libkineto::DeviceInfo> CuptiPMSamplingSession::getDeviceInfo() {

--- a/libkineto/src/CuptiPMSamplingProfiler.h
+++ b/libkineto/src/CuptiPMSamplingProfiler.h
@@ -37,6 +37,11 @@ class CuptiPMSamplingSession final
   void stop() override;
   [[nodiscard]] std::vector<std::string> errors() override;
   void processTrace(libkineto::ActivityLogger& logger) override;
+  void processTrace(
+      libkineto::ActivityLogger& logger,
+      libkineto::getLinkedActivityCallback getLinkedActivity,
+      int64_t startTime,
+      int64_t endTime) override;
   [[nodiscard]] std::unique_ptr<libkineto::DeviceInfo> getDeviceInfo() override;
   [[nodiscard]] std::vector<libkineto::ResourceInfo> getResourceInfos()
       override;


### PR DESCRIPTION
Two changes:
1. Support A100 machines, which do not support sampling frequency based on duration, only clock cycles. I had hoped to convert a requested duration to clock cycles by querying the device properties, but the frequency listed on there might not be the one that is used when profiling is run. I don't want to get into a cycle where I'm tuning some equation to make this work, so I am hardcoding something that seems reasonable for now and am open to changing this later. The initial value is based on the PM sampling doc example listing 100000 cycles -> 100 us.
2. Truncate and PM samples that fall outside the start, end range of profiling. Note that we need to fully drop instead of trimming any samples that fall out of range because the metrics are aggregated over the time period (mean, min, max, etc.) so changing the time period would change the value of the metric.