### PR TITLE
[Kineto] Make Kineto PM Sampling config options device agnostic

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -228,13 +228,12 @@ class Config : public AbstractConfig {
     return cuptiDeviceBufferPoolLimit_;
   }
 
-  [[nodiscard]] const std::vector<std::string>& cuptiPMSamplingMetricNames()
-      const {
-    return cuptiPMSamplingMetricNames_;
+  [[nodiscard]] const std::vector<std::string>& performanceMetricNames() const {
+    return performanceMetricNames_;
   }
 
-  [[nodiscard]] int32_t cuptiPMSamplingDeviceId() const {
-    return cuptiPMSamplingDeviceId_;
+  [[nodiscard]] int32_t performanceMetricsDeviceId() const {
+    return performanceMetricsDeviceId_;
   }
 
   [[nodiscard]] bool memoryProfilerEnabled() const {
@@ -373,9 +372,9 @@ class Config : public AbstractConfig {
   size_t cuptiDeviceBufferSize_;
   size_t cuptiDeviceBufferPoolLimit_;
 
-  // CUPTI PM Sampling
-  std::vector<std::string> cuptiPMSamplingMetricNames_;
-  int32_t cuptiPMSamplingDeviceId_{-1};
+  // Performance metrics
+  std::vector<std::string> performanceMetricNames_;
+  int32_t performanceMetricsDeviceId_{-1};
 
   // CUPTI Timestamp Format
   bool useTSCTimestamp_{true};

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -52,8 +52,9 @@ constexpr size_t kDefaultCuptiDeviceBufferPoolLimit(20);
 constexpr char kActivitiesEnabledKey[] = "ACTIVITIES_ENABLED";
 constexpr char kCuptiPerThreadBufferEnabledKey[] =
     "CUPTI_PER_THREAD_BUFFER_ENABLED";
-constexpr char kCuptiPMSamplingMetricsKey[] = "CUPTI_PM_SAMPLING_METRICS";
-constexpr char kCuptiPMSamplingDeviceIdKey[] = "CUPTI_PM_SAMPLING_DEVICE_ID";
+constexpr char kPerformanceMetricsKey[] = "PERFORMANCE_METRICS";
+constexpr char kPerformanceMetricsDeviceIdKey[] =
+    "PERFORMANCE_METRICS_DEVICE_ID";
 constexpr char kActivityTypesKey[] = "ACTIVITY_TYPES";
 constexpr char kActivitiesLogFileKey[] = "ACTIVITIES_LOG_FILE";
 constexpr char kActivitiesDurationKey[] = "ACTIVITIES_DURATION_SECS";
@@ -326,7 +327,6 @@ void Config::setActivityTypes(
 }
 
 bool Config::handleOption(const std::string& name, std::string& val) {
-  // Activity Profiler
   if (!name.compare(kActivitiesDurationKey)) {
     activitiesDuration_ = duration_cast<milliseconds>(seconds(toInt32(val)));
     activitiesOnDemandTimestamp_ = timestamp();
@@ -347,10 +347,10 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     activityProfilerEnabled_ = toBool(val);
   } else if (!name.compare(kCuptiPerThreadBufferEnabledKey)) {
     perThreadBufferEnabled_ = toBool(val);
-  } else if (!name.compare(kCuptiPMSamplingMetricsKey)) {
-    cuptiPMSamplingMetricNames_ = splitAndTrim(val, ',');
-  } else if (!name.compare(kCuptiPMSamplingDeviceIdKey)) {
-    cuptiPMSamplingDeviceId_ = toInt32(val);
+  } else if (!name.compare(kPerformanceMetricsKey)) {
+    performanceMetricNames_ = splitAndTrim(val, ',');
+  } else if (!name.compare(kPerformanceMetricsDeviceIdKey)) {
+    performanceMetricsDeviceId_ = toInt32(val);
   } else if (!name.compare(kProfileMemory)) {
     memoryProfilerEnabled_ = toBool(val);
     if (memoryProfilerEnabled_) {

--- a/libkineto/src/CuptiPMSamplingProfiler.cpp
+++ b/libkineto/src/CuptiPMSamplingProfiler.cpp
@@ -145,23 +145,17 @@ const std::set<libkineto::ActivityType>& CuptiPMSamplingProfiler::
 
 std::unique_ptr<libkineto::IActivityProfilerSession> CuptiPMSamplingProfiler::
     configure(
-        const std::set<libkineto::ActivityType>& activityTypes,
+        const std::set<libkineto::ActivityType>& /*activityTypes*/,
         const libkineto::Config& config) {
-  if (activityTypes.find(libkineto::ActivityType::HARDWARE_COUNTERS) ==
-      activityTypes.end()) {
-    return nullptr;
-  }
-
-  // Translate from the Kineto config into the sampling-specific config
-  const auto& metricNames = config.cuptiPMSamplingMetricNames();
+  const auto& metricNames = config.performanceMetricNames();
   if (metricNames.empty()) {
     return nullptr;
   }
 
-  const auto deviceId = config.cuptiPMSamplingDeviceId();
+  const auto deviceId = config.performanceMetricsDeviceId();
   if (deviceId < 0) {
     LOG(WARNING) << "CUPTI PM sampling requires a nonnegative "
-                    "CUPTI_PM_SAMPLING_DEVICE_ID";
+                    "PERFORMANCE_METRICS_DEVICE_ID";
     return nullptr;
   }
 

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -133,7 +133,6 @@ target_include_directories(CuptiActivityProfilerTest PRIVATE
     "${CUDA_SOURCE_DIR}/include"
     "${CUPTI_INCLUDE_DIR}")
 gtest_discover_tests(CuptiActivityProfilerTest)
-
 # CuptiCallbackApiTest
 add_executable(CuptiCallbackApiTest CuptiCallbackApiTest.cpp)
 target_link_libraries(CuptiCallbackApiTest PRIVATE

--- a/libkineto/test/CMakeLists.txt
+++ b/libkineto/test/CMakeLists.txt
@@ -133,6 +133,7 @@ target_include_directories(CuptiActivityProfilerTest PRIVATE
     "${CUDA_SOURCE_DIR}/include"
     "${CUPTI_INCLUDE_DIR}")
 gtest_discover_tests(CuptiActivityProfilerTest)
+
 # CuptiCallbackApiTest
 add_executable(CuptiCallbackApiTest CuptiCallbackApiTest.cpp)
 target_link_libraries(CuptiCallbackApiTest PRIVATE

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -139,6 +139,27 @@ TEST(ParseTest, ActivityTypes) {
            ActivityType::PRIVATEUSE1_DRIVER}));
 }
 
+TEST(ParseTest, PerformanceMetrics) {
+  Config cfg;
+  EXPECT_TRUE(cfg.performanceMetricNames().empty());
+  EXPECT_EQ(cfg.performanceMetricsDeviceId(), -1);
+
+  EXPECT_TRUE(
+      cfg.parse("PERFORMANCE_METRICS_DEVICE_ID=2\n"
+                "PERFORMANCE_METRICS="
+                "sm__cycles_active.avg,dram__bytes_read.sum"));
+
+  EXPECT_EQ(
+      cfg.performanceMetricNames(),
+      std::vector<std::string>(
+          {"sm__cycles_active.avg", "dram__bytes_read.sum"}));
+  EXPECT_EQ(cfg.performanceMetricsDeviceId(), 2);
+
+  auto clone = cfg.clone();
+  EXPECT_EQ(clone->performanceMetricNames(), cfg.performanceMetricNames());
+  EXPECT_EQ(clone->performanceMetricsDeviceId(), 2);
+}
+
 TEST(ParseTest, ProfileStartTime) {
   Config cfg;
   system_clock::time_point now = system_clock::now();


### PR DESCRIPTION
As titled. PyTorch will pass these keys in from the profiler entry point and we want this to be applicable across any hardware type that implements a hardware counter profielr.