### PR TITLE
[xpupti] Guard v2 device records by PTI version

### DIFF
--- a/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityHandlers.cpp
@@ -281,14 +281,16 @@ void XpuptiActivityProfilerSession::handleRuntimeKernelMemcpyMemsetActivities(
         XpuFields::kSyclQueue, static_cast<uint64_t>(activity->_sycl_queue_id));
     trace_activity->addMetadataQuoted(
         "l0 queue", handleToHexString(activity->_queue_handle));
-    // Hardware engine the operation ran on: the ordinal identifies the engine
-    // group (compute, copy, ...), the index the engine within that group.
-    trace_activity->addMetadata(
-        XpuFields::kEngineOrdinal,
-        static_cast<uint64_t>(activity->_engine_ordinal));
-    trace_activity->addMetadata(
-        XpuFields::kEngineIndex,
-        static_cast<uint64_t>(activity->_engine_index));
+    if constexpr (kReportsEngineIds) {
+      // Hardware engine the operation ran on: the ordinal identifies the engine
+      // group (compute, copy, ...), the index the engine within that group.
+      trace_activity->addMetadata(
+          XpuFields::kEngineOrdinal,
+          static_cast<uint64_t>(activity->_engine_ordinal));
+      trace_activity->addMetadata(
+          XpuFields::kEngineIndex,
+          static_cast<uint64_t>(activity->_engine_index));
+    }
   }
 
   if constexpr (handleKernelActivities) {

--- a/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
+++ b/libkineto/src/plugin/xpupti/XpuptiActivityProfilerSession.h
@@ -35,6 +35,22 @@ class XpuptiActivityApi;
 
 using DeviceUUIDsT = std::array<unsigned char, 16>;
 
+// Device activity record versions this plugin consumes. The v2 records (PTI
+// 0.18+) extend v1 with the hardware engine an operation ran on; against older
+// PTI only v1 exists and the engine is not reported. Declared here rather than
+// inside the session so the plugin tests build the same records it consumes.
+#if PTI_VERSION_AT_LEAST(0, 18)
+inline constexpr bool kReportsEngineIds = true;
+using pti_view_record_kernel_t = pti_view_record_kernel_v2;
+using pti_view_record_memcpy_t = pti_view_record_memory_copy_v2;
+using pti_view_record_memfill_t = pti_view_record_memory_fill_v2;
+#else
+inline constexpr bool kReportsEngineIds = false;
+using pti_view_record_kernel_t = pti_view_record_kernel;
+using pti_view_record_memcpy_t = pti_view_record_memory_copy;
+using pti_view_record_memfill_t = pti_view_record_memory_fill;
+#endif
+
 class XpuptiActivityProfilerSession
     : public libkineto::IActivityProfilerSession {
  public:
@@ -92,12 +108,6 @@ class XpuptiActivityProfilerSession
       const pti_view_record_external_correlation* correlation);
 
   using pti_view_record_api_t = pti_view_record_api;
-
-  // Device activity record versions this plugin consumes. The v2 records (PTI
-  // 1.0+) extend v1 with the hardware engine an operation ran on.
-  using pti_view_record_kernel_t = pti_view_record_kernel_v2;
-  using pti_view_record_memcpy_t = pti_view_record_memory_copy_v2;
-  using pti_view_record_memfill_t = pti_view_record_memory_fill_v2;
 
   template <typename PTI_VIEW>
   std::string getApiName(const PTI_VIEW* activity) {

--- a/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
+++ b/libkineto/test/xpupti/XpuptiActivityHandlersTest.cpp
@@ -251,7 +251,7 @@ TEST_F(XpuptiActivityHandlersTest, SynchronizationActivityMetadata) {
 }
 
 TEST_F(XpuptiActivityHandlersTest, ZeroDurationMemoryCopyOmitsBandwidth) {
-  pti_view_record_memory_copy_v2 memory_record{};
+  KN::pti_view_record_memcpy_t memory_record{};
   memory_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_MEM_COPY;
   memory_record._name = "zeCommandListAppendMemoryCopy(M2D)";
   memory_record._start_timestamp = 100;
@@ -282,8 +282,12 @@ TEST_F(XpuptiActivityHandlersTest, ZeroDurationMemoryCopyOmitsBandwidth) {
 
 // --- Hardware engine metadata tests ---
 
+// Records carry the engine only from PTI 0.18 on, so the tests asserting the
+// engine metadata are built against the newer records only.
+#if PTI_VERSION_AT_LEAST(0, 18)
+
 TEST_F(XpuptiActivityHandlersTest, KernelActivityExposesEngineIds) {
-  pti_view_record_kernel_v2 kernel_record{};
+  KN::pti_view_record_kernel_t kernel_record{};
   kernel_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_KERNEL;
   kernel_record._name = "test_kernel";
   kernel_record._start_timestamp = 100;
@@ -311,7 +315,7 @@ TEST_F(XpuptiActivityHandlersTest, KernelActivityExposesEngineIds) {
 }
 
 TEST_F(XpuptiActivityHandlersTest, MemoryCopyActivityExposesEngineIds) {
-  pti_view_record_memory_copy_v2 memory_record{};
+  KN::pti_view_record_memcpy_t memory_record{};
   memory_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_MEM_COPY;
   memory_record._name = "zeCommandListAppendMemoryCopy(M2D)";
   memory_record._start_timestamp = 100;
@@ -339,11 +343,13 @@ TEST_F(XpuptiActivityHandlersTest, MemoryCopyActivityExposesEngineIds) {
       std::optional<uint64_t>{3});
 }
 
+#endif // PTI_VERSION_AT_LEAST(0, 18)
+
 TEST_F(XpuptiActivityHandlersTest, SwimLanesStayPerSyclQueueNotPerEngine) {
   // A kernel on a compute engine and a copy on a copy engine, both submitted to
   // the SAME SYCL queue, must share one swim lane named after that queue.
   // Engine identity belongs in metadata; CUDA groups lanes by stream likewise.
-  pti_view_record_kernel_v2 kernel_record{};
+  KN::pti_view_record_kernel_t kernel_record{};
   kernel_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_KERNEL;
   kernel_record._name = "test_kernel";
   kernel_record._start_timestamp = 100;
@@ -352,10 +358,12 @@ TEST_F(XpuptiActivityHandlersTest, SwimLanesStayPerSyclQueueNotPerEngine) {
   kernel_record._correlation_id = 31;
   kernel_record._sycl_queue_id = 64;
   kernel_record._kernel_id = 1;
+#if PTI_VERSION_AT_LEAST(0, 18)
   kernel_record._engine_ordinal = 0;
   kernel_record._engine_index = 0;
+#endif
 
-  pti_view_record_memory_copy_v2 memory_record{};
+  KN::pti_view_record_memcpy_t memory_record{};
   memory_record._view_kind._view_kind = PTI_VIEW_DEVICE_GPU_MEM_COPY;
   memory_record._name = "zeCommandListAppendMemoryCopy(M2D)";
   memory_record._start_timestamp = 300;
@@ -365,8 +373,10 @@ TEST_F(XpuptiActivityHandlersTest, SwimLanesStayPerSyclQueueNotPerEngine) {
   memory_record._sycl_queue_id = 64;
   memory_record._mem_op_id = 2;
   memory_record._bytes = 1024;
+#if PTI_VERSION_AT_LEAST(0, 18)
   memory_record._engine_ordinal = 1;
   memory_record._engine_index = 0;
+#endif
 
   mockApi_.records.push_back(&kernel_record._view_kind);
   mockApi_.records.push_back(&memory_record._view_kind);


### PR DESCRIPTION
## Why

The v2 device activity records (`pti_view_record_kernel_v2`, `pti_view_record_memory_copy_v2`,
`pti_view_record_memory_fill_v2`) only exist from PTI 0.18. #1555 started consuming them
unconditionally, so the plugin no longer compiles against an older PTI. The XPU `n-1` build
images still ship PTI 0.17, so `linux-jammy-xpu-n-1-py3.10 / build` and
`win-vs2022-xpu-n-1-py3 / build` on pytorch/pytorch main fail with
`'pti_view_record_kernel_v2' does not name a type`.

## How

Pick the record version with the `PTI_VERSION_AT_LEAST` macro the plugin already provides, and
fall back to the v1 records below PTI 0.18, where the hardware engine is then not reported. The
aliases move to namespace scope so the plugin tests build the same records the plugin consumes;
the tests asserting the engine metadata are compiled for PTI 0.18+ only.
