### PR TITLE
[XPU] Improve include hygiene in the XPU PTI Kineto plugin

### DIFF
--- a/libkineto/src/plugin/xpupti/XpuptiActivityApi.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityApi.cpp
@@ -7,12 +7,19 @@
  */
 
 #include "XpuptiActivityApi.h"
+#include "ILoggerObserver.h"
+#include "Logger.h"
+#include "XpuptiActivityBuffer.h"
+#include "XpuptiProfilerMacros.h"
 
 #include <chrono>
+#include <cstdlib>
 #include <filesystem>
-#include <stdexcept>
+#include <map>
+#include <ostream>
+#include <system_error>
 
-#include "Logger.h"
+#include <pti/pti.h>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiActivityApi.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityApi.h
@@ -8,15 +8,18 @@
 
 #pragma once
 
-#include "XpuptiActivityBuffer.h"
-#include "XpuptiProfilerMacros.h"
-
 #include "ActivityType.h"
+#include "XpuptiActivityBuffer.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <utility>
 
 #include <pti/pti_view.h>
-
-#include <functional>
-#include <mutex>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
@@ -6,16 +6,32 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "ActivityType.h"
+#include "GenericTraceActivity.h"
+#include "ITraceActivity.h"
 #include "MetadataFieldCatalog.h"
+#include "TraceSpan.h"
 #include "XpuptiActivityProfilerSession.h"
+#include "libkineto.h"
+#include "output_base.h"
 #include "output_json.h"
 
+#include <bits/std_abs.h>
 #include <algorithm>
-#include <iterator>
-#include <type_traits>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <fmt/format.h>
-#include <fmt/ranges.h>
+#include <pti/pti_view.h>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
@@ -16,9 +16,9 @@
 #include "output_base.h"
 #include "output_json.h"
 
-#include <bits/std_abs.h>
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <deque>
 #include <functional>
 #include <map>
