### PR TITLE
[ROCm][CI] Update to ROCm 10.0 and Split Kineto & PyTorch compiles onto CPU runners; keep tests on MI350

### DIFF
--- a/.github/scripts/config_rocm.sh
+++ b/.github/scripts/config_rocm.sh
@@ -76,19 +76,18 @@ export PYTORCH_TEST_WITH_ROCM=1
 export PYTORCH_ROCM_ARCH="gfx950"
 
 # Cap parallel compile jobs. PyTorch's build otherwise spawns one compile per
-# core, and ROCm never reaches the sccache bucket (see below), so every build
-# recompiles the heavy ATen kernels from scratch. Without a cap they compile
-# all at once and can exhaust runner memory, tripping the OOM killer.
+# core. Without a cap they compile all at once and can exhaust runner memory,
+# tripping the OOM killer.
 #
 # Note that this is naively set the same as on the CUDA side. We can tweak this
 # if needed.
 export MAX_JOBS=8
 
 # --- PyTorch build caching ---
-# This arch's CI runner is not on AWS and cannot reach PyTorch's S3 sccache
-# bucket.
+# The ROCm wheel is built on linux.12xlarge (AWS), which can reach PyTorch's
+# shared S3 sccache bucket. The MI350 test job never compiles.
 # shellcheck disable=SC2034
-KINETO_USE_SCCACHE=0
+KINETO_USE_SCCACHE=1
 
 # --- Deselected PyTorch profiler tests ---
 # Each entry is a pytest node ID passed as a --deselect argument.

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -77,35 +77,18 @@ maybe_enable_sccache() {
 }
 
 run_profiler_tests() {
-  local pytest_extra=()
-  local test_path="test/profiler/"
-
-  # A wheel install must not import the unbuilt in-tree torch/. pytest's default
-  # import mode prepends the clone (pytest.ini rootdir) to sys.path, so use
-  # importlib mode and an absolute test path from outside the clone.
-  if [[ "${MODE}" == "test" ]]; then
-    python -c "
-import pathlib, torch
-p = pathlib.Path(torch.__file__).resolve()
-print(f'====: torch.__file__={p}')
-clone = pathlib.Path(r'${PYTORCH_DIR}').resolve()
-assert clone not in p.parents and p != clone, p
-"
-    pytest_extra+=(--import-mode=importlib)
-    test_path="${PYTORCH_DIR}/test/profiler/"
-    pushd "${KINETO_DIR}"
-  fi
+  # Run from the PyTorch clone. Its test/conftest.py imports sibling helpers
+  # such as pytest_shard_custom, which only resolve because pytest's default
+  # import mode prepends the conftest's directory to sys.path.
+  pushd "${PYTORCH_DIR}"
 
   # Download PyTorch's dynamic disabled tests list from S3. This is generated every
   # 15 minutes from DISABLED GitHub Issues in pytorch/pytorch, enabling automatic
   # skipping of known-broken/flaky tests without hardcoded deselections.
   # The function downloads, processes (converts format and filters re-enabled issues),
   # and caches the result to .pytorch-disabled-tests.json.
-  (
-    cd "${PYTORCH_DIR}"
-    python -c "from tools.stats.import_test_stats import get_disabled_tests; get_disabled_tests('.')"
-  )
-  export DISABLED_TESTS_FILE="${PYTORCH_DIR}/.pytorch-disabled-tests.json"
+  python -c "from tools.stats.import_test_stats import get_disabled_tests; get_disabled_tests('.')"
+  export DISABLED_TESTS_FILE=.pytorch-disabled-tests.json
   echo "====: Downloaded disabled tests list"
 
   # The deselected tests array is sourced from the architecture config above.
@@ -115,19 +98,25 @@ assert clone not in p.parents and p != clone, p
     deselect_args+=(--deselect="$t")
   done
 
+  # Invoke pytest through its console script rather than `python -m pytest`,
+  # which prepends the clone to sys.path. After a wheel install the clone's
+  # torch/ holds Python sources with no compiled extensions, so that entry
+  # shadows the installed torch and `import torch` fails.
+  local pytest_cmd=(python -m pytest)
+  if [[ "${MODE}" == "test" ]]; then
+    pytest_cmd=(pytest)
+  fi
+
   # Run PyTorch profiler tests under a per-test timeout so a hang fails that one
   # test instead of consuming the whole job's timeout. Use the signal method, not
   # thread: the thread method's watchdog thread is captured by the profiler and
   # inflates the thread counts that some profiler tests assert on. The tradeoff is
   # that signal cannot interrupt a hang holding the GIL in native code.
   pip install pytest pytest-timeout
-  python -m pytest "${test_path}" -v --timeout=300 --timeout-method=signal \
-    "${pytest_extra[@]}" "${deselect_args[@]}"
+  "${pytest_cmd[@]}" test/profiler/ -v --timeout=300 --timeout-method=signal \
+    "${deselect_args[@]}"
   echo "====: Ran PyTorch profiler tests"
-
-  if [[ "${MODE}" == "test" ]]; then
-    popd
-  fi
+  popd
 }
 
 git clone --recursive --branch viable/strict https://github.com/pytorch/pytorch.git "${PYTORCH_DIR}"
