### PR TITLE
Fix `cudaMemAdvise` signature change in `kineto_stress_test`

### DIFF
--- a/libkineto/stress_test/kineto_stress_test.cpp
+++ b/libkineto/stress_test/kineto_stress_test.cpp
@@ -69,6 +69,27 @@ void trace_collection_thread(
   trace->save(kTraceFile);
 }
 
+// CUDA 13 replaced cudaMemAdvise's device ordinal with a cudaMemLocation and
+// dropped the cudaMemAdvise_v2 spelling that carried it in CUDA 12.
+static cudaError_t memAdvise(
+    const void* devPtr,
+    size_t count,
+    cudaMemoryAdvise advice,
+    int device) {
+#if CUDART_VERSION >= 13000
+  cudaMemLocation location{};
+  if (device == cudaCpuDeviceId) {
+    location.type = cudaMemLocationTypeHost;
+  } else {
+    location.type = cudaMemLocationTypeDevice;
+    location.id = device;
+  }
+  return cudaMemAdvise(devPtr, count, advice, location);
+#else
+  return cudaMemAdvise(devPtr, count, advice, device);
+#endif
+}
+
 void uvm_allocation_thread(stress_test_args* test_args) {
   uint64_t alloc_size = test_args->uvm_len * sizeof(float);
 
@@ -85,28 +106,28 @@ void uvm_allocation_thread(stress_test_args* test_args) {
           (void**)&test_args->uvm_b, alloc_size, cudaMemAttachGlobal),
       __LINE__);
   checkCudaStatus(
-      cudaMemAdvise(
+      memAdvise(
           (void*)test_args->uvm_a,
           alloc_size,
           cudaMemAdviseSetPreferredLocation,
           cudaCpuDeviceId),
       __LINE__);
   checkCudaStatus(
-      cudaMemAdvise(
+      memAdvise(
           (void*)test_args->uvm_b,
           alloc_size,
           cudaMemAdviseSetPreferredLocation,
           cudaCpuDeviceId),
       __LINE__);
   checkCudaStatus(
-      cudaMemAdvise(
+      memAdvise(
           (void*)test_args->uvm_a,
           alloc_size,
           cudaMemAdviseSetAccessedBy,
           currentDevice),
       __LINE__);
   checkCudaStatus(
-      cudaMemAdvise(
+      memAdvise(
           (void*)test_args->uvm_b,
           alloc_size,
           cudaMemAdviseSetAccessedBy,


### PR DESCRIPTION
Summary:
CUDA 13 changed `cudaMemAdvise`'s 4th parameter from an `int` device ordinal to a `struct cudaMemLocation`, and dropped the `cudaMemAdvise_v2` spelling that carried the new signature in CUDA 12. That breaks `kineto/libkineto/stress_test:kineto_stress_test` under CUDA 13.3:

```
kineto_stress_test.cpp:88:7: error: no matching function for call to 'cudaMemAdvise'
   88 |       cudaMemAdvise(
      |       ^~~~~~~~~~~~~
cuda/13.3/include/cuda_runtime_api.h:7547:39: note: candidate function not viable: no known conversion from 'int' to 'struct cudaMemLocation' for 4th argument
```

Add a small `memAdvise` wrapper that keeps the device-ordinal call sites unchanged and builds the `cudaMemLocation` under `CUDART_VERSION >= 13000`, mapping `cudaCpuDeviceId` to `cudaMemLocationTypeHost`. This mirrors the version-guard pattern already used for `hipMemAdvise` in `comms/rcclx/develop/projects/hipother/hipnv`, so the target still builds on CUDA 12.x.

Differential Revision: D119752644


