### PR TITLE
Enable CUDA sync event correlation on CUDA 12.9+ (#1552)

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -380,6 +380,9 @@ void CuptiActivityApi::enableCuptiActivities(
       externalCorrelationEnabled_.store(true, std::memory_order_relaxed);
     }
     if (activity == CUDA_SYNC) {
+      // CUDA event records supply source-stream correlation. CUDA 12.9+
+      // requires explicitly enabling them separately from synchronization.
+      CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CUDA_EVENT));
 #if CUDA_VERSION >= 13000
       CUPTI_CALL(cuptiActivityEnableCudaEventDeviceTimestamps(true));
 #endif
@@ -429,6 +432,7 @@ void CuptiActivityApi::disableCuptiActivities(
           cuptiActivityDisable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION));
     }
     if (activity == CUDA_SYNC) {
+      CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_CUDA_EVENT));
       CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION));
     }
     if (activity == CUDA_RUNTIME) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/195068


## Summary

CUDA 12.9 decoupled `CUPTI_ACTIVITY_KIND_CUDA_EVENT` from `CUPTI_ACTIVITY_KIND_SYNCHRONIZATION`. Kineto continued enabling only synchronization when sync events were requested, so CUDA 13 traces lacked event-record inputs and left `wait_on_stream` and `wait_on_cuda_event_record_corr_id` unresolved.

## Changes

Update `CuptiActivityApi.cpp` to enable and disable `CUPTI_ACTIVITY_KIND_CUDA_EVENT` alongside synchronization activity collection on CUDA 12.9 and newer. The CUDA 13 device-timestamp opt-in remains unchanged, and the implementation is mirrored between fbcode and xplat.

Add an end-to-end profiler test that creates a cross-stream wait and verifies the exported trace contains resolved source-stream and event-correlation metadata. The test runs whenever Kineto is available without CUDA-version or ROCm gating, uses a backend-neutral name, and validates the metadata contract without depending on backend-specific category or event display strings.

Differential Revision: D117757961