@@ -185,5 +174,25 @@ if [[ "${#wheels[@]}" -eq 0 ]]; then
 fi
 python -m pip install --no-build-isolation -v "${wheels[0]}"
 echo "====: Installed $(basename "${wheels[0]}")"
+
+# The wheel brings torch but not its test-time imports (numpy, expecttest,
+# sympy, ...) that torch.testing._internal pulls in. The build job gets these
+# from the same file.
+(
+  cd "${PYTORCH_DIR}"
+  pip install -r requirements.txt
+)
+echo "====: Installed PyTorch test requirements"
+
+# Confirm the tests will exercise the wheel built from this PR, not the clone's
+# uncompiled torch/ sources. Checked from outside the clone, where `python -c`
+# would otherwise put the clone on sys.path.
+python -c "
+import pathlib, torch
+p = pathlib.Path(torch.__file__).resolve()
+print(f'====: torch.__file__={p}')
+clone = pathlib.Path(r'${PYTORCH_DIR}').resolve()
+assert clone not in p.parents and p != clone, p
+"
 
 run_profiler_tests

--- a/.github/scripts/pytorch_build_test.sh
+++ b/.github/scripts/pytorch_build_test.sh
@@ -7,8 +7,14 @@
 
 set -eux
 
-GPU_ARCH="${1:?Usage: pytorch_build_test.sh <cpu|cuda|rocm>}"
+GPU_ARCH="${1:?Usage: pytorch_build_test.sh <cpu|cuda|rocm> [all|wheel|test]}"
+MODE="${2:-all}"
 SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [[ "${MODE}" != "all" && "${MODE}" != "wheel" && "${MODE}" != "test" ]]; then
+  echo "ERROR: unknown mode '${MODE}' (expected all|wheel|test)" >&2
+  exit 1
+fi
 
 # Save kineto directory path before cloning PyTorch
 KINETO_DIR=$(pwd)
@@ -19,24 +25,17 @@ echo "====: Kineto directory: ${KINETO_DIR}"
 # PyTorch tree lived inside KINETO_DIR, that symlink would point at a directory
 # that contains the clone, forming an endless path cycle.
 PYTORCH_DIR="$(dirname "${KINETO_DIR}")/pytorch"
-git clone --recursive --branch viable/strict https://github.com/pytorch/pytorch.git "${PYTORCH_DIR}"
-echo "====: Cloned PyTorch"
 