@@ -26,6 +26,7 @@
 #include <set>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -152,7 +153,7 @@ void XpuptiActivityProfilerSession::addResouceInfo(
 
 template <class T>
 inline std::string formatTimeLikeOutputJson(T time) {
-  return fmt::format("{}.{:03}", time / 1000, abs(time) % 1000);
+  return fmt::format("{}.{:03}", time / 1000, std::abs(time) % 1000);
 }
 
 inline int64_t signedFromUnsignedDiff(uint64_t time, uint64_t time_ref) {

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.cpp
@@ -9,13 +9,20 @@
 #include "XpuptiActivityProfiler.h"
 #include "MetadataFieldCatalog.h"
 #include "ThrowUtil.h"
+#include "TypedMetadata.h"
 #include "TypedMetadataJson.h"
-#include "XpuptiScopeProfilerApi.h"
+#include "XpuptiActivityApi.h"
 #include "XpuptiScopeProfilerSession.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <sycl/sycl.hpp>
-#include <utility>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfiler.h
@@ -8,7 +8,14 @@
 
 #pragma once
 
+#include "ActivityType.h"
+#include "Config.h"
 #include "IActivityProfiler.h"
+
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <string>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
@@ -7,16 +7,21 @@
  */
 
 #include "XpuptiActivityProfilerSession.h"
+#include "TraceSpan.h"
 #include "XpuptiActivityApi.h"
-
+#include "XpuptiProfilerMacros.h"
 #include "time_since_epoch.h"
-
-#include <pti/pti_version.h>
-#include <sycl/sycl.hpp>
 
 #include <algorithm>
 #include <chrono>
+#include <functional>
 #include <iterator>
+#include <ostream>
+#include <ranges>
+
+#include <fmt/format.h>
+#include <pti/pti_version.h>
+#include <sycl/sycl.hpp>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <chrono>
 #include <functional>
+#include <iostream>
 #include <iterator>
 #include <ostream>
 #include <ranges>

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
@@ -8,19 +8,26 @@
 
 #pragma once
 
-#include "XpuptiProfilerMacros.h"
-
+#include "ActivityType.h"
+#include "Config.h"
+#include "GenericTraceActivity.h"
 #include "IActivityProfiler.h"
+#include "ITraceActivity.h"
+#include "XpuptiProfilerMacros.h"
 #include "libkineto.h"
 
-#include <pti/pti_view.h>
-
+#include <array>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
+
+#include <pti/pti_view.h>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.cpp
@@ -10,6 +10,7 @@
 #include "ThrowUtil.h"
 
 #include <stdexcept>
+#include <string>
 #include <string_view>
 
 #include <fmt/format.h>

--- a/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.h
+++ b/libkineto/src/plugin/xpupti/XpuptiProfilerMacros.h
@@ -8,10 +8,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <source_location>
 #include <string_view>
 
 #include <pti/pti.h>
+#include <pti/pti_version.h>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.cpp
@@ -6,14 +6,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <algorithm>
-#include <iterator>
-#include <stdexcept>
-
 #include "XpuptiScopeProfilerApi.h"
+#include "Config.h"
+#include "ThrowUtil.h"
+#include "XpuptiProfilerMacros.h"
 #include "XpuptiScopeProfilerConfig.h"
 
-#include "ThrowUtil.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <pti/pti.h>
+#include <pti/pti_metrics.h>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.h
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.h
@@ -8,11 +8,11 @@
 
 #pragma once
 
+#include <exception>
+#include <functional>
 #include <optional>
 
 #include <pti/pti_metrics_scope.h>
-
-#include "XpuptiActivityApi.h"
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerConfig.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerConfig.cpp
@@ -7,10 +7,12 @@
  */
 
 #include "XpuptiScopeProfilerConfig.h"
-
 #include <Logger.h>
 
-#include <fmt/core.h>
+#include <functional>
+#include <ostream>
+#include <string_view>
+
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
 

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerConfig.h
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerConfig.h
@@ -8,9 +8,13 @@
 
 #pragma once
 
+#include "AbstractConfig.h"
 #include "Config.h"
 
 #include <chrono>
+#include <cstdint>
+#include <iosfwd>
+#include <string>
 #include <vector>
 
 namespace KINETO_NAMESPACE {

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerHandlers.cpp
@@ -6,9 +6,26 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "ActivityType.h"
+#include "GenericTraceActivity.h"
+#include "ITraceActivity.h"
 #include "MetadataFieldCatalog.h"
-#include "XpuptiProfilerMacros.h"
+#include "TypedMetadata.h"
 #include "XpuptiScopeProfilerSession.h"
+#include "libkineto.h"
+
+#include <array>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include <fmt/format.h>
+#include <pti/pti_metrics.h>
+#include <pti/pti_metrics_scope.h>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerSession.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerSession.cpp
@@ -7,6 +7,15 @@
  */
 
 #include "XpuptiScopeProfilerSession.h"
+#include "ActivityType.h"
+#include "Config.h"
+#include "ITraceActivity.h"
+#include "XpuptiActivityApi.h"
+#include "XpuptiActivityProfilerSession.h"
+#include "XpuptiScopeProfilerApi.h"
+
+#include <functional>
+#include <memory>
 
 namespace KINETO_NAMESPACE {
 

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerSession.h
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerSession.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <ActivityType.h>
-#include <Config.h>
-#include <ITraceActivity.h>
+#include "ActivityType.h"
+#include "Config.h"
+#include "ITraceActivity.h"
 #include "XpuptiActivityApi.h"
 #include "XpuptiActivityProfilerSession.h"
 #include "XpuptiScopeProfilerApi.h"

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerSession.h
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerSession.h
@@ -8,14 +8,19 @@
 
 #pragma once
 
+#include <ActivityType.h>
+#include <Config.h>
+#include <ITraceActivity.h>
+#include "XpuptiActivityApi.h"
 #include "XpuptiActivityProfilerSession.h"
 #include "XpuptiScopeProfilerApi.h"
+
+#include <set>
+#include <string>
 
 #include <pti/pti_metrics_scope.h>
 
 namespace KINETO_NAMESPACE {
-
-class XpuptiScopeProfilerApi;
 
 class XpuptiScopeProfilerSession : public XpuptiActivityProfilerSession {
  public:


### PR DESCRIPTION
This PR makes the XPU PTI plugin headers and sources explicitly include the types, utilities, and PTI APIs they use.

- Adds missing direct project, standard-library, fmt, PTI dependencies across the XPU activity and scope-profiler components.
- Removes unused or unnecessary transitive dependencies, including redundant headers from the activity and scope-profiler paths.
- Normalizes include ordering with Kineto’s configured clang-format.

The changes are make based on: `pytorch/tools/iwyu/run.sh` - without applying suggestion regarding sycl.hpp includes