### PR TITLE
[Kineto] Add lookback window and sampling interval as config options

### DIFF
--- a/libkineto/include/Config.h
+++ b/libkineto/include/Config.h
@@ -236,6 +236,16 @@ class Config : public AbstractConfig {
     return performanceMetricsDeviceId_;
   }
 
+  [[nodiscard]] std::chrono::nanoseconds performanceMetricsSamplingInterval()
+      const {
+    return performanceMetricsSamplingInterval_;
+  }
+
+  [[nodiscard]] std::chrono::nanoseconds performanceMetricsLookbackWindow()
+      const {
+    return performanceMetricsLookbackWindow_;
+  }
+
   [[nodiscard]] bool memoryProfilerEnabled() const {
     return memoryProfilerEnabled_;
   }
@@ -375,6 +385,10 @@ class Config : public AbstractConfig {
   // Performance metrics
   std::vector<std::string> performanceMetricNames_;
   int32_t performanceMetricsDeviceId_{-1};
+  std::chrono::nanoseconds performanceMetricsSamplingInterval_{
+      std::chrono::milliseconds{1}};
+  std::chrono::nanoseconds performanceMetricsLookbackWindow_{
+      std::chrono::seconds{10}};
 
   // CUPTI Timestamp Format
   bool useTSCTimestamp_{true};

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -9,10 +9,8 @@
 #include "Config.h"
 #include "ThrowUtil.h"
 
-#include <cerrno>
 #include <cmath>
 #include <cstdlib>
-#include <limits>
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>
@@ -235,29 +233,18 @@ bool isAllowedOnDemandTraceFile(const string& path) {
   return path.starts_with(dir) && path.find("..") == string::npos;
 }
 
-nanoseconds parsePositiveMilliseconds(
+nanoseconds parseMilliseconds(
     const string& value,
-    const char* optionName) {
-  errno = 0;
+    nanoseconds fallback) noexcept {
   char* end = nullptr;
-  const long double milliseconds = std::strtold(value.c_str(), &end);
-  constexpr long double kNanosecondsPerMillisecond = 1'000'000.0L;
-  const long double nanosecondCount = milliseconds * kNanosecondsPerMillisecond;
-  if (value.empty() || end != value.c_str() + value.size() || errno == ERANGE ||
-      !std::isfinite(milliseconds) || nanosecondCount < 1.0L ||
-      nanosecondCount >
-          static_cast<long double>(
-              std::numeric_limits<std::chrono::nanoseconds::rep>::max())) {
-    KINETO_THROW(
-        std::invalid_argument,
-        fmt::format(
-            "Invalid {}: {} - expected positive milliseconds representable "
-            "as nanoseconds",
-            optionName,
-            value));
+  const duration<double, std::milli> milliseconds{
+      std::strtod(value.c_str(), &end)};
+  if (end != value.c_str() + value.size() ||
+      !std::isfinite(milliseconds.count()) || milliseconds < nanoseconds{1} ||
+      milliseconds > nanoseconds::max()) {
+    return fallback;
   }
-  return std::chrono::nanoseconds{
-      static_cast<std::chrono::nanoseconds::rep>(nanosecondCount)};
+  return duration_cast<nanoseconds>(milliseconds);
 }
 
 } // namespace
@@ -384,11 +371,11 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   } else if (!name.compare(kPerformanceMetricsDeviceIdKey)) {
     performanceMetricsDeviceId_ = toInt32(val);
   } else if (!name.compare(kPerformanceMetricsSamplingIntervalMsecsKey)) {
-    performanceMetricsSamplingInterval_ = parsePositiveMilliseconds(
-        val, kPerformanceMetricsSamplingIntervalMsecsKey);
+    performanceMetricsSamplingInterval_ =
+        parseMilliseconds(val, performanceMetricsSamplingInterval_);
   } else if (!name.compare(kPerformanceMetricsLookbackWindowMsecsKey)) {
-    performanceMetricsLookbackWindow_ = parsePositiveMilliseconds(
-        val, kPerformanceMetricsLookbackWindowMsecsKey);
+    performanceMetricsLookbackWindow_ =
+        parseMilliseconds(val, performanceMetricsLookbackWindow_);
   } else if (!name.compare(kProfileMemory)) {
     memoryProfilerEnabled_ = toBool(val);
     if (memoryProfilerEnabled_) {

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -17,6 +17,7 @@
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
 
+#include <charconv>
 #include <chrono>
 #include <ctime>
 #include <functional>
@@ -234,10 +235,11 @@ bool isAllowedOnDemandTraceFile(const string& path) {
   return path.starts_with(dir) && path.find("..") == string::npos;
 }
 
-std::optional<nanoseconds> parseMilliseconds(const string& text) noexcept {
-  char* parseEnd = nullptr;
-  const double count = std::strtod(text.c_str(), &parseEnd);
-  if (parseEnd != text.c_str() + text.size()) {
+std::optional<nanoseconds> parseMilliseconds(std::string_view text) noexcept {
+  double count = 0;
+  const auto [parseEnd, error] =
+      std::from_chars(text.begin(), text.end(), count);
+  if (error != std::errc{} || parseEnd != text.end()) {
     return std::nullopt;
   }
 

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -21,6 +21,7 @@
 #include <ctime>
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <ostream>
 #include <string_view>
 #include <utility>
@@ -233,18 +234,20 @@ bool isAllowedOnDemandTraceFile(const string& path) {
   return path.starts_with(dir) && path.find("..") == string::npos;
 }
 
-nanoseconds parseMilliseconds(
-    const string& value,
-    nanoseconds fallback) noexcept {
-  char* end = nullptr;
-  const duration<double, std::milli> milliseconds{
-      std::strtod(value.c_str(), &end)};
-  if (end != value.c_str() + value.size() ||
-      !std::isfinite(milliseconds.count()) || milliseconds < nanoseconds{1} ||
-      milliseconds > nanoseconds::max()) {
-    return fallback;
+std::optional<nanoseconds> parseMilliseconds(const string& text) noexcept {
+  char* parseEnd = nullptr;
+  const double count = std::strtod(text.c_str(), &parseEnd);
+  if (parseEnd != text.c_str() + text.size()) {
+    return std::nullopt;
   }
-  return duration_cast<nanoseconds>(milliseconds);
+
+  const duration<double, std::milli> value{count};
+  if (!std::isfinite(count) || value < nanoseconds{1} ||
+      value > nanoseconds::max()) {
+    return std::nullopt;
+  }
+
+  return duration_cast<nanoseconds>(value);
 }
 
 } // namespace
@@ -371,11 +374,13 @@ bool Config::handleOption(const std::string& name, std::string& val) {
   } else if (!name.compare(kPerformanceMetricsDeviceIdKey)) {
     performanceMetricsDeviceId_ = toInt32(val);
   } else if (!name.compare(kPerformanceMetricsSamplingIntervalMsecsKey)) {
-    performanceMetricsSamplingInterval_ =
-        parseMilliseconds(val, performanceMetricsSamplingInterval_);
+    if (const auto value = parseMilliseconds(val)) {
+      performanceMetricsSamplingInterval_ = *value;
+    }
   } else if (!name.compare(kPerformanceMetricsLookbackWindowMsecsKey)) {
-    performanceMetricsLookbackWindow_ =
-        parseMilliseconds(val, performanceMetricsLookbackWindow_);
+    if (const auto value = parseMilliseconds(val)) {
+      performanceMetricsLookbackWindow_ = *value;
+    }
   } else if (!name.compare(kProfileMemory)) {
     memoryProfilerEnabled_ = toBool(val);
     if (memoryProfilerEnabled_) {

--- a/libkineto/src/Config.cpp
+++ b/libkineto/src/Config.cpp
@@ -9,7 +9,10 @@
 #include "Config.h"
 #include "ThrowUtil.h"
 
+#include <cerrno>
+#include <cmath>
 #include <cstdlib>
+#include <limits>
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>
@@ -55,6 +58,10 @@ constexpr char kCuptiPerThreadBufferEnabledKey[] =
 constexpr char kPerformanceMetricsKey[] = "PERFORMANCE_METRICS";
 constexpr char kPerformanceMetricsDeviceIdKey[] =
     "PERFORMANCE_METRICS_DEVICE_ID";
+constexpr char kPerformanceMetricsSamplingIntervalMsecsKey[] =
+    "PERFORMANCE_METRICS_SAMPLING_INTERVAL_MS";
+constexpr char kPerformanceMetricsLookbackWindowMsecsKey[] =
+    "PERFORMANCE_METRICS_LOOKBACK_WINDOW_MS";
 constexpr char kActivityTypesKey[] = "ACTIVITY_TYPES";
 constexpr char kActivitiesLogFileKey[] = "ACTIVITIES_LOG_FILE";
 constexpr char kActivitiesDurationKey[] = "ACTIVITIES_DURATION_SECS";
@@ -228,6 +235,31 @@ bool isAllowedOnDemandTraceFile(const string& path) {
   return path.starts_with(dir) && path.find("..") == string::npos;
 }
 
+nanoseconds parsePositiveMilliseconds(
+    const string& value,
+    const char* optionName) {
+  errno = 0;
+  char* end = nullptr;
+  const long double milliseconds = std::strtold(value.c_str(), &end);
+  constexpr long double kNanosecondsPerMillisecond = 1'000'000.0L;
+  const long double nanosecondCount = milliseconds * kNanosecondsPerMillisecond;
+  if (value.empty() || end != value.c_str() + value.size() || errno == ERANGE ||
+      !std::isfinite(milliseconds) || nanosecondCount < 1.0L ||
+      nanosecondCount >
+          static_cast<long double>(
+              std::numeric_limits<std::chrono::nanoseconds::rep>::max())) {
+    KINETO_THROW(
+        std::invalid_argument,
+        fmt::format(
+            "Invalid {}: {} - expected positive milliseconds representable "
+            "as nanoseconds",
+            optionName,
+            value));
+  }
+  return std::chrono::nanoseconds{
+      static_cast<std::chrono::nanoseconds::rep>(nanosecondCount)};
+}
+
 } // namespace
 
 Config::Config()
@@ -351,6 +383,12 @@ bool Config::handleOption(const std::string& name, std::string& val) {
     performanceMetricNames_ = splitAndTrim(val, ',');
   } else if (!name.compare(kPerformanceMetricsDeviceIdKey)) {
     performanceMetricsDeviceId_ = toInt32(val);
+  } else if (!name.compare(kPerformanceMetricsSamplingIntervalMsecsKey)) {
+    performanceMetricsSamplingInterval_ = parsePositiveMilliseconds(
+        val, kPerformanceMetricsSamplingIntervalMsecsKey);
+  } else if (!name.compare(kPerformanceMetricsLookbackWindowMsecsKey)) {
+    performanceMetricsLookbackWindow_ = parsePositiveMilliseconds(
+        val, kPerformanceMetricsLookbackWindowMsecsKey);
   } else if (!name.compare(kProfileMemory)) {
     memoryProfilerEnabled_ = toBool(val);
     if (memoryProfilerEnabled_) {

--- a/libkineto/src/CuptiPMSamplingApi.cpp
+++ b/libkineto/src/CuptiPMSamplingApi.cpp
@@ -8,6 +8,7 @@
 
 #include "CuptiPMSamplingApi.h"
 
+#include <limits>
 #include <stdexcept>
 
 #include <cuda_runtime_api.h>
@@ -47,13 +48,28 @@ namespace KINETO_NAMESPACE {
 namespace {
 
 constexpr size_t kHardwareBufferSizeBytes = 64 * 1024 * 1024;
-constexpr uint32_t kMaxSamplesPerDecode = 1024;
 
 // GA100 only supports variable-frequency SYSCLK sampling. One option is to
 // measure hardware clock frequency and estimate the number of cycles needed to
 // fill a certain sampling duration, but clock frequency is not necessarily
 // fixed. This is almost certainly something we'll need to revisit/tune.
 constexpr uint64_t kGa100SamplingIntervalCycles = 1'000'000;
+
+uint32_t validatedSampleCapacity(const CuptiPMSamplingConfig& config) {
+  const auto capacity = config.sampleCapacity();
+  if (capacity == 0) {
+    KINETO_THROW(
+        std::runtime_error,
+        "CUPTI PM sampling interval and lookback window must be positive");
+  }
+  if (capacity > std::numeric_limits<uint32_t>::max()) {
+    KINETO_THROW(
+        std::runtime_error,
+        "CUPTI PM sampling lookback window requires more samples than CUPTI "
+        "supports");
+  }
+  return static_cast<uint32_t>(capacity);
+}
 
 /*
  * ========================== CUPTI PM SAMPLING API ==========================
@@ -110,6 +126,7 @@ void CuptiPMSamplingApi::configure(const CuptiPMSamplingConfig& config) {
         "Cannot configure CUPTI PM sampling before the previous "
         "configuration is fully disabled");
   }
+  static_cast<void>(validatedSampleCapacity(config));
   config_ = config;
 
   // CUPTI expects metric names as std::vector<const char*>
@@ -171,10 +188,6 @@ void CuptiPMSamplingApi::configureCupti() {
   } else if (
       deviceProperties.major > 8 ||
       (deviceProperties.major == 8 && deviceProperties.minor >= 6)) {
-    if (config_.samplingInterval.count() <= 0) {
-      KINETO_THROW(
-          std::runtime_error, "CUPTI PM sampling interval must be positive");
-    }
     triggerMode = CUPTI_PM_SAMPLING_TRIGGER_MODE_GPU_TIME_INTERVAL;
     samplingInterval = static_cast<uint64_t>(config_.samplingInterval.count());
   } else {
@@ -272,15 +285,14 @@ void CuptiPMSamplingApi::configureCupti() {
       CUPTI_PM_SAMPLING_HARDWARE_BUFFER_APPEND_MODE_KEEP_LATEST;
   CUPTI_CALL_THROW(cuptiPmSamplingSetConfig(&setConfig));
 
-  // Asking CUPTI how large the (counter) data image should be.
-  // Since the data image has an opage CUPTI-defined layout, the size
-  // depends on sampling config, metrics, etc.
+  // Size the counter data image to hold the requested lookback window. CUPTI
+  // 12.x requires SetConfig to run before GetCounterDataSize.
   CUpti_PmSampling_GetCounterDataSize_Params counterDataSize{
       CUpti_PmSampling_GetCounterDataSize_Params_STRUCT_SIZE};
   counterDataSize.pPmSamplingObject = samplingObject_;
   counterDataSize.pMetricNames = metricNamePtrs_.data();
   counterDataSize.numMetrics = metricNamePtrs_.size();
-  counterDataSize.maxSamples = kMaxSamplesPerDecode;
+  counterDataSize.maxSamples = validatedSampleCapacity(config_);
   CUPTI_CALL_THROW(cuptiPmSamplingGetCounterDataSize(&counterDataSize));
 
   counterDataImage_.resize(counterDataSize.counterDataSize);
@@ -425,6 +437,7 @@ void CuptiPMSamplingApi::disable() {
   metricNamePtrs_.clear();
   config_.metricNames.clear();
   config_.samplingInterval = std::chrono::nanoseconds::zero();
+  config_.lookbackWindow = std::chrono::nanoseconds::zero();
 }
 
 } // namespace KINETO_NAMESPACE

--- a/libkineto/src/CuptiPMSamplingApi.cpp
+++ b/libkineto/src/CuptiPMSamplingApi.cpp
@@ -8,7 +8,7 @@
 
 #include "CuptiPMSamplingApi.h"
 
-#include <limits>
+#include <algorithm>
 #include <stdexcept>
 
 #include <cuda_runtime_api.h>
@@ -54,22 +54,6 @@ constexpr size_t kHardwareBufferSizeBytes = 64 * 1024 * 1024;
 // fill a certain sampling duration, but clock frequency is not necessarily
 // fixed. This is almost certainly something we'll need to revisit/tune.
 constexpr uint64_t kGa100SamplingIntervalCycles = 1'000'000;
-
-uint32_t validatedSampleCapacity(const CuptiPMSamplingConfig& config) {
-  const auto capacity = config.sampleCapacity();
-  if (capacity == 0) {
-    KINETO_THROW(
-        std::runtime_error,
-        "CUPTI PM sampling interval and lookback window must be positive");
-  }
-  if (capacity > std::numeric_limits<uint32_t>::max()) {
-    KINETO_THROW(
-        std::runtime_error,
-        "CUPTI PM sampling lookback window requires more samples than CUPTI "
-        "supports");
-  }
-  return static_cast<uint32_t>(capacity);
-}
 
 /*
  * ========================== CUPTI PM SAMPLING API ==========================
@@ -126,7 +110,6 @@ void CuptiPMSamplingApi::configure(const CuptiPMSamplingConfig& config) {
         "Cannot configure CUPTI PM sampling before the previous "
         "configuration is fully disabled");
   }
-  static_cast<void>(validatedSampleCapacity(config));
   config_ = config;
 
   // CUPTI expects metric names as std::vector<const char*>
@@ -188,6 +171,10 @@ void CuptiPMSamplingApi::configureCupti() {
   } else if (
       deviceProperties.major > 8 ||
       (deviceProperties.major == 8 && deviceProperties.minor >= 6)) {
+    if (config_.samplingInterval.count() <= 0) {
+      KINETO_THROW(
+          std::runtime_error, "CUPTI PM sampling interval must be positive");
+    }
     triggerMode = CUPTI_PM_SAMPLING_TRIGGER_MODE_GPU_TIME_INTERVAL;
     samplingInterval = static_cast<uint64_t>(config_.samplingInterval.count());
   } else {
@@ -292,7 +279,8 @@ void CuptiPMSamplingApi::configureCupti() {
   counterDataSize.pPmSamplingObject = samplingObject_;
   counterDataSize.pMetricNames = metricNamePtrs_.data();
   counterDataSize.numMetrics = metricNamePtrs_.size();
-  counterDataSize.maxSamples = validatedSampleCapacity(config_);
+  counterDataSize.maxSamples = static_cast<uint32_t>(
+      std::max<int64_t>(1, config_.lookbackWindow / config_.samplingInterval));
   CUPTI_CALL_THROW(cuptiPmSamplingGetCounterDataSize(&counterDataSize));
 
   counterDataImage_.resize(counterDataSize.counterDataSize);

--- a/libkineto/src/CuptiPMSamplingApi.h
+++ b/libkineto/src/CuptiPMSamplingApi.h
@@ -30,7 +30,16 @@ struct CuptiPMSample {
 struct CuptiPMSamplingConfig {
   int32_t deviceId{-1};
   std::vector<std::string> metricNames;
-  std::chrono::nanoseconds samplingInterval{0};
+  std::chrono::nanoseconds samplingInterval{std::chrono::milliseconds{1}};
+  std::chrono::nanoseconds lookbackWindow{std::chrono::seconds{10}};
+
+  [[nodiscard]] uint64_t sampleCapacity() const {
+    if (samplingInterval.count() <= 0 || lookbackWindow.count() <= 0) {
+      return 0;
+    }
+    const auto samples = lookbackWindow.count() / samplingInterval.count();
+    return static_cast<uint64_t>(samples > 0 ? samples : 1);
+  }
 };
 
 class CuptiPMSamplingApi {

--- a/libkineto/src/CuptiPMSamplingApi.h
+++ b/libkineto/src/CuptiPMSamplingApi.h
@@ -32,14 +32,6 @@ struct CuptiPMSamplingConfig {
   std::vector<std::string> metricNames;
   std::chrono::nanoseconds samplingInterval{std::chrono::milliseconds{1}};
   std::chrono::nanoseconds lookbackWindow{std::chrono::seconds{10}};
-
-  [[nodiscard]] uint64_t sampleCapacity() const {
-    if (samplingInterval.count() <= 0 || lookbackWindow.count() <= 0) {
-      return 0;
-    }
-    const auto samples = lookbackWindow.count() / samplingInterval.count();
-    return static_cast<uint64_t>(samples > 0 ? samples : 1);
-  }
 };
 
 class CuptiPMSamplingApi {

--- a/libkineto/src/CuptiPMSamplingProfiler.cpp
+++ b/libkineto/src/CuptiPMSamplingProfiler.cpp
@@ -26,9 +26,6 @@ namespace {
 const std::string kProfilerName{"CUPTI PM Sampling"};
 const std::set<libkineto::ActivityType> kSupportedActivities{
     libkineto::ActivityType::HARDWARE_COUNTERS};
-// TODO: This is a temporary constant -- we need to tune the interval by
-// hardware type to prevent hardware buffer overflow and sample loss.
-constexpr std::chrono::milliseconds kSamplingInterval{1};
 
 } // namespace
 
@@ -201,7 +198,10 @@ std::unique_ptr<libkineto::IActivityProfilerSession> CuptiPMSamplingProfiler::
   }
 
   const CuptiPMSamplingConfig pmConfig{
-      deviceId, metricNames, kSamplingInterval};
+      deviceId,
+      metricNames,
+      config.performanceMetricsSamplingInterval(),
+      config.performanceMetricsLookbackWindow()};
   auto session = std::make_unique<CuptiPMSamplingSession>(pmConfig);
   if (!session->prepare()) {
     return nullptr;

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -168,16 +168,17 @@ TEST(ParseTest, PerformanceMetrics) {
   EXPECT_EQ(clone->performanceMetricsLookbackWindow(), seconds(2));
 }
 
-TEST(ParseTest, PerformanceMetricsDurationsRequirePositiveFiniteValues) {
-  for (const auto* key :
-       {"PERFORMANCE_METRICS_SAMPLING_INTERVAL_MS",
-        "PERFORMANCE_METRICS_LOOKBACK_WINDOW_MS"}) {
-    for (const auto* value :
-         {"", "0", "-1", "nan", "inf", "1ms", "0.0000001", "1e10000"}) {
-      Config cfg;
-      EXPECT_FALSE(cfg.parse(fmt::format("{}={}", key, value)))
-          << key << "=" << value;
-    }
+TEST(ParseTest, PerformanceMetricsInvalidDurationsUseDefaults) {
+  for (const auto* value :
+       {"", "0", "-1", "nan", "inf", "1ms", "0.0000001", "1e10000"}) {
+    Config cfg;
+    EXPECT_TRUE(cfg.parse(fmt::format(
+        "PERFORMANCE_METRICS_SAMPLING_INTERVAL_MS={}\n"
+        "PERFORMANCE_METRICS_LOOKBACK_WINDOW_MS={}",
+        value,
+        value)));
+    EXPECT_EQ(cfg.performanceMetricsSamplingInterval(), milliseconds(1));
+    EXPECT_EQ(cfg.performanceMetricsLookbackWindow(), seconds(10));
   }
 }
 

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -169,17 +169,12 @@ TEST(ParseTest, PerformanceMetrics) {
 }
 
 TEST(ParseTest, PerformanceMetricsInvalidDurationsUseDefaults) {
-  for (const auto* value :
-       {"", "0", "-1", "nan", "inf", "1ms", "0.0000001", "1e10000"}) {
-    Config cfg;
-    EXPECT_TRUE(cfg.parse(fmt::format(
-        "PERFORMANCE_METRICS_SAMPLING_INTERVAL_MS={}\n"
-        "PERFORMANCE_METRICS_LOOKBACK_WINDOW_MS={}",
-        value,
-        value)));
-    EXPECT_EQ(cfg.performanceMetricsSamplingInterval(), milliseconds(1));
-    EXPECT_EQ(cfg.performanceMetricsLookbackWindow(), seconds(10));
-  }
+  Config cfg;
+  EXPECT_TRUE(
+      cfg.parse("PERFORMANCE_METRICS_SAMPLING_INTERVAL_MS=invalid\n"
+                "PERFORMANCE_METRICS_LOOKBACK_WINDOW_MS=0"));
+  EXPECT_EQ(cfg.performanceMetricsSamplingInterval(), milliseconds(1));
+  EXPECT_EQ(cfg.performanceMetricsLookbackWindow(), seconds(10));
 }
 
 TEST(ParseTest, ProfileStartTime) {

--- a/libkineto/test/ConfigTest.cpp
+++ b/libkineto/test/ConfigTest.cpp
@@ -143,21 +143,42 @@ TEST(ParseTest, PerformanceMetrics) {
   Config cfg;
   EXPECT_TRUE(cfg.performanceMetricNames().empty());
   EXPECT_EQ(cfg.performanceMetricsDeviceId(), -1);
+  EXPECT_EQ(cfg.performanceMetricsSamplingInterval(), milliseconds(1));
+  EXPECT_EQ(cfg.performanceMetricsLookbackWindow(), seconds(10));
 
   EXPECT_TRUE(
       cfg.parse("PERFORMANCE_METRICS_DEVICE_ID=2\n"
                 "PERFORMANCE_METRICS="
-                "sm__cycles_active.avg,dram__bytes_read.sum"));
+                "sm__cycles_active.avg,dram__bytes_read.sum\n"
+                "PERFORMANCE_METRICS_SAMPLING_INTERVAL_MS=0.5\n"
+                "PERFORMANCE_METRICS_LOOKBACK_WINDOW_MS=2000"));
 
   EXPECT_EQ(
       cfg.performanceMetricNames(),
       std::vector<std::string>(
           {"sm__cycles_active.avg", "dram__bytes_read.sum"}));
   EXPECT_EQ(cfg.performanceMetricsDeviceId(), 2);
+  EXPECT_EQ(cfg.performanceMetricsSamplingInterval(), microseconds(500));
+  EXPECT_EQ(cfg.performanceMetricsLookbackWindow(), seconds(2));
 
   auto clone = cfg.clone();
   EXPECT_EQ(clone->performanceMetricNames(), cfg.performanceMetricNames());
   EXPECT_EQ(clone->performanceMetricsDeviceId(), 2);
+  EXPECT_EQ(clone->performanceMetricsSamplingInterval(), microseconds(500));
+  EXPECT_EQ(clone->performanceMetricsLookbackWindow(), seconds(2));
+}
+
+TEST(ParseTest, PerformanceMetricsDurationsRequirePositiveFiniteValues) {
+  for (const auto* key :
+       {"PERFORMANCE_METRICS_SAMPLING_INTERVAL_MS",
+        "PERFORMANCE_METRICS_LOOKBACK_WINDOW_MS"}) {
+    for (const auto* value :
+         {"", "0", "-1", "nan", "inf", "1ms", "0.0000001", "1e10000"}) {
+      Config cfg;
+      EXPECT_FALSE(cfg.parse(fmt::format("{}={}", key, value)))
+          << key << "=" << value;
+    }
+  }
 }
 
 TEST(ParseTest, ProfileStartTime) {

--- a/libkineto/test/CuptiPMSamplingApiTest.cpp
+++ b/libkineto/test/CuptiPMSamplingApiTest.cpp
@@ -13,7 +13,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
-#include <limits>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -59,7 +58,6 @@ struct FakeCuptiState {
   CUpti_PmSampling_HardwareBuffer_AppendMode appendMode{};
   std::vector<std::string> counterDataMetricNames;
   uint32_t maxSamples{0};
-  size_t counterDataSize{8 * 1024};
 
   std::byte hostObject{};
   std::byte samplingObject{};
@@ -230,7 +228,7 @@ CUptiResult CUPTIAPI cuptiPmSamplingGetCounterDataSize(
   fakeCupti().counterDataMetricNames =
       copyMetricNames(params->pMetricNames, params->numMetrics);
   fakeCupti().maxSamples = params->maxSamples;
-  params->counterDataSize = fakeCupti().counterDataSize;
+  params->counterDataSize = 1;
   return CUPTI_SUCCESS;
 }
 
@@ -321,7 +319,8 @@ TEST_F(CuptiPMSamplingApiTest, ConfiguresDeviceMetricsAndBuffers) {
   const auto config = makeConfig(
       250us,
       /*deviceId=*/2,
-      {"sm__cycles_active.avg", "dram__bytes_read.sum"});
+      {"sm__cycles_active.avg", "dram__bytes_read.sum"},
+      2s);
   CuptiPMSamplingApi api;
 
   api.configure(config);
@@ -337,19 +336,6 @@ TEST_F(CuptiPMSamplingApiTest, ConfiguresDeviceMetricsAndBuffers) {
       fakeCupti().appendMode,
       CUPTI_PM_SAMPLING_HARDWARE_BUFFER_APPEND_MODE_KEEP_LATEST);
   EXPECT_EQ(fakeCupti().counterDataMetricNames, config.metricNames);
-  EXPECT_EQ(fakeCupti().maxSamples, 40'000);
-  api.disable();
-}
-
-TEST_F(CuptiPMSamplingApiTest, SizesCounterDataFromLookbackWindow) {
-  CuptiPMSamplingApi api;
-
-  api.configure(makeConfig(
-      250us,
-      /*deviceId=*/0,
-      {"sm__cycles_active.avg"},
-      2s));
-
   EXPECT_EQ(fakeCupti().maxSamples, 8'000);
   api.disable();
 }
@@ -397,30 +383,6 @@ TEST_F(CuptiPMSamplingApiTest, RejectsUnsupportedComputeCapabilities) {
 
 TEST_F(CuptiPMSamplingApiTest, RejectsNonpositiveTimeIntervals) {
   EXPECT_THROW(configureForDevice(8, 6, 0ns), std::runtime_error);
-}
-
-TEST_F(CuptiPMSamplingApiTest, RejectsNonpositiveLookbackWindows) {
-  CuptiPMSamplingApi api;
-  EXPECT_THROW(
-      api.configure(makeConfig(
-          500us,
-          /*deviceId=*/0,
-          {"sm__cycles_active.avg"},
-          0ns)),
-      std::runtime_error);
-}
-
-TEST_F(CuptiPMSamplingApiTest, RejectsSampleCapacityAboveCuptiLimit) {
-  CuptiPMSamplingApi api;
-  constexpr auto kTooManySamples =
-      static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) + 1;
-  EXPECT_THROW(
-      api.configure(makeConfig(
-          1ns,
-          /*deviceId=*/0,
-          {"sm__cycles_active.avg"},
-          std::chrono::nanoseconds{kTooManySamples})),
-      std::runtime_error);
 }
 
 TEST_F(CuptiPMSamplingApiTest, RejectsMultipassConfigurationBeforeEnabling) {

--- a/libkineto/test/CuptiPMSamplingApiTest.cpp
+++ b/libkineto/test/CuptiPMSamplingApiTest.cpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -58,6 +59,7 @@ struct FakeCuptiState {
   CUpti_PmSampling_HardwareBuffer_AppendMode appendMode{};
   std::vector<std::string> counterDataMetricNames;
   uint32_t maxSamples{0};
+  size_t counterDataSize{8 * 1024};
 
   std::byte hostObject{};
   std::byte samplingObject{};
@@ -103,9 +105,10 @@ std::vector<std::string> copyMetricNames(
 CuptiPMSamplingConfig makeConfig(
     std::chrono::nanoseconds samplingInterval = 500us,
     int32_t deviceId = 0,
-    std::vector<std::string> metricNames = {"sm__cycles_active.avg"}) {
+    std::vector<std::string> metricNames = {"sm__cycles_active.avg"},
+    std::chrono::nanoseconds lookbackWindow = 10s) {
   return CuptiPMSamplingConfig{
-      deviceId, std::move(metricNames), samplingInterval};
+      deviceId, std::move(metricNames), samplingInterval, lookbackWindow};
 }
 
 void configureForDevice(
@@ -227,7 +230,7 @@ CUptiResult CUPTIAPI cuptiPmSamplingGetCounterDataSize(
   fakeCupti().counterDataMetricNames =
       copyMetricNames(params->pMetricNames, params->numMetrics);
   fakeCupti().maxSamples = params->maxSamples;
-  params->counterDataSize = 1;
+  params->counterDataSize = fakeCupti().counterDataSize;
   return CUPTI_SUCCESS;
 }
 
@@ -334,12 +337,38 @@ TEST_F(CuptiPMSamplingApiTest, ConfiguresDeviceMetricsAndBuffers) {
       fakeCupti().appendMode,
       CUPTI_PM_SAMPLING_HARDWARE_BUFFER_APPEND_MODE_KEEP_LATEST);
   EXPECT_EQ(fakeCupti().counterDataMetricNames, config.metricNames);
-  EXPECT_EQ(fakeCupti().maxSamples, 1024);
+  EXPECT_EQ(fakeCupti().maxSamples, 40'000);
+  api.disable();
+}
+
+TEST_F(CuptiPMSamplingApiTest, SizesCounterDataFromLookbackWindow) {
+  CuptiPMSamplingApi api;
+
+  api.configure(makeConfig(
+      250us,
+      /*deviceId=*/0,
+      {"sm__cycles_active.avg"},
+      2s));
+
+  EXPECT_EQ(fakeCupti().maxSamples, 8'000);
+  api.disable();
+}
+
+TEST_F(CuptiPMSamplingApiTest, KeepsAtLeastOneSample) {
+  CuptiPMSamplingApi api;
+
+  api.configure(makeConfig(
+      2ms,
+      /*deviceId=*/0,
+      {"sm__cycles_active.avg"},
+      1ms));
+
+  EXPECT_EQ(fakeCupti().maxSamples, 1);
   api.disable();
 }
 
 TEST_F(CuptiPMSamplingApiTest, UsesFixedSysclkIntervalOnGa100) {
-  configureForDevice(8, 0, 0ns);
+  configureForDevice(8, 0, 500us);
 
   EXPECT_EQ(
       fakeCupti().triggerMode,
@@ -368,6 +397,30 @@ TEST_F(CuptiPMSamplingApiTest, RejectsUnsupportedComputeCapabilities) {
 
 TEST_F(CuptiPMSamplingApiTest, RejectsNonpositiveTimeIntervals) {
   EXPECT_THROW(configureForDevice(8, 6, 0ns), std::runtime_error);
+}
+
+TEST_F(CuptiPMSamplingApiTest, RejectsNonpositiveLookbackWindows) {
+  CuptiPMSamplingApi api;
+  EXPECT_THROW(
+      api.configure(makeConfig(
+          500us,
+          /*deviceId=*/0,
+          {"sm__cycles_active.avg"},
+          0ns)),
+      std::runtime_error);
+}
+
+TEST_F(CuptiPMSamplingApiTest, RejectsSampleCapacityAboveCuptiLimit) {
+  CuptiPMSamplingApi api;
+  constexpr auto kTooManySamples =
+      static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) + 1;
+  EXPECT_THROW(
+      api.configure(makeConfig(
+          1ns,
+          /*deviceId=*/0,
+          {"sm__cycles_active.avg"},
+          std::chrono::nanoseconds{kTooManySamples})),
+      std::runtime_error);
 }
 
 TEST_F(CuptiPMSamplingApiTest, RejectsMultipassConfigurationBeforeEnabling) {

--- a/libkineto/test/CuptiPMSamplingProfilerTest.cpp
+++ b/libkineto/test/CuptiPMSamplingProfilerTest.cpp
@@ -86,29 +86,17 @@ TEST(CuptiPMSamplingProfilerTest, ReportsNameAndSupportedActivity) {
   EXPECT_EQ(profiler.availableActivities(), kHardwareCounterActivities);
 }
 
-TEST(CuptiPMSamplingProfilerTest, RequiresActivityMetricsAndDevice) {
+TEST(CuptiPMSamplingProfilerTest, RequiresMetricsAndDevice) {
   CuptiPMSamplingProfiler profiler;
 
-  Config validConfig;
-  ASSERT_TRUE(
-      validConfig.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg\n"
-                        "CUPTI_PM_SAMPLING_DEVICE_ID = 0"));
-  EXPECT_EQ(
-      profiler.configure(
-          /*startTimeMs=*/123,
-          /*durationMs=*/456,
-          /*activityTypes=*/{},
-          validConfig),
-      nullptr);
-
   Config missingMetrics;
-  ASSERT_TRUE(missingMetrics.parse("CUPTI_PM_SAMPLING_DEVICE_ID = 0"));
+  ASSERT_TRUE(missingMetrics.parse("PERFORMANCE_METRICS_DEVICE_ID = 0"));
   EXPECT_EQ(
       profiler.configure(kHardwareCounterActivities, missingMetrics), nullptr);
 
   Config missingDevice;
   ASSERT_TRUE(
-      missingDevice.parse("CUPTI_PM_SAMPLING_METRICS = sm__cycles_active.avg"));
+      missingDevice.parse("PERFORMANCE_METRICS = sm__cycles_active.avg"));
   EXPECT_EQ(
       profiler.configure(kHardwareCounterActivities, missingDevice), nullptr);
 }


### PR DESCRIPTION
These were introduced as inputs in https://github.com/pytorch/pytorch/pull/196065, but are not yet being parsed by Kineto (only cupti monitor/cuspy).

Lookback window is a proxy for buffer capacity, which we previously fixed as `maxSamplesForDecode` but is now calculated as `max(1, lookbackWindow / samplingInterval)`.