### PR TITLE
[xpupti] Report the hardware engine per GPU op via PTI v2 records

### DIFF
--- a/libkineto/include/MetadataFieldCatalog.h
+++ b/libkineto/include/MetadataFieldCatalog.h
@@ -185,6 +185,8 @@ inline constexpr MetadataField<uint64_t> kBytes{"bytes"};
 inline constexpr MetadataField<uint64_t> kCommunicatorId{"Communicator_id"};
 inline constexpr MetadataField<uint64_t> kCorrelation{"correlation"};
 inline constexpr MetadataField<int64_t> kDevice{"device"};
+inline constexpr MetadataField<uint64_t> kEngineIndex{"engine_index"};
+inline constexpr MetadataField<uint64_t> kEngineOrdinal{"engine_ordinal"};
 inline constexpr MetadataField<uint64_t> kKernelId{"kernel_id"};
 inline constexpr MetadataField<double> kMemoryBandwidthGbps{
     "memory bandwidth (GB/s)"};

--- a/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
@@ -167,11 +167,11 @@ void XpuptiActivityProfilerSession::handleRuntimeKernelMemcpyMemsetActivities(
   constexpr bool handleRuntimeActivities =
       std::is_same_v<pti_view_memory_record_type, pti_view_record_api_t>;
   constexpr bool handleKernelActivities =
-      std::is_same_v<pti_view_memory_record_type, pti_view_record_kernel>;
+      std::is_same_v<pti_view_memory_record_type, pti_view_record_kernel_t>;
   constexpr bool handleMemcpyActivities =
-      std::is_same_v<pti_view_memory_record_type, pti_view_record_memory_copy>;
+      std::is_same_v<pti_view_memory_record_type, pti_view_record_memcpy_t>;
   constexpr bool handleMemsetActivities =
-      std::is_same_v<pti_view_memory_record_type, pti_view_record_memory_fill>;
+      std::is_same_v<pti_view_memory_record_type, pti_view_record_memfill_t>;
 
   traceBuffer_.span.opCount += 1;
   traceBuffer_.gpuOpCount += 1;
@@ -264,6 +264,14 @@ void XpuptiActivityProfilerSession::handleRuntimeKernelMemcpyMemsetActivities(
         XpuFields::kSyclQueue, static_cast<uint64_t>(activity->_sycl_queue_id));
     trace_activity->addMetadataQuoted(
         "l0 queue", handleToHexString(activity->_queue_handle));
+    // Hardware engine the operation ran on: the ordinal identifies the engine
+    // group (compute, copy, ...), the index the engine within that group.
+    trace_activity->addMetadata(
+        XpuFields::kEngineOrdinal,
+        static_cast<uint64_t>(activity->_engine_ordinal));
+    trace_activity->addMetadata(
+        XpuFields::kEngineIndex,
+        static_cast<uint64_t>(activity->_engine_index));
   }
 
   if constexpr (handleKernelActivities) {
@@ -552,19 +560,19 @@ void XpuptiActivityProfilerSession::handlePtiActivity(
     case PTI_VIEW_DEVICE_GPU_KERNEL:
       handleRuntimeKernelMemcpyMemsetActivities(
           ActivityType::CONCURRENT_KERNEL,
-          reinterpret_cast<const pti_view_record_kernel*>(record),
+          reinterpret_cast<const pti_view_record_kernel_t*>(record),
           logger);
       break;
     case PTI_VIEW_DEVICE_GPU_MEM_COPY:
       handleRuntimeKernelMemcpyMemsetActivities(
           ActivityType::GPU_MEMCPY,
-          reinterpret_cast<const pti_view_record_memory_copy*>(record),
+          reinterpret_cast<const pti_view_record_memcpy_t*>(record),
           logger);
       break;
     case PTI_VIEW_DEVICE_GPU_MEM_FILL:
       handleRuntimeKernelMemcpyMemsetActivities(
           ActivityType::GPU_MEMSET,
-          reinterpret_cast<const pti_view_record_memory_fill*>(record),
+          reinterpret_cast<const pti_view_record_memfill_t*>(record),
           logger);
       break;
     case PTI_VIEW_COLLECTION_OVERHEAD:

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
@@ -86,6 +86,12 @@ class XpuptiActivityProfilerSession
 
   using pti_view_record_api_t = pti_view_record_api;
 
+  // Device activity record versions this plugin consumes. The v2 records (PTI
+  // 1.0+) extend v1 with the hardware engine an operation ran on.
+  using pti_view_record_kernel_t = pti_view_record_kernel_v2;
+  using pti_view_record_memcpy_t = pti_view_record_memory_copy_v2;
+  using pti_view_record_memfill_t = pti_view_record_memory_fill_v2;
+
   template <typename PTI_VIEW>
   std::string getApiName(const PTI_VIEW* activity) {
     const char* api_name = nullptr;

--- a/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
+++ b/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
@@ -74,23 +74,32 @@ class XpuptiActivityHandlersTest : public ::testing::Test {
  protected:
   MockXpuptiActivityApi mockApi_;
   MockActivityLogger logger_;
+  Config config_;
+  // The session keeps a reference to this set, so it must outlive the session.
+  std::set<ActivityType> activityTypes_ = {
+      ActivityType::COLLECTIVE_COMM,
+      ActivityType::XPU_SYNC};
 
-  // Processes all records in mockApi_ through the handler pipeline
-  // and returns the resulting trace buffer.
-  std::unique_ptr<CpuTraceBuffer> processAndGetTrace(
+  // Processes all records in mockApi_ through the handler pipeline and returns
+  // the session, so both the trace buffer and the lane (ResourceInfo) state it
+  // built can be inspected.
+  std::unique_ptr<KN::XpuptiActivityProfilerSession> processAndGetSession(
       int64_t windowStart = 0,
       int64_t windowEnd = 1000) {
-    Config config;
-    std::set<ActivityType> activity_types = {
-        ActivityType::COLLECTIVE_COMM, ActivityType::XPU_SYNC};
     auto session = std::make_unique<KN::XpuptiActivityProfilerSession>(
-        mockApi_, "__test_profiler__", config, activity_types);
+        mockApi_, "__test_profiler__", config_, activityTypes_);
     session->processTrace(
         logger_,
         [](int64_t) -> const ITraceActivity* { return nullptr; },
         windowStart,
         windowEnd);
-    return session->getTraceBuffer();
+    return session;
+  }
+
+  std::unique_ptr<CpuTraceBuffer> processAndGetTrace(
+      int64_t windowStart = 0,
+      int64_t windowEnd = 1000) {
+    return processAndGetSession(windowStart, windowEnd)->getTraceBuffer();
   }
 };
 
@@ -241,9 +250,9 @@ TEST_F(XpuptiActivityHandlersTest, SynchronizationActivityMetadata) {
 }
 
 TEST_F(XpuptiActivityHandlersTest, ZeroDurationMemoryCopyOmitsBandwidth) {
-  pti_view_record_memory_copy memory_record{};
+  pti_view_record_memory_copy_v2 memory_record{};
   memory_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_MEM_COPY;
-  memory_record._name = "zeCommandListAppendMemoryCopy";
+  memory_record._name = "zeCommandListAppendMemoryCopy(M2D)";
   memory_record._start_timestamp = 100;
   memory_record._end_timestamp = 100;
   memory_record._thread_id = 7;
@@ -252,8 +261,7 @@ TEST_F(XpuptiActivityHandlersTest, ZeroDurationMemoryCopyOmitsBandwidth) {
   memory_record._mem_op_id = 4;
   memory_record._bytes = 1024;
 
-  mockApi_.records.push_back(
-      reinterpret_cast<const pti_view_record_base*>(&memory_record));
+  mockApi_.records.push_back(&memory_record._view_kind);
 
   auto traceBuffer = processAndGetTrace();
   ASSERT_EQ(traceBuffer->activities.size(), 1);
@@ -269,6 +277,109 @@ TEST_F(XpuptiActivityHandlersTest, ZeroDurationMemoryCopyOmitsBandwidth) {
       activity.metadataJson().find(
           XpuMetadataFields::kMemoryBandwidthGbps.name),
       std::string::npos);
+}
+
+// --- Hardware engine metadata tests ---
+
+TEST_F(XpuptiActivityHandlersTest, KernelActivityExposesEngineIds) {
+  pti_view_record_kernel_v2 kernel_record{};
+  kernel_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_KERNEL;
+  kernel_record._name = "test_kernel";
+  kernel_record._start_timestamp = 100;
+  kernel_record._end_timestamp = 200;
+  kernel_record._thread_id = 7;
+  kernel_record._correlation_id = 21;
+  kernel_record._sycl_queue_id = 64;
+  kernel_record._kernel_id = 1;
+  kernel_record._engine_ordinal = 0;
+  kernel_record._engine_index = 2;
+
+  mockApi_.records.push_back(&kernel_record._view_kind);
+
+  auto traceBuffer = processAndGetTrace();
+  ASSERT_EQ(traceBuffer->activities.size(), 1);
+
+  auto& activity = *traceBuffer->activities[0];
+  EXPECT_EQ(activity.type(), ActivityType::CONCURRENT_KERNEL);
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kEngineOrdinal),
+      std::optional<uint64_t>{0});
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kEngineIndex),
+      std::optional<uint64_t>{2});
+}
+
+TEST_F(XpuptiActivityHandlersTest, MemoryCopyActivityExposesEngineIds) {
+  pti_view_record_memory_copy_v2 memory_record{};
+  memory_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_MEM_COPY;
+  memory_record._name = "zeCommandListAppendMemoryCopy(M2D)";
+  memory_record._start_timestamp = 100;
+  memory_record._end_timestamp = 200;
+  memory_record._thread_id = 7;
+  memory_record._correlation_id = 22;
+  memory_record._sycl_queue_id = 64;
+  memory_record._mem_op_id = 4;
+  memory_record._bytes = 1024;
+  memory_record._engine_ordinal = 1;
+  memory_record._engine_index = 3;
+
+  mockApi_.records.push_back(&memory_record._view_kind);
+
+  auto traceBuffer = processAndGetTrace();
+  ASSERT_EQ(traceBuffer->activities.size(), 1);
+
+  auto& activity = *traceBuffer->activities[0];
+  EXPECT_EQ(activity.type(), ActivityType::GPU_MEMCPY);
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kEngineOrdinal),
+      std::optional<uint64_t>{1});
+  EXPECT_EQ(
+      activity.getMetadataValue(XpuMetadataFields::kEngineIndex),
+      std::optional<uint64_t>{3});
+}
+
+TEST_F(XpuptiActivityHandlersTest, SwimLanesStayPerSyclQueueNotPerEngine) {
+  // A kernel on a compute engine and a copy on a copy engine, both submitted to
+  // the SAME SYCL queue, must share one swim lane named after that queue.
+  // Engine identity belongs in metadata; CUDA groups lanes by stream likewise.
+  pti_view_record_kernel_v2 kernel_record{};
+  kernel_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_KERNEL;
+  kernel_record._name = "test_kernel";
+  kernel_record._start_timestamp = 100;
+  kernel_record._end_timestamp = 200;
+  kernel_record._thread_id = 7;
+  kernel_record._correlation_id = 31;
+  kernel_record._sycl_queue_id = 64;
+  kernel_record._kernel_id = 1;
+  kernel_record._engine_ordinal = 0;
+  kernel_record._engine_index = 0;
+
+  pti_view_record_memory_copy_v2 memory_record{};
+  memory_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_MEM_COPY;
+  memory_record._name = "zeCommandListAppendMemoryCopy(M2D)";
+  memory_record._start_timestamp = 300;
+  memory_record._end_timestamp = 400;
+  memory_record._thread_id = 7;
+  memory_record._correlation_id = 32;
+  memory_record._sycl_queue_id = 64;
+  memory_record._mem_op_id = 2;
+  memory_record._bytes = 1024;
+  memory_record._engine_ordinal = 1;
+  memory_record._engine_index = 0;
+
+  mockApi_.records.push_back(&kernel_record._view_kind);
+  mockApi_.records.push_back(&memory_record._view_kind);
+
+  auto session = processAndGetSession();
+  auto traceBuffer = session->getTraceBuffer();
+  ASSERT_EQ(traceBuffer->activities.size(), 2);
+  EXPECT_EQ(traceBuffer->activities[0]->resourceId(), 64);
+  EXPECT_EQ(traceBuffer->activities[1]->resourceId(), 64);
+
+  const auto resourceInfos = session->getResourceInfos();
+  ASSERT_EQ(resourceInfos.size(), 1);
+  EXPECT_EQ(resourceInfos[0].id, 64);
+  EXPECT_EQ(resourceInfos[0].name, "Stream 64");
 }
 
 TEST_F(XpuptiActivityHandlersTest, SynchronizationAllTypes) {


### PR DESCRIPTION
## Why

Intel GPU traces put one swim lane per SYCL queue. A SYCL queue is a *software*
queue: the driver maps its operations onto hardware engines, several queues can
share one engine, and a single queue's copies can be spread over several copy
engines. Nothing in the trace says which engine an operation actually ran on, so
two questions users regularly ask cannot be answered from a trace today:

- Did these two overlapping slices really run concurrently, or are they on the
  same engine with misleading timestamps?
- Did this copy ride a dedicated copy engine, or the compute engine?

Both matter when judging compute/copy overlap. On parts that expose a single
compute engine, overlapping SYCL-queue lanes do not imply concurrent execution
at all — and there is currently no way to tell that from the trace.

## How

PTI 1.0 introduced v2 device activity records (`pti_view_record_kernel_v2` and
friends) which extend the v1 layout with the hardware engine an operation ran
on. They are a binary extension of v1, reported under the same view kinds, so
the plugin only changes the record type it casts to — no new view kinds to
enable, no change in collection.

The engine is then emitted as per-op metadata:

- `engine_ordinal` — the engine group (compute, copy, …)
- `engine_index` — the engine within that group

matching how Level Zero reports command queue groups.

**Swim lanes are deliberately left unchanged:** still one per SYCL queue, named
`Stream <id>`, mirroring how CUDA lays out streams.

### Alternative considered and rejected: keying swim lanes on the engine

Splitting lanes per hardware engine is worse in both directions:

- When more than one copy engine is enabled, the Level Zero adapter
  **round-robins a single queue's copies across them**
  (`ur_queue_group_t::getQueueIndex`). Measured on Intel Data Center GPU Max
  Series with `UR_L0_USE_COPY_ENGINE=0:7`: the 32 copies of **one in-order
  queue** landed on **8 different engines** — one main copy engine plus seven
  link copy engines. Engine-keyed lanes would shred that single stream across
  eight tracks. (With default settings the same queue stays on a single copy
  engine, so this is configuration-dependent — but the configuration is a plain
  environment variable.)
- Conversely, on parts that expose a single compute engine, all compute lanes
  collapse into one, merging genuinely distinct queues.

Ordering is preserved either way: even with the copies spread over eight
engines, the trace shows **zero overlapping copy slices**, because the in-order
queue serialises them. So an engine axis does not buy overlap insight that the
queue axis lacks — which is the other reason to keep it out of the lane key.

Per-op metadata gives the same information without changing the shape of the
trace, and keeps the lane axis (the SYCL queue) the one that actually separates
independent streams of work.

Naming the engine *type* in the lane label was also dropped: it needs an
additional PTI query and buys nothing once lanes are not engine-keyed.

## Tests

`XpuptiActivityHandlersTest` gains three cases:

- `KernelActivityExposesEngineIds`
- `MemoryCopyActivityExposesEngineIds`
- `SwimLanesStayPerSyclQueueNotPerEngine` — pins the lane behaviour: a kernel and
  a copy on *different* engines but the *same* SYCL queue must share one lane,
  named `Stream 64`.

`ZeroDurationMemoryCopyOmitsBandwidth` moves to the v2 record type: a hand-built
v1 record would now be read past its end.

Built and ran on Intel Data Center GPU Max Series against PTI 1.2.0 —
`XpuptiActivityHandlersTest` 13/13 pass.

## Note on the minimum PTI version

Building the xpupti plugin now requires **PTI 1.0 or newer**, which is where the
v2 records were introduced.
