### PR TITLE
Compact PE instruction traces in Chrome JSON

### DIFF
--- a/libkineto/src/output_json.cpp
+++ b/libkineto/src/output_json.cpp
@@ -241,7 +241,8 @@ void ChromeTraceLogger::writeCompleteEvent(
     std::string_view tid,
     int64_t ts,
     int64_t dur,
-    const ArgsBuilder& args) {
+    const ArgsBuilder& args,
+    std::string_view extraFields) {
   // clang-format off
   fmt::print(traceOf_, R"JSON(
   {{
@@ -251,10 +252,17 @@ void ChromeTraceLogger::writeCompleteEvent(
     "pid": {},
     "tid": {},
     "ts": {},
-    "dur": {}
+    "dur": {}{}
     {}
   }},)JSON",
-      cat, name, pid, tid, fmtTs(ts), fmtTs(dur), args.renderField());
+      cat,
+      name,
+      pid,
+      tid,
+      fmtTs(ts),
+      fmtTs(dur),
+      extraFields,
+      args.renderField());
   // clang-format on
 }
 
@@ -363,9 +371,17 @@ void ChromeTraceLogger::writeCompleteEvent(
     int64_t tid,
     int64_t ts,
     int64_t dur,
-    const ArgsBuilder& args) {
+    const ArgsBuilder& args,
+    std::string_view extraFields) {
   writeCompleteEvent(
-      cat, name, std::to_string(pid), std::to_string(tid), ts, dur, args);
+      cat,
+      name,
+      std::to_string(pid),
+      std::to_string(tid),
+      ts,
+      dur,
+      args,
+      extraFields);
 }
 
 void ChromeTraceLogger::writeInstantEvent(
@@ -948,6 +964,16 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
   sanitizeForNonReadableChars(op_name);
   escapeQuotesForJSON(op_name);
 
+  const bool inlineInstructionFlow = op.flowId() > 0 &&
+      op.type() == ActivityType::MTIA_INSIGHT &&
+      op.getMetadataValue("event_type") == "instruction_trace";
+  const std::string flowFields = inlineInstructionFlow
+      ? fmt::format(
+            ",\n    \"bind_id\": {},\n    \"{}\": true",
+            op.flowId(),
+            op.flowStart() ? "flow_out" : "flow_in")
+      : std::string{};
+
   ts = transToRelativeTime(ts);
   writeCompleteEvent(
       /*cat=*/toString(op.type()),
@@ -956,8 +982,9 @@ void ChromeTraceLogger::handleActivity(const libkineto::ITraceActivity& op) {
       /*tid=*/sanitizeTid(resource),
       /*ts=*/ts,
       /*dur=*/duration,
-      /*args=*/args);
-  if (op.flowId() > 0) {
+      /*args=*/args,
+      /*extraFields=*/flowFields);
+  if (op.flowId() > 0 && !inlineInstructionFlow) {
     handleGenericLink(op);
   }
 }

--- a/libkineto/src/output_json.h
+++ b/libkineto/src/output_json.h
@@ -143,7 +143,8 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
       std::string_view tid,
       int64_t ts,
       int64_t dur,
-      const ArgsBuilder& args);
+      const ArgsBuilder& args,
+      std::string_view extraFields = {});
 
   void writeCompleteEvent(
       std::string_view cat,
@@ -152,7 +153,8 @@ class ChromeTraceLogger : public libkineto::ActivityLogger {
       int64_t tid,
       int64_t ts,
       int64_t dur,
-      const ArgsBuilder& args);
+      const ArgsBuilder& args,
+      std::string_view extraFields = {});
 
   void writeInstantEvent(
       std::string_view cat,

--- a/libkineto/test/OutputJsonTest.cpp
+++ b/libkineto/test/OutputJsonTest.cpp
@@ -14,6 +14,7 @@
 #include <iterator>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "include/GenericTraceActivity.h"
 #include "include/ThreadUtil.h"
@@ -149,6 +150,54 @@ TEST(OutputJsonTest, EventNameWithQuotesProducesValidJson) {
 
 TEST(OutputJsonTest, PlainEventNameIsUnchanged) {
   expectEventNameRoundTrips("aten::addmm");
+}
+
+TEST(OutputJsonTest, InstructionFlowIsAttachedToDurationSlices) {
+  const auto traceFile =
+      libkineto::test::createTempTraceFile("OutputJsonTest.", ".json");
+  TraceSpan span(0, 0, "test_span");
+
+  GenericTraceActivity receive(span, ActivityType::MTIA_INSIGHT, "sdin r1, r2");
+  receive.startTime = 100;
+  receive.endTime = 200;
+  receive.device = 10;
+  receive.resource = 20;
+  receive.flow.id = 123;
+  receive.flow.type = kLinkAsyncCpuGpu;
+  receive.flow.start = true;
+  receive.addMetadataQuoted("event_type", "instruction_trace");
+
+  GenericTraceActivity dispatch = receive;
+  dispatch.startTime = 300;
+  dispatch.endTime = 400;
+  dispatch.resource = 21;
+  dispatch.flow.start = false;
+
+  TestableChromeTraceLogger logger(traceFile.path());
+  logger.handleTraceStart({}, "");
+  logger.handleGenericActivity(receive);
+  logger.handleGenericActivity(dispatch);
+  logger.finalizeTrace(/*endTime=*/500);
+
+  const auto trace = nlohmann::json::parse(readFile(traceFile.path()));
+  std::vector<nlohmann::json> slices;
+  size_t standaloneFlows = 0;
+  for (const auto& event : trace["traceEvents"]) {
+    if (event.value("ph", "") == "s" || event.value("ph", "") == "f") {
+      ++standaloneFlows;
+    }
+    if (event.value("name", "") == "sdin r1, r2") {
+      slices.push_back(event);
+    }
+  }
+  ASSERT_EQ(slices.size(), 2);
+  EXPECT_EQ(slices[0]["bind_id"], 123);
+  EXPECT_TRUE(slices[0]["flow_out"]);
+  EXPECT_FALSE(slices[0].contains("flow_in"));
+  EXPECT_EQ(slices[1]["bind_id"], 123);
+  EXPECT_TRUE(slices[1]["flow_in"]);
+  EXPECT_FALSE(slices[1].contains("flow_out"));
+  EXPECT_EQ(standaloneFlows, 0);
 }
 
 TEST(OutputJsonTest, DisplayContainsThreadNameAndTID) {


### PR DESCRIPTION
Summary: Compact PE instruction traces in Chrome JSON by attaching bind_id and flow_out or flow_in directly to instruction duration slices, eliminating standalone instruction flow records while preserving existing behavior for other activity types. Also omit the redundant raw instruction_trace array once instruction_traces_processed is available. This revision does not change PerfettoTraceLogger or native .pftrace output; native generic GPU TrackEvent support is deferred to the upstream Perfetto-based follow-up.

Reviewed By: zytyz

Differential Revision: D116032623


