### PR TITLE
[Kineto] Fix CUPTI teardown race when two profiling sessions start in quick succession

### DIFF
--- a/libkineto/src/CuptiActivityApi.cpp
+++ b/libkineto/src/CuptiActivityApi.cpp
@@ -26,6 +26,9 @@ namespace KINETO_NAMESPACE {
 // case, there will be 32 buffers contending for the mutex.
 constexpr size_t kBufSize(4 * 1024 * 1024);
 constexpr uint32_t kCuptiBufferRejectionMinVersion = 27;
+// Stop waiting for the previous teardown after this interval and continue the
+// trace without GPU activities.
+constexpr auto kTeardownTimeout = seconds(10);
 
 inline bool cuptiTearDown_() {
   auto teardown_env = getenv("TEARDOWN_CUPTI");
@@ -444,66 +447,140 @@ void CuptiActivityApi::disableCuptiActivities(
   externalCorrelationEnabled_.store(false, std::memory_order_relaxed);
 }
 
-void CuptiActivityApi::teardownContext() {
-  if (!tracingEnabled_) {
-    return;
-  }
-  if (tearingDown_) {
-    return;
-  }
-  if (cuptiTearDown_()) {
-    tearingDown_ = 1;
-    LOG(INFO) << "teardownCupti starting";
-
-    // PyTorch Profiler is synchronous, so teardown needs to be run async in
-    // this thread.
-    std::thread teardownThread([&] {
-      auto& cbapi = CuptiCallbackApi::singleton();
-      if (!cbapi.initSuccess()) {
-        cbapi.initCallbackApi();
-        if (!cbapi.initSuccess()) {
-          LOG(WARNING) << "CUPTI Callback failed to init, skipping teardown";
-          tearingDown_ = 0;
-          return;
-        }
+bool CuptiActivityApi::ensureReadyForTrace() {
+  const auto deadline = steady_clock::now() + kTeardownTimeout;
+  {
+    std::unique_lock<std::mutex> lock(teardownMutex_);
+    while (teardownState_ != TeardownState::Idle) {
+      auto expected = TeardownState::Pending;
+      // If finalization is pending, cancel it and notify the teardown thread.
+      if (teardownState_.compare_exchange_strong(
+              expected, TeardownState::Restoring)) {
+        LOG(INFO) << "Cancelling pending CUPTI teardown";
+        teardownCond_.notify_all();
       }
-      // Subscribe callbacks to call cuptiFinalize in the exit callback of these
-      // APIs
-      bool status = cbapi.enableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);
-      status = status && cbapi.enableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
-      if (!status) {
-        LOG(WARNING)
-            << "CUPTI Callback failed to enable for domain, skipping teardown";
-        tearingDown_ = 0;
+      // Wait for Idle before configure uses CUPTI. After cancellation, the
+      // teardown thread still has to disable the temporary domains and restore
+      // callbacks. If finalization started, cuptiFinalize() must return before
+      // the subscriber can be recreated.
+      if (!teardownCond_.wait_until(lock, deadline, [&] {
+            const auto state = teardownState_.load();
+            return state == TeardownState::Idle ||
+                state == TeardownState::Pending;
+          })) {
+        LOG(WARNING) << "Timed out waiting for CUPTI teardown";
+        return false;
+      }
+    }
+  }
+
+  // Finalization removes the CUPTI subscriber. Recreate it here when lazy
+  // reinitialization is enabled so configure can continue.
+  auto& cbapi = CuptiCallbackApi::singleton();
+  if (!tracingEnabled_ && !cbapi.initSuccess() && cuptiLazyInit_()) {
+    reenableCuptiCallbacks_(cbapi);
+  }
+  return true;
+}
+
+void CuptiActivityApi::teardownContext() {
+  if (!tracingEnabled_ || !cuptiTearDown_()) {
+    return;
+  }
+
+  auto expected = TeardownState::Idle;
+  if (!teardownState_.compare_exchange_strong(
+          expected, TeardownState::Preparing)) {
+    return;
+  }
+  LOG(INFO) << "teardownCupti starting";
+
+  // Finalization runs from a later runtime callback. Do not block the thread
+  // ending this trace while waiting for that callback.
+  std::thread teardownThread([&] {
+    auto finishTeardown = [&] {
+      // Changing the state to Idle allows a new trace to use CUPTI. Do it only
+      // after this thread has disabled the temporary domains and restored or
+      // recreated the callbacks.
+      {
+        std::lock_guard<std::mutex> lock(teardownMutex_);
+        teardownState_ = TeardownState::Idle;
+      }
+      teardownCond_.notify_all();
+    };
+
+    auto& cbapi = CuptiCallbackApi::singleton();
+    if (!cbapi.initSuccess()) {
+      cbapi.initCallbackApi();
+      if (!cbapi.initSuccess()) {
+        LOG(WARNING) << "CUPTI Callback failed to init, skipping teardown";
+        finishTeardown();
         return;
       }
+    }
 
-      // Force Flush before finalize
-      CUPTI_CALL(cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
+    bool status = cbapi.enableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);
+    status = status && cbapi.enableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
+    if (!status) {
+      LOG(WARNING)
+          << "CUPTI Callback failed to enable for domain, skipping teardown";
+      finishTeardown();
+      return;
+    }
 
-      LOG(INFO) << "  CUPTI subscriber before finalize:"
-                << cbapi.getCuptiSubscriber();
-      teardownCupti_ = 1;
-      std::unique_lock<std::mutex> lck(finalizeMutex_);
-      finalizeCond_.wait(lck, [&] { return teardownCupti_ == 0; });
-      lck.unlock();
-      LOG(INFO) << "teardownCupti complete";
+    // Flush activity buffers before finalizing CUPTI.
+    CUPTI_CALL(cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
 
-      teardownCupti_ = 0;
-      tracingEnabled_ = 0;
+    LOG(INFO) << "  CUPTI subscriber before finalize:"
+              << cbapi.getCuptiSubscriber();
+    {
+      // Change the state while holding teardownMutex_. Otherwise
+      // ensureReadyForTrace() could see Preparing and go to sleep after
+      // this thread sends the notification.
+      std::lock_guard<std::mutex> lock(teardownMutex_);
+      teardownState_ = TeardownState::Pending;
+    }
+    teardownCond_.notify_all();
 
-      // Remove the callbacks used specifically for cuptiFinalize
-      cbapi.disableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);
-      cbapi.disableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
+    {
+      // A new trace changes Pending to Restoring immediately. A callback
+      // changes it to Finalizing, then changes it to Restoring after
+      // cuptiFinalize() returns.
+      std::unique_lock<std::mutex> lock(teardownMutex_);
+      teardownCond_.wait(
+          lock, [&] { return teardownState_ == TeardownState::Restoring; });
+    }
 
-      // Re-init CUPTI Callbacks if Lazy Re-init is not enabled.
-      if (!cuptiLazyInit_()) {
-        reenableCuptiCallbacks_(cbapi);
+    // On cancellation, disable the runtime and driver domains added above.
+    // After finalization, the subscriber is gone, so these calls only remove
+    // those domains from enabledCallbacks_.
+    cbapi.disableCallbackDomain(CUPTI_CB_DOMAIN_RUNTIME_API);
+    cbapi.disableCallbackDomain(CUPTI_CB_DOMAIN_DRIVER_API);
+
+    // The callback marks its API uninitialized after finalization. If it is
+    // still initialized, a new trace cancelled teardown before finalization.
+    if (cbapi.initSuccess()) {
+      LOG(INFO) << "CUPTI teardown cancelled";
+      // Disabling a domain also disables its individual callbacks. Restore the
+      // callbacks that were enabled before teardown.
+      if (!cbapi.reenableCallbacks()) {
+        LOG(WARNING)
+            << "Failed to restore CUPTI callbacks after cancelling teardown";
       }
-      tearingDown_ = 0;
-    });
-    teardownThread.detach();
-  }
+      finishTeardown();
+      return;
+    }
+
+    tracingEnabled_ = 0;
+    LOG(INFO) << "teardownCupti complete";
+
+    // Without lazy reinitialization, recreate the subscriber before finishing.
+    if (!cuptiLazyInit_()) {
+      reenableCuptiCallbacks_(cbapi);
+    }
+    finishTeardown();
+  });
+  teardownThread.detach();
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiActivityApi.h
+++ b/libkineto/src/CuptiActivityApi.h
@@ -30,10 +30,23 @@ using namespace libkineto;
 class CuptiActivityApi {
  public:
   enum CorrelationFlowType { Default, User };
-  // Control Variables shared with CuptiCallbackApi for teardown
-  std::atomic<uint32_t> teardownCupti_{0};
-  std::mutex finalizeMutex_;
-  std::condition_variable finalizeCond_;
+
+  enum class TeardownState {
+    Idle,
+    // The teardown thread is enabling callback domains and flushing activities.
+    Preparing,
+    // The next exiting runtime callback may finalize; a new trace may cancel.
+    Pending,
+    // An exiting callback is running cuptiFinalize().
+    Finalizing,
+    // The teardown thread is removing temporary callback domains and restoring
+    // callbacks when needed.
+    Restoring,
+  };
+
+  std::atomic<TeardownState> teardownState_{TeardownState::Idle};
+  std::mutex teardownMutex_;
+  std::condition_variable teardownCond_;
 
   CuptiActivityApi() = default;
   CuptiActivityApi(const CuptiActivityApi&) = delete;
@@ -54,6 +67,8 @@ class CuptiActivityApi {
       const std::set<ActivityType>& selected_activities);
   void clearActivities();
   void flushActivities();
+  // Waits for an earlier teardown and returns false if it times out.
+  bool ensureReadyForTrace();
   void teardownContext();
 
   virtual std::unique_ptr<CuptiActivityBufferMap> activityBuffers();
@@ -80,7 +95,6 @@ class CuptiActivityApi {
   std::unique_ptr<CuptiActivityBufferMap> readyGpuTraceBuffers_;
   std::mutex mutex_;
   std::atomic<uint32_t> tracingEnabled_{0};
-  std::atomic<uint32_t> tearingDown_{0};
   std::atomic<bool> externalCorrelationEnabled_{false};
 
   int processActivitiesForBuffer(

--- a/libkineto/src/CuptiActivityProfiler.cpp
+++ b/libkineto/src/CuptiActivityProfiler.cpp
@@ -102,20 +102,36 @@ void CuptiActivityProfiler::setMaxGpuBufferSize(int64_t size) {
   cupti_.setMaxBufferSize(size);
 }
 
-void CuptiActivityProfiler::enableGpuTracing() {
+void CuptiActivityProfiler::ensureGpuTracingReady() {
   // @lint-ignore CLANGTIDY facebook-hte-std::call_once
   std::call_once(cuptiInitializationOnce_, [this] {
     uint32_t cuptiVersion = 0;
     cuptiAvailable_ = cupti_.isAvailable(cuptiVersion);
     if (cuptiAvailable_) {
       recordGpuVersions(cuptiVersion);
-    } else {
-      cpuOnly_ = true;
-      VLOG(0) << "CUPTI unavailable; continuing with CPU-only profiling";
     }
   });
-  if (!cuptiAvailable_) {
+  if (cuptiAvailable_ && !cupti_.ensureReadyForTrace()) {
+    // TODO: Limit this fallback to the current trace so a later trace can
+    // retry GPU profiling.
+    // cpuOnly_ is not reset between traces, and the controller normally owns
+    // this profiler for the process lifetime. A teardown timeout therefore
+    // disables GPU profiling for all later traces in this process.
+    cpuOnly_ = true;
     toggleState_.store(false);
+    LOG(WARNING) << "CUPTI teardown timed out; continuing CPU-only for the "
+                    "remaining profiler lifetime";
+  }
+}
+
+void CuptiActivityProfiler::enableGpuTracing() {
+  if (cpuOnly_) {
+    return;
+  }
+  if (!cuptiAvailable_) {
+    cpuOnly_ = true;
+    toggleState_.store(false);
+    VLOG(0) << "CUPTI unavailable; continuing with CPU-only profiling";
     return;
   }
 
@@ -126,10 +142,14 @@ void CuptiActivityProfiler::enableGpuTracing() {
 }
 
 void CuptiActivityProfiler::disableGpuTracing() {
-  if (!cuptiAvailable_) {
+  if (cpuOnly_ || !cuptiAvailable_) {
     return;
   }
   cupti_.disableCuptiActivities(derivedConfig_->profileActivityTypes());
+}
+
+void CuptiActivityProfiler::requestGpuTracingTeardown() {
+  cupti_.teardownContext();
 }
 
 void CuptiActivityProfiler::clearGpuActivities() {
@@ -140,11 +160,12 @@ void CuptiActivityProfiler::clearGpuActivities() {
 }
 
 bool CuptiActivityProfiler::isGpuCollectionStopped() const {
-  return cupti_.stopCollection;
+  // stopCollection may belong to the GPU trace whose teardown timed out.
+  return !cpuOnly_ && cupti_.stopCollection;
 }
 
 void CuptiActivityProfiler::synchronizeGpuDevice() {
-  if (!cuptiAvailable_) {
+  if (cpuOnly_ || !cuptiAvailable_) {
     return;
   }
   CUDA_CALL(cudaDeviceSynchronize());
@@ -170,7 +191,6 @@ void CuptiActivityProfiler::popCorrelationIdImpl(CorrelationFlowType type) {
 }
 
 void CuptiActivityProfiler::onResetTraceData() {
-  cupti_.teardownContext();
   KernelRegistry::singleton()->clear();
   waitEventMap().clear();
   ctxToDeviceId().clear();

--- a/libkineto/src/CuptiActivityProfiler.h
+++ b/libkineto/src/CuptiActivityProfiler.h
@@ -24,9 +24,11 @@ class CuptiActivityProfiler : public GenericActivityProfiler {
   ~CuptiActivityProfiler() override = default;
 
  protected:
+  void ensureGpuTracingReady() override;
   void setMaxGpuBufferSize(int64_t size) override;
   void enableGpuTracing() override;
   void disableGpuTracing() override;
+  void requestGpuTracingTeardown() override;
   void clearGpuActivities() override;
   bool isGpuCollectionStopped() const override;
   void processGpuActivities(ActivityLogger& logger) override;

--- a/libkineto/src/CuptiCallbackApi.cpp
+++ b/libkineto/src/CuptiCallbackApi.cpp
@@ -72,7 +72,7 @@ void CuptiCallbackApi::__callback_switchboard(
   switch (domain) {
     // add the fastest path for kernel launch callbacks
     // as these are the most frequent ones
-    case CUPTI_CB_DOMAIN_RUNTIME_API:
+    case CUPTI_CB_DOMAIN_RUNTIME_API: {
       switch (cbid) {
         case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000:
           cblist = &callbacks_.runtime[domainIndex(
@@ -89,22 +89,32 @@ void CuptiCallbackApi::__callback_switchboard(
         default:
           break;
       }
-      // This is required to teardown cupti after profiling to prevent QPS
-      // slowdown.
-      if (CuptiActivityApi::singleton().teardownCupti_) {
-        if (cbInfo->callbackSite == CUPTI_API_EXIT) {
-          LOG(INFO) << "  Calling cuptiFinalize in exit callsite";
-          // Teardown CUPTI calling cuptiFinalize()
-          CUPTI_CALL(cuptiUnsubscribe(subscriber_));
-          CUPTI_CALL(cuptiFinalize());
-          initSuccess_ = false;
-          subscriber_ = nullptr;
-          CuptiActivityApi::singleton().teardownCupti_ = 0;
-          CuptiActivityApi::singleton().finalizeCond_.notify_all();
-          return;
+      auto& activityApi = CuptiActivityApi::singleton();
+      auto expected = CuptiActivityApi::TeardownState::Pending;
+      // Only the callback that changes Pending to Finalizing runs
+      // cuptiFinalize(). A new trace cancels by changing Pending to Restoring.
+      if (activityApi.teardownState_ ==
+              CuptiActivityApi::TeardownState::Pending &&
+          cbInfo != nullptr && cbInfo->callbackSite == CUPTI_API_EXIT &&
+          activityApi.teardownState_.compare_exchange_strong(
+              expected, CuptiActivityApi::TeardownState::Finalizing)) {
+        LOG(INFO) << "  Calling cuptiFinalize in exit callsite";
+        CUPTI_CALL(cuptiUnsubscribe(subscriber_));
+        CUPTI_CALL(cuptiFinalize());
+        initSuccess_ = false;
+        subscriber_ = nullptr;
+        {
+          // Keep the state at Finalizing until cuptiFinalize() returns. The
+          // teardown thread may reinitialize CUPTI after it sees Restoring.
+          std::lock_guard<std::mutex> lock(activityApi.teardownMutex_);
+          activityApi.teardownState_ =
+              CuptiActivityApi::TeardownState::Restoring;
         }
+        activityApi.teardownCond_.notify_all();
+        return;
       }
       break;
+    }
 
     case CUPTI_CB_DOMAIN_RESOURCE:
       switch (cbid) {

--- a/libkineto/src/GenericActivityProfiler.cpp
+++ b/libkineto/src/GenericActivityProfiler.cpp
@@ -475,6 +475,12 @@ void GenericActivityProfiler::configure(
 
   config_ = config.clone();
 
+  if (!cpuOnly_) {
+    // Wait for the previous GPU teardown before clearGpuActivities(). If the
+    // wait times out, cpuOnly_ is set and resetTraceData() skips that call.
+    ensureGpuTracingReady();
+  }
+
   // Ensure we're starting in a clean state
   resetTraceData();
 
@@ -650,6 +656,9 @@ void GenericActivityProfiler::stopTraceInternal(
 void GenericActivityProfiler::resetInternal() {
   acceptCpuTraces_ = false;
   resetTraceData();
+  if (!cpuOnly_) {
+    requestGpuTracingTeardown();
+  }
 }
 
 void GenericActivityProfiler::finalizeTrace(

--- a/libkineto/src/GenericActivityProfiler.h
+++ b/libkineto/src/GenericActivityProfiler.h
@@ -292,9 +292,11 @@ class GenericActivityProfiler {
   // these virtual member functions. We provide empty defaults because
   // GenericActivityProfiler can also be in cpuOnly mode.
   virtual void logGpuVersions() {}
+  virtual void ensureGpuTracingReady() {}
   virtual void setMaxGpuBufferSize([[maybe_unused]] int64_t size) {}
   virtual void enableGpuTracing() {}
   virtual void disableGpuTracing() {}
+  virtual void requestGpuTracingTeardown() {}
   virtual void clearGpuActivities() {}
   virtual void processGpuActivities([[maybe_unused]] ActivityLogger& logger) {}
   virtual void synchronizeGpuDevice() {}

--- a/libkineto/test/GenericActivityProfilerTeardownTest.cpp
+++ b/libkineto/test/GenericActivityProfilerTeardownTest.cpp
@@ -8,6 +8,8 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -19,6 +21,34 @@ using namespace KINETO_NAMESPACE;
 using namespace std::chrono;
 
 namespace {
+
+class RecordingGpuProfiler : public GenericActivityProfiler {
+ public:
+  RecordingGpuProfiler() : GenericActivityProfiler(/*cpuOnly=*/false) {}
+
+  std::vector<std::string> events;
+  bool useCpuOnly{false};
+
+ protected:
+  void ensureGpuTracingReady() override {
+    events.emplace_back("ready");
+    if (useCpuOnly) {
+      cpuOnly_ = true;
+    }
+  }
+
+  void clearGpuActivities() override {
+    events.emplace_back("clear");
+  }
+
+  void requestGpuTracingTeardown() override {
+    events.emplace_back("teardown");
+  }
+
+  void enableGpuTracing() override {
+    events.emplace_back("enable");
+  }
+};
 
 // Run one full synchronous trace and leave the profiler in the post-teardown
 // state the guards protect: processTrace() -> finalizeTrace() std::move()s
@@ -72,4 +102,30 @@ TEST_F(GenericActivityProfilerTeardownTest, RedundantProcessTraceIsNoOp) {
 
   MemoryTraceLogger logger(*cfg_);
   profiler.processTrace(logger); // must not crash
+}
+
+TEST_F(
+    GenericActivityProfilerTeardownTest,
+    ConfigureEnsuresGpuTracingReadyWithoutRequestingTeardown) {
+  RecordingGpuProfiler profiler;
+
+  profiler.configure(*cfg_, system_clock::now());
+  EXPECT_EQ(
+      profiler.events, (std::vector<std::string>{"ready", "clear", "enable"}));
+
+  profiler.events.clear();
+  profiler.reset();
+  EXPECT_EQ(profiler.events, (std::vector<std::string>{"clear", "teardown"}));
+}
+
+TEST_F(GenericActivityProfilerTeardownTest, ConfigureContinuesCpuOnly) {
+  RecordingGpuProfiler profiler;
+  profiler.useCpuOnly = true;
+
+  profiler.configure(*cfg_, system_clock::now());
+  EXPECT_EQ(profiler.events, (std::vector<std::string>{"ready"}));
+
+  profiler.events.clear();
+  profiler.configure(*cfg_, system_clock::now());
+  EXPECT_TRUE(profiler.events.empty());
 }


### PR DESCRIPTION
We are trying to enable `TEARDOWN_CUPTI=1` by default. One problem with this is that if two profiling sessions run in quick succession, because teardown happens async as a callback on the next CUDA call, the teardown for the first session can happen in the middle of the second session. This also happens if collection runs on a schedule and the user doesn't use a wait period. The result is usually that the second session unexpectedly doesn't have any GPU events.

To fix this, this PR adds a mechanism for the second session to cancel a pending CUPTI teardown. I prefer this over other solutions:
- Making the second session wait for the first to finish teardown is an unnecessary cost, because we're starting CUPTI back up as soon as it's torn down.
- Flipping TEARDOWN_CUPTI to 0 under schedules with no wait period doesn't help for sequential sessions. Worse, we can't be sure what the minimum number of wait iterations before teardown becomes worth it is, since this is model dependent.
- Having the user flip TEARDOWN_CUPTI manually seems like a cop-out.

How it works:
1. When a session completes, it queues teardown and moves the teardown state to `Preparing`
2. The teardown thread enables the callbacks needed for finalization, flushes CUPTI, and moves state to `Pending`
3. If a new session starts while finalization is `Pending`, it moves it to `Restoring`, cancelling the finalization.
4. If the teardown comes first, it moves the state to `Finalizing`. Any new session must then wait for the finalization to complete before starting.
5. New session preparation happens on the main thread, so we are sensitive to deadlocks. If new session preparation is waiting on finalization from a previous session, we cap the wait period to 10 seconds. This will break GPU profiling for the rest of the Kineto lifetime, but I'd rather break profiling than hang the training job.

Transitions between states are atomic so that all the threads/callbacks involved don't race with each other.

Testing:
Two simple tests
```
# Test 1
with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
    workload(...)
with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
    workload(...)

# Test 2
with profile(
    activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
    schedule=schedule(warmup=1, active=2, repeat=2)
) as prof:
    workload(...)
```

Previously, the second session in both examples would result in no GPU activities.

I also had codex generate a test bench with a bunch of different scenarios.

> - 100 real-CUDA sync/async interleaving repetitions in each reinitialization mode, including both sync-to-async and async-to-sync transitions;
  > - pending-cancellation, callback-wins, Finalizing, Restoring, and timeout state-machine tests;
  > - repeated wait=0 schedules;
  > - early stop, exceptions, dynamic collection toggling, CUDA graphs, multistream and multithread workloads;
  > - process-exit and multi-process contention scenarios;
  > - behavior comparisons with teardown unset and set to 0;
  > - Kineto callback, activity-profiler, synchronous/asynchronous handler, and controller tests.
  >
  > The largest stress campaigns covered 24,256 case rows, 2,286 validated traces, and 19,322 teardowns, with no teardown timeout, deadlock, malformed trace, or missing required GPU activity.