### PR TITLE
[XPUPTI] Fix buffer lifetime and report processed-record stats with some minor improvements.

### DIFF
--- a/libkineto/src/plugin/xpupti/XpuptiActivityApi.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityApi.cpp
@@ -8,7 +8,7 @@
 
 #include "XpuptiActivityApi.h"
 
-#include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <stdexcept>
 
@@ -16,7 +16,7 @@
 
 namespace KINETO_NAMESPACE {
 
-constexpr size_t kBufSize(4 * 1024 * 1024);
+constexpr std::size_t kBufSize(4 * 1024 * 1024);
 
 XpuptiActivityApi& XpuptiActivityApi::singleton() {
   static XpuptiActivityApi instance;
@@ -54,8 +54,8 @@ void XpuptiActivityApi::popCorrelationID(CorrelationFlowType type) {
 }
 
 static bool nextActivityRecord(
-    uint8_t* buffer,
-    size_t valid_size,
+    std::uint8_t* buffer,
+    std::size_t valid_size,
     pti_view_record_base*& record) {
   pti_result status = ptiViewGetNextRecord(buffer, valid_size, &record);
   if (status != pti_result::PTI_SUCCESS) {
@@ -65,12 +65,14 @@ static bool nextActivityRecord(
 }
 
 void XpuptiActivityApi::bufferRequestedTrampoline(
-    uint8_t** buffer,
-    size_t* size) {
+    std::uint8_t** buffer,
+    std::size_t* size) {
   singleton().bufferRequested(buffer, size);
 }
 
-void XpuptiActivityApi::bufferRequested(uint8_t** buffer, size_t* size) {
+void XpuptiActivityApi::bufferRequested(
+    std::uint8_t** buffer,
+    std::size_t* size) {
   std::lock_guard<std::mutex> guard(mutex_);
 
   auto buf = std::make_unique<XpuptiActivityBuffer>(kBufSize);
@@ -84,22 +86,24 @@ std::unique_ptr<XpuptiActivityBufferMap> XpuptiActivityApi::activityBuffers() {
   {
     std::lock_guard<std::mutex> guard(mutex_);
     if (allocatedGpuTraceBuffers_.empty()) {
+      if (readyGpuTraceBuffers_) {
+        return std::move(readyGpuTraceBuffers_);
+      }
       return nullptr;
     }
   }
 
-  std::chrono::time_point<std::chrono::system_clock> t1;
-  XPUPTI_CALL(ptiFlushAllViews());
+  flushActivities();
 
   std::lock_guard<std::mutex> guard(mutex_);
   return std::move(readyGpuTraceBuffers_);
 }
 
-int XpuptiActivityApi::processActivitiesForBuffer(
-    uint8_t* buf,
-    size_t validSize,
-    std::function<void(const pti_view_record_base*)> handler) {
-  int count = 0;
+std::size_t XpuptiActivityApi::processActivitiesForBuffer(
+    std::uint8_t* buf,
+    std::size_t validSize,
+    const std::function<void(const pti_view_record_base*)>& handler) {
+  std::size_t count = 0;
   if (buf && validSize) {
     pti_view_record_base* record{nullptr};
     while (nextActivityRecord(buf, validSize, record)) {
@@ -110,14 +114,14 @@ int XpuptiActivityApi::processActivitiesForBuffer(
   return count;
 }
 
-const std::pair<int, int> XpuptiActivityApi::processActivities(
+ActivitiesStats XpuptiActivityApi::processActivities(
     XpuptiActivityBufferMap& buffers,
-    std::function<void(const pti_view_record_base*)> handler) {
-  std::pair<int, int> res{0, 0};
-  for (auto& pair : buffers) {
-    auto& buf = pair.second;
-    res.first += processActivitiesForBuffer(buf->data(), buf->size(), handler);
-    res.second += buf->size();
+    const std::function<void(const pti_view_record_base*)>& handler) {
+  ActivitiesStats res{};
+  for (const auto& [_, buf] : buffers) {
+    res.activitiesCount +=
+        processActivitiesForBuffer(buf->data(), buf->size(), handler);
+    res.buffersSize += buf->size();
   }
   return res;
 }
@@ -130,31 +134,39 @@ void XpuptiActivityApi::clearActivities() {
   {
     std::lock_guard<std::mutex> guard(mutex_);
     if (allocatedGpuTraceBuffers_.empty()) {
+      readyGpuTraceBuffers_.reset();
       return;
     }
   }
-  XPUPTI_CALL(ptiFlushAllViews());
+  flushActivities();
   std::lock_guard<std::mutex> guard(mutex_);
-  readyGpuTraceBuffers_ = nullptr;
+  readyGpuTraceBuffers_.reset();
 }
 
 void XpuptiActivityApi::bufferCompletedTrampoline(
-    uint8_t* buffer,
-    size_t size,
-    size_t validSize) {
+    std::uint8_t* buffer,
+    std::size_t size,
+    std::size_t validSize) {
   singleton().bufferCompleted(buffer, size, validSize);
 }
 
 void XpuptiActivityApi::bufferCompleted(
-    uint8_t* buffer,
-    [[maybe_unused]] size_t size,
-    size_t validSize) {
+    std::uint8_t* buffer,
+    [[maybe_unused]] std::size_t size,
+    std::size_t validSize) {
   std::lock_guard<std::mutex> guard(mutex_);
+
   auto it = allocatedGpuTraceBuffers_.find(buffer);
+  if (it == std::end(allocatedGpuTraceBuffers_)) {
+    LOG(ERROR) << "bufferCompleted called with unknown buffer: "
+               << static_cast<void*>(buffer);
+    return;
+  }
 
   if (!readyGpuTraceBuffers_) {
     readyGpuTraceBuffers_ = std::make_unique<XpuptiActivityBufferMap>();
   }
+
   it->second->setSize(validSize);
   (*readyGpuTraceBuffers_)[it->first] = std::move(it->second);
   allocatedGpuTraceBuffers_.erase(it);

--- a/libkineto/src/plugin/xpupti/XpuptiActivityApi.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityApi.h
@@ -20,6 +20,11 @@
 
 namespace KINETO_NAMESPACE {
 
+struct ActivitiesStats {
+  std::size_t activitiesCount;
+  std::size_t buffersSize; // Valid bytes
+};
+
 class XpuptiActivityApi {
  public:
   enum CorrelationFlowType { Default, User };
@@ -43,9 +48,9 @@ class XpuptiActivityApi {
 
   virtual std::unique_ptr<XpuptiActivityBufferMap> activityBuffers();
 
-  virtual const std::pair<int, int> processActivities(
+  virtual ActivitiesStats processActivities(
       XpuptiActivityBufferMap&,
-      std::function<void(const pti_view_record_base*)> handler);
+      const std::function<void(const pti_view_record_base*)>& handler);
 
  private:
   XpuptiActivityBufferMap allocatedGpuTraceBuffers_;
@@ -53,19 +58,24 @@ class XpuptiActivityApi {
   std::mutex mutex_;
   bool externalCorrelationEnabled_{false};
 
-  int processActivitiesForBuffer(
-      uint8_t* buf,
-      size_t validSize,
-      std::function<void(const pti_view_record_base*)> handler);
-  static void bufferRequestedTrampoline(uint8_t** buffer, size_t* size);
+  std::size_t processActivitiesForBuffer(
+      std::uint8_t* buf,
+      std::size_t validSize,
+      const std::function<void(const pti_view_record_base*)>& handler);
+  static void bufferRequestedTrampoline(
+      std::uint8_t** buffer,
+      std::size_t* size);
   static void bufferCompletedTrampoline(
-      uint8_t* buffer,
-      size_t size,
-      size_t validSize);
+      std::uint8_t* buffer,
+      std::size_t size,
+      std::size_t validSize);
 
  protected:
-  void bufferRequested(uint8_t** buffer, size_t* size);
-  void bufferCompleted(uint8_t* buffer, size_t size, size_t validSize);
+  void bufferRequested(std::uint8_t** buffer, std::size_t* size);
+  void bufferCompleted(
+      std::uint8_t* buffer,
+      std::size_t size,
+      std::size_t validSize);
 };
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/plugin/xpupti/XpuptiActivityBuffer.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityBuffer.h
@@ -45,6 +45,7 @@ class XpuptiActivityBuffer {
   size_t size_;
 };
 
+// Maps the buffer handle PTI reports back to the buffer that owns it.
 using XpuptiActivityBufferMap =
     std::map<uint8_t*, std::unique_ptr<XpuptiActivityBuffer>>;
 

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.cpp
@@ -8,7 +8,9 @@
 
 #include "XpuptiActivityProfilerSession.h"
 #include "XpuptiActivityApi.h"
+#include "XpuptiProfilerMacros.h"
 
+#include "Logger.h"
 #include "time_since_epoch.h"
 
 #include <pti/pti_version.h>
@@ -75,11 +77,14 @@ void XpuptiActivityProfilerSession::processTrace(ActivityLogger& logger) {
   traceBuffer_.span.iteration = iterationCount_++;
   auto gpuBuffer = xpti_.activityBuffers();
   if (gpuBuffer) {
-    xpti_.processActivities(
+    const auto stats = xpti_.processActivities(
         *gpuBuffer,
         [this, &logger](const pti_view_record_base* record) -> void {
           handlePtiActivity(record, logger);
         });
+    LOG(INFO) << "Processed " << stats.activitiesCount << " GPU records ("
+              << stats.buffersSize << " bytes)";
+    LOGGER_OBSERVER_ADD_EVENT_COUNT(stats.activitiesCount);
   }
   for (auto& kv : userAnnotationsByStream_) {
     kv.second->log(logger);

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
@@ -144,7 +144,7 @@ class XpuptiActivityProfilerSession
   XpuptiActivityApi& xpti_;
   libkineto::CpuTraceBuffer traceBuffer_;
   std::vector<std::pair<int32_t, int32_t>> resourceInfo_;
-  std::unique_ptr<const libkineto::Config> config_{nullptr};
+  std::unique_ptr<const libkineto::Config> config_;
   const std::set<ActivityType>& activity_types_;
   std::string name_;
 

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.cpp
@@ -111,9 +111,9 @@ static size_t IntDivRoundUp(size_t a, size_t b) {
 }
 
 void XpuptiScopeProfilerApi::processScopeTrace(
-    std::function<void(
+    const std::function<void(
         const pti_metrics_scope_record_t*,
-        const pti_metrics_scope_record_metadata_t& metadata)> handler) {
+        const pti_metrics_scope_record_metadata_t& metadata)>& handler) {
   if (scopeHandleOpt_) {
     pti_metrics_scope_record_metadata_t metadata;
     metadata._struct_size = sizeof(pti_metrics_scope_record_metadata_t);

--- a/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.h
+++ b/libkineto/src/plugin/xpupti/XpuptiScopeProfilerApi.h
@@ -32,9 +32,9 @@ class XpuptiScopeProfilerApi {
   void stopScopeActivity();
 
   void processScopeTrace(
-      std::function<void(
+      const std::function<void(
           const pti_metrics_scope_record_t*,
-          const pti_metrics_scope_record_metadata_t& metadata)> handler);
+          const pti_metrics_scope_record_metadata_t& metadata)>& handler);
 
  private:
   struct safe_pti_scope_collection_handle_t {

--- a/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
+++ b/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
@@ -32,13 +32,14 @@ class MockXpuptiActivityApi : public KN::XpuptiActivityApi {
     return std::make_unique<KN::XpuptiActivityBufferMap>();
   }
 
-  const std::pair<int, int> processActivities(
+  KN::ActivitiesStats processActivities(
       KN::XpuptiActivityBufferMap&,
-      std::function<void(const pti_view_record_base*)> handler) override {
+      const std::function<void(const pti_view_record_base*)>& handler)
+      override {
     for (auto* record : records) {
       handler(record);
     }
-    return {static_cast<int>(records.size()), 0};
+    return {.activitiesCount = records.size(), .buffersSize = 0};
   }
 };
 


### PR DESCRIPTION
Port the CUPTI completed-buffer fix to the XPU plugin: activityBuffers() now returns already-completed buffers when nothing is in flight, clearActivities() drops them on the early-return path, and bufferCompleted() rejects unknown buffer pointers instead of dereferencing an invalid map iterator.

Replace processActivities()' std::pair<int, int> return with a named ActivitiesStats struct and log the record count/byte total, wiring up LOGGER_OBSERVER_ADD_EVENT_COUNT which XPU never reported.

Match the signature convention used by XpuptiActivityApi::processActivities and avoid copying the std::function on every call. The handler is only invoked in-scope, never stored.