### PR TITLE
[Kineto] Reintroduce Windows timestamp fix in CUPTI test

### DIFF
--- a/libkineto/test/CuptiActivityProfilerTest.cpp
+++ b/libkineto/test/CuptiActivityProfilerTest.cpp
@@ -441,7 +441,7 @@ TEST_F(CuptiActivityProfilerTest, UnavailableCuptiFallsBackToCpuOnly) {
       startTimeNs, startTimeNs + duration.count());
   cpuOps->addOp("cpu_op", startTimeNs + 20, startTimeNs + 50, 1);
   profiler_->transferCpuTrace(std::move(cpuOps));
-  profiler_->stopTrace(startTime + duration);
+  profiler_->stopTrace(timePointFromNs(startTimeNs + duration.count()));
 
   auto logger = std::make_unique<MemoryTraceLogger>(*cfg_);
   profiler_->processTrace(*logger);


### PR DESCRIPTION
For upstreaming -- seems like this fix was accidentally reverted, causing failures in the test enablement PR in the upstreaming experiments