-pushd "${PYTORCH_DIR}"
-rm -rf third_party/kineto
-ln -s "${KINETO_DIR}" third_party/kineto
-echo "====: Linked PR version of Kineto to PyTorch (${KINETO_DIR} -> third_party/kineto)"
+maybe_enable_sccache() {
+  # Enable sccache so PyTorch object files persist across CI runs. Most Kineto
+  # PRs touch only Kineto, so the bulk of PyTorch's objects are cache hits on
+  # warm runs. Whether the runner can reach the S3 cache is architecture
+  # specific (only the AWS-hosted runners can), so each config_<arch>.sh opts
+  # in via KINETO_USE_SCCACHE.
+  if [[ "${KINETO_USE_SCCACHE:-0}" != "1" ]]; then
+    return 0
+  fi
 
-# Load architecture-specific build env vars and deselected tests
-# shellcheck source=/dev/null
-source "${SCRIPTS_DIR}/config_${GPU_ARCH}.sh"
-
-# Enable sccache so PyTorch object files persist across CI runs. Most Kineto
-# PRs touch only Kineto, so the bulk of PyTorch's objects are cache hits on
-# warm runs. Whether the runner can reach the S3 cache is architecture
-# specific (only the AWS-hosted runners can), so each config_<arch>.sh opts
-# in via KINETO_USE_SCCACHE.
-if [[ "${KINETO_USE_SCCACHE:-0}" == "1" ]]; then
   # Note that the sscache binary we use is hard-coded to be Linux specific.
   # That's safe because we only have Linux specific callers. Also note that
   # GPU_ARCH does not determine a CPU architecture, so we determine that here.
@@ -48,70 +47,143 @@ if [[ "${KINETO_USE_SCCACHE:-0}" == "1" ]]; then
 
   if [[ -z "${SCCACHE_ARCH}" ]]; then
     echo "====: Unsupported arch for sccache: $(uname -m); building uncached" >&2
-  else
-    SCCACHE_VERSION="v0.8.2"
-    SCCACHE_PKG="sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl"
-    curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${SCCACHE_PKG}.tar.gz" | tar -xz -C /tmp
-    install -m755 "/tmp/${SCCACHE_PKG}/sccache" /usr/local/bin/sccache
-
-    export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
-    export SCCACHE_REGION=us-east-1
-    export SCCACHE_S3_KEY_PREFIX=kineto
-    export SCCACHE_IDLE_TIMEOUT=0
-    export SCCACHE_ERROR_LOG=/tmp/sccache_error.log
-
-    # Route compilers through sccache only if the cache backend actually
-    # starts. A configured-but-unreachable bucket otherwise makes every
-    # compile fail, so this keeps a cache problem from breaking the build.
-    if sccache --start-server; then
-      sccache --zero-stats || true
-      export CMAKE_C_COMPILER_LAUNCHER=sccache
-      export CMAKE_CXX_COMPILER_LAUNCHER=sccache
-      export CMAKE_CUDA_COMPILER_LAUNCHER=sccache
-      echo "====: Enabled sccache (${SCCACHE_VERSION}, ${SCCACHE_ARCH})"
-    else
-      echo "====: sccache cache unreachable; building without it" >&2
-    fi
+    return 0
   fi
+
+  SCCACHE_VERSION="v0.8.2"
+  SCCACHE_PKG="sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl"
+  curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${SCCACHE_PKG}.tar.gz" | tar -xz -C /tmp
+  install -m755 "/tmp/${SCCACHE_PKG}/sccache" /usr/local/bin/sccache
+
+  export SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2
+  export SCCACHE_REGION=us-east-1
+  export SCCACHE_S3_KEY_PREFIX=kineto
+  export SCCACHE_IDLE_TIMEOUT=0
+  export SCCACHE_ERROR_LOG=/tmp/sccache_error.log
+
+  # Route compilers through sccache only if the cache backend actually
+  # starts. A configured-but-unreachable bucket otherwise makes every
+  # compile fail, so this keeps a cache problem from breaking the build.
+  if sccache --start-server; then
+    sccache --zero-stats || true
+    export CMAKE_C_COMPILER_LAUNCHER=sccache
+    export CMAKE_CXX_COMPILER_LAUNCHER=sccache
+    export CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+    export CMAKE_HIP_COMPILER_LAUNCHER=sccache
+    echo "====: Enabled sccache (${SCCACHE_VERSION}, ${SCCACHE_ARCH})"
+  else
+    echo "====: sccache cache unreachable; building without it" >&2
+  fi
+}
+
+run_profiler_tests() {
+  local pytest_extra=()
+  local test_path="test/profiler/"
+
+  # A wheel install must not import the unbuilt in-tree torch/. pytest's default
+  # import mode prepends the clone (pytest.ini rootdir) to sys.path, so use
+  # importlib mode and an absolute test path from outside the clone.
+  if [[ "${MODE}" == "test" ]]; then
+    python -c "
+import pathlib, torch
+p = pathlib.Path(torch.__file__).resolve()
+print(f'====: torch.__file__={p}')
+clone = pathlib.Path(r'${PYTORCH_DIR}').resolve()
+assert clone not in p.parents and p != clone, p
+"
+    pytest_extra+=(--import-mode=importlib)
+    test_path="${PYTORCH_DIR}/test/profiler/"
+    pushd "${KINETO_DIR}"
+  fi
+
+  # Download PyTorch's dynamic disabled tests list from S3. This is generated every
+  # 15 minutes from DISABLED GitHub Issues in pytorch/pytorch, enabling automatic
+  # skipping of known-broken/flaky tests without hardcoded deselections.
+  # The function downloads, processes (converts format and filters re-enabled issues),
+  # and caches the result to .pytorch-disabled-tests.json.
+  (
+    cd "${PYTORCH_DIR}"
+    python -c "from tools.stats.import_test_stats import get_disabled_tests; get_disabled_tests('.')"
+  )
+  export DISABLED_TESTS_FILE="${PYTORCH_DIR}/.pytorch-disabled-tests.json"
+  echo "====: Downloaded disabled tests list"
+
+  # The deselected tests array is sourced from the architecture config above.
+  local deselect_args=()
+  local t
+  for t in "${DESELECTED_TESTS[@]}"; do
+    deselect_args+=(--deselect="$t")
+  done
+
+  # Run PyTorch profiler tests under a per-test timeout so a hang fails that one
+  # test instead of consuming the whole job's timeout. Use the signal method, not
+  # thread: the thread method's watchdog thread is captured by the profiler and
+  # inflates the thread counts that some profiler tests assert on. The tradeoff is
+  # that signal cannot interrupt a hang holding the GIL in native code.
+  pip install pytest pytest-timeout
+  python -m pytest "${test_path}" -v --timeout=300 --timeout-method=signal \
+    "${pytest_extra[@]}" "${deselect_args[@]}"
+  echo "====: Ran PyTorch profiler tests"
+
+  if [[ "${MODE}" == "test" ]]; then
+    popd
+  fi
+}
+
+git clone --recursive --branch viable/strict https://github.com/pytorch/pytorch.git "${PYTORCH_DIR}"
+echo "====: Cloned PyTorch"
+
+# Load architecture-specific build env vars and deselected tests
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/config_${GPU_ARCH}.sh"
+
+if [[ "${MODE}" != "test" ]]; then
+  rm -rf "${PYTORCH_DIR}/third_party/kineto"
+  ln -s "${KINETO_DIR}" "${PYTORCH_DIR}/third_party/kineto"
+  echo "====: Linked PR version of Kineto to PyTorch (${KINETO_DIR} -> third_party/kineto)"
+
+  maybe_enable_sccache
+
+  pushd "${PYTORCH_DIR}"
+  pip install -r requirements.txt
+
+  # Hipify PyTorch source code for ROCm build
+  if [[ "${GPU_ARCH}" == "rocm" ]]; then
+    python tools/amd_build/build_amd.py
+    echo "====: Hipified PyTorch source for ROCm"
+  fi
+
+  if [[ "${MODE}" == "wheel" ]]; then
+    python -m build --wheel --no-isolation
+    echo "====: Built PyTorch wheel"
+    sccache --show-stats || true
+    mkdir -p "${KINETO_DIR}/artifacts-to-be-uploaded"
+    cp -v dist/*.whl "${KINETO_DIR}/artifacts-to-be-uploaded/"
+    echo "====: Copied wheel to artifacts-to-be-uploaded"
+    popd
+    exit 0
+  fi
+
+  python -m pip install --no-build-isolation -v -e .
+  echo "====: Built PyTorch from source"
+  # Surface cache hit rates so warm-vs-cold runs are diagnosable from the log.
+  # Harmless when sccache was not enabled (no server running).
+  sccache --show-stats || true
+  run_profiler_tests
+  popd
+  exit 0
 fi
 
-# Build PyTorch from source
-pip install -r requirements.txt
-
-# Hipify PyTorch source code for ROCm build
-if [[ "${GPU_ARCH}" == "rocm" ]]; then
-  python tools/amd_build/build_amd.py
-  echo "====: Hipified PyTorch source for ROCm"
+ARTIFACT_ROOT="${RUNNER_ARTIFACT_DIR:-/artifacts}"
+shopt -s nullglob
+wheels=("${ARTIFACT_ROOT}"/*.whl)
+shopt -u nullglob
+if [[ "${#wheels[@]}" -eq 0 ]]; then
+  echo "ERROR: no torch wheel in ${ARTIFACT_ROOT}" >&2
+  ls -la "${ARTIFACT_ROOT}" >&2 || true
+  exit 1
 fi
+python -m pip install --no-build-isolation -v "${wheels[0]}"
+echo "====: Installed $(basename "${wheels[0]}")"
 
-python -m pip install --no-build-isolation -v -e .
-echo "====: Built PyTorch from source"
-
-# Surface cache hit rates so warm-vs-cold runs are diagnosable from the log.
-# Harmless when sccache was not enabled (no server running).
-sccache --show-stats || true
-
-# Download PyTorch's dynamic disabled tests list from S3. This is generated every
-# 15 minutes from DISABLED GitHub Issues in pytorch/pytorch, enabling automatic
-# skipping of known-broken/flaky tests without hardcoded deselections.
-# The function downloads, processes (converts format and filters re-enabled issues),
-# and caches the result to .pytorch-disabled-tests.json.
-python -c "from tools.stats.import_test_stats import get_disabled_tests; get_disabled_tests('.')"
-export DISABLED_TESTS_FILE=.pytorch-disabled-tests.json
-echo "====: Downloaded disabled tests list"
-
-# The deselected tests array is sourced from the architecture config above.
-DESELECT_ARGS=()
-for t in "${DESELECTED_TESTS[@]}"; do
-  DESELECT_ARGS+=(--deselect="$t")
-done
-
-# Run PyTorch profiler tests under a per-test timeout so a hang fails that one
-# test instead of consuming the whole job's timeout. Use the signal method, not
-# thread: the thread method's watchdog thread is captured by the profiler and
-# inflates the thread counts that some profiler tests assert on. The tradeoff is
-# that signal cannot interrupt a hang holding the GIL in native code.
-pip install pytest pytest-timeout
-python -m pytest test/profiler/ -v --timeout=300 --timeout-method=signal "${DESELECT_ARGS[@]}"
-popd
-echo "====: Ran PyTorch profiler tests"
+run_profiler_tests

--- a/.github/workflows/linux_rocm_kineto.yml
+++ b/.github/workflows/linux_rocm_kineto.yml
@@ -16,19 +16,81 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-test:
+  # Compiling libkineto needs the ROCm toolchain but no GPU, so it runs on a
+  # cheap CPU runner and hands the built tree to the GPU job below. Note that
+  # gpu-arch-type must stay cpu here: the rocm setup action fails the job when
+  # rocminfo finds no GPU.
+  build:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      job-name: linux-rocm-kineto-build-and-test
-      runner: linux.rocm.gpu.ecosystem.mi350.1
+      job-name: linux-rocm-kineto-build
+      runner: linux.4xlarge
       timeout: 180
       # Checkout the Kineto repo at the PR ref with submodules
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       submodules: recursive
-      gpu-arch-type: rocm
-      gpu-arch-version: "7.14"
+      gpu-arch-type: cpu
+      # Same image the test job resolves to from gpu-arch-type/gpu-arch-version,
+      # so the binaries built here find the same ROCm libraries there.
+      docker-image: pytorch/almalinux-builder:rocm7.14
+      upload-artifact: linux-rocm-kineto-build
       script: |
         set -eux
         .github/scripts/setup.sh
-        .github/scripts/kineto_build_test.sh rocm
+
+        # This is the build half of kineto_build_test.sh, inlined because that
+        # script also runs the tests, which need a GPU.
+        # shellcheck source=/dev/null
+        source .github/scripts/config_rocm.sh
+
+        mkdir -p build_static build_shared
+
+        pushd build_static
+        cmake "${KINETO_CMAKE_FLAGS[@]}" -DKINETO_LIBRARY_TYPE=static ../libkineto/
+        make -j
+        popd
+        echo "====: Compiled static libkineto"
+
+        pushd build_shared
+        cmake "${KINETO_CMAKE_FLAGS[@]}" -DKINETO_LIBRARY_TYPE=shared ../libkineto/
+        make -j
+        popd
+        echo "====: Compiled shared libkineto"
+
+        # Only the static build carries the test binaries; the shared build is
+        # here purely as a compile check, so it does not need to be shipped.
+        mkdir -p artifacts-to-be-uploaded
+        tar czf artifacts-to-be-uploaded/kineto-build.tar.gz build_static
+        echo "====: Packed build_static for the test job"
+
+  test:
+    needs: build
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      job-name: linux-rocm-kineto-test
+      runner: linux.rocm.gpu.ecosystem.mi350.1
+      timeout: 180
+      # Checkout the Kineto repo at the PR ref with submodules. The build tree
+      # below is unpacked over this checkout so the paths baked into CMake's
+      # cache by the build job still resolve.
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}
+      submodules: recursive
+      gpu-arch-type: rocm
+      gpu-arch-version: "7.14"
+      docker-image: pytorch/almalinux-builder:rocm7.14
+      download-artifact: linux-rocm-kineto-build
+      script: |
+        set -eux
+        # Reinstall the same cmake the build job used: CMake bakes the absolute
+        # path of its own ctest into the generated makefiles.
+        .github/scripts/setup.sh
+
+        tar xzf "${RUNNER_ARTIFACT_DIR}/kineto-build.tar.gz"
+        echo "====: Restored build_static from the build job"
+
+        pushd build_static
+        CTEST_OUTPUT_ON_FAILURE=1 make test
+        popd
+        echo "====: Ran static libkineto tests"

--- a/.github/workflows/linux_rocm_pytorch.yml
+++ b/.github/workflows/linux_rocm_pytorch.yml
@@ -16,19 +16,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-test:
+  # Compile torch (with this Kineto) on an AWS CPU runner so sccache can reach
+  # S3. gpu-arch-type must stay cpu: the rocm setup action fails when rocminfo
+  # finds no GPU. The wheel is uploaded as a GitHub Actions artifact, same
+  # mechanism as linux_rocm_kineto.yml but a different artifact name.
+  build:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      job-name: linux-rocm-pytorch-build-and-test
+      job-name: linux-rocm-pytorch-build
+      runner: linux.12xlarge
+      timeout: 180
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}
+      submodules: recursive
+      gpu-arch-type: cpu
+      docker-image: pytorch/almalinux-builder:rocm7.14
+      upload-artifact: linux-rocm-pytorch-wheel
+      script: |
+        set -eux
+        .github/scripts/setup.sh
+        .github/scripts/pytorch_build_test.sh rocm wheel
+
+  test:
+    needs: build
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      job-name: linux-rocm-pytorch-test
       runner: linux.rocm.gpu.ecosystem.mi350.1
       timeout: 180
-      # Checkout the Kineto repo at the PR ref with submodules
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       submodules: recursive
       gpu-arch-type: rocm
       gpu-arch-version: "7.14"
+      docker-image: pytorch/almalinux-builder:rocm7.14
+      download-artifact: linux-rocm-pytorch-wheel
       script: |
         set -eux
         .github/scripts/setup.sh
-        .github/scripts/pytorch_build_test.sh rocm
+        .github/scripts/pytorch_build_test.sh rocm test


### PR DESCRIPTION
## Summary
- Update Kineto ROCm CI gpu-arch-version from 7.14 to 10.0.
- Stop occupying `linux.rocm.gpu.ecosystem.mi350.1` for compiles that do not need a GPU. Both ROCm workflows now build on CPU and only run tests on MI350.
- **libkineto** (`linux_rocm_kineto.yml`): compile on `linux.4xlarge` with `pytorch/almalinux-builder:rocm7.14`, upload `build_static`, `ctest` on MI350. `kineto_build_test.sh` is unchanged (build/test inlined in the workflow).
- **PyTorch** (`linux_rocm_pytorch.yml`): compile a wheel on `linux.12xlarge` (AWS, `KINETO_USE_SCCACHE=1`) with this Kineto in `third_party/kineto`, upload GitHub artifact `linux-rocm-pytorch-wheel`, MI350 `pip install`s that wheel and runs `test/profiler/`.
- `pytorch_build_test.sh` takes an optional mode: `all` (default; CPU/CUDA unchanged), `wheel`, or `test`, so ROCm does not fork a second copy of the script